### PR TITLE
test(friends): mock friendship service in blocked component

### DIFF
--- a/src/app/layout/friend-management/friend-blocked/friend-blocked.component.spec.ts
+++ b/src/app/layout/friend-management/friend-blocked/friend-blocked.component.spec.ts
@@ -1,12 +1,11 @@
 // src/app/layout/friend-management/friend-blocked/friend-blocked.component.spec.ts
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Store } from '@ngrx/store';
-import { Firestore } from '@angular/fire/firestore';
-import { Functions } from '@angular/fire/functions';
 import { of } from 'rxjs';
 import { vi } from 'vitest';
 
 import { FriendBlockedComponent } from './friend-blocked.component';
+import { FriendshipService } from 'src/app/core/services/interactions/friendship/friendship.service';
 
 describe('FriendBlockedComponent', () => {
   let component: FriendBlockedComponent;
@@ -16,8 +15,13 @@ describe('FriendBlockedComponent', () => {
     await TestBed.configureTestingModule({
       imports: [FriendBlockedComponent],
       providers: [
-        { provide: Firestore, useValue: {} },
-        { provide: Functions, useValue: {} },
+        {
+          provide: FriendshipService,
+          useValue: {
+            blockUser: vi.fn(() => of(void 0)),
+            unblockUser: vi.fn(() => of(void 0)),
+          },
+        },
         {
           provide: Store,
           useValue: {


### PR DESCRIPTION
Corrige o teste de FriendBlockedComponent para mockar FriendshipService e não subir a cadeia real de Firestore/Functions.

Validação local informada: build, functions:build e test:ci passaram. Resultado do test:ci: 128 arquivos e 343 testes.