### PR TITLE
test: clean vitest mock warnings

### DIFF
--- a/src/app/core/services/batepapo/room-services/room.service.spec.ts
+++ b/src/app/core/services/batepapo/room-services/room.service.spec.ts
@@ -1,6 +1,4 @@
 // src/app/core/services/batepapo/room-services/room.service.spec.ts
-import { describe, beforeEach, it, expect, vi } from 'vitest';
-
 const firestoreMocks = vi.hoisted(() => ({
   Firestore: class FirestoreMock {},
   collection: vi.fn(() => ({ kind: 'collection' })),

--- a/src/app/core/services/batepapo/room-services/room.service.spec.ts
+++ b/src/app/core/services/batepapo/room-services/room.service.spec.ts
@@ -1,5 +1,11 @@
 // src/app/core/services/batepapo/room-services/room.service.spec.ts
-const firestoreMocks = vi.hoisted(() => ({
+import { TestBed } from '@angular/core/testing';
+import { firstValueFrom, from, of } from 'rxjs';
+
+import { GlobalErrorHandlerService } from '../../error-handler/global-error-handler.service';
+import { FirestoreContextService } from '../../data-handling/firestore/core/firestore-context.service';
+
+const firestoreMocks = {
   Firestore: class FirestoreMock {},
   collection: vi.fn(() => ({ kind: 'collection' })),
   collectionData: vi.fn(),
@@ -9,25 +15,29 @@ const firestoreMocks = vi.hoisted(() => ({
   limit: vi.fn((value: number) => ({ kind: 'limit', value })),
   query: vi.fn((_ref: unknown, ...constraints: unknown[]) => ({ kind: 'query', constraints })),
   where: vi.fn((field: string, op: string, value: unknown) => ({ kind: 'where', field, op, value })),
-}));
+};
 
-vi.mock('@angular/fire/firestore', () => firestoreMocks);
-
-import { TestBed } from '@angular/core/testing';
-import { firstValueFrom, from, of } from 'rxjs';
-import { Firestore } from '@angular/fire/firestore';
-import { RoomService } from './room.service';
-import { GlobalErrorHandlerService } from '../../error-handler/global-error-handler.service';
-import { FirestoreContextService } from '../../data-handling/firestore/core/firestore-context.service';
+vi.doMock('@angular/fire/firestore', () => firestoreMocks);
 
 describe('RoomService', () => {
-  let service: RoomService;
+  let service: any;
+  let RoomServiceToken: any;
+  let FirestoreToken: any;
 
   let globalErrorMock: {
     handleError: ReturnType<typeof vi.fn>;
   };
 
+  beforeAll(async () => {
+    const firestoreModule = await import('@angular/fire/firestore');
+    const roomModule = await import('./room.service');
+
+    FirestoreToken = firestoreModule.Firestore;
+    RoomServiceToken = roomModule.RoomService;
+  });
+
   beforeEach(() => {
+    TestBed.resetTestingModule();
     vi.clearAllMocks();
 
     globalErrorMock = {
@@ -36,8 +46,8 @@ describe('RoomService', () => {
 
     TestBed.configureTestingModule({
       providers: [
-        RoomService,
-        { provide: Firestore, useValue: {} },
+        RoomServiceToken,
+        { provide: FirestoreToken, useValue: {} },
         {
           provide: FirestoreContextService,
           useValue: {
@@ -49,7 +59,7 @@ describe('RoomService', () => {
       ],
     });
 
-    service = TestBed.inject(RoomService);
+    service = TestBed.inject(RoomServiceToken);
   });
 
   it('deve ser criado', () => {

--- a/src/app/core/services/batepapo/room-services/room.service.spec.ts
+++ b/src/app/core/services/batepapo/room-services/room.service.spec.ts
@@ -1,4 +1,3 @@
-// src/app/core/services/batepapo/room-services/room.service.spec.ts
 import { TestBed } from '@angular/core/testing';
 import { firstValueFrom, from, of } from 'rxjs';
 
@@ -13,36 +12,27 @@ const firestoreMocks = {
   docData: vi.fn(),
   getDocs: vi.fn(),
   limit: vi.fn((value: number) => ({ kind: 'limit', value })),
-  query: vi.fn((_ref: unknown, ...constraints: unknown[]) => ({ kind: 'query', constraints })),
-  where: vi.fn((field: string, op: string, value: unknown) => ({ kind: 'where', field, op, value })),
+  query: vi.fn(() => ({ kind: 'query' })),
+  where: vi.fn(() => ({ kind: 'where' })),
 };
 
 vi.doMock('@angular/fire/firestore', () => firestoreMocks);
+
+type RoomSpecItem = { id: string; roomName: string; participants: string[] };
 
 describe('RoomService', () => {
   let service: any;
   let RoomServiceToken: any;
   let FirestoreToken: any;
 
-  let globalErrorMock: {
-    handleError: ReturnType<typeof vi.fn>;
-  };
-
   beforeAll(async () => {
-    const firestoreModule = await import('@angular/fire/firestore');
-    const roomModule = await import('./room.service');
-
-    FirestoreToken = firestoreModule.Firestore;
-    RoomServiceToken = roomModule.RoomService;
+    FirestoreToken = (await import('@angular/fire/firestore')).Firestore;
+    RoomServiceToken = (await import('./room.service')).RoomService;
   });
 
   beforeEach(() => {
     TestBed.resetTestingModule();
     vi.clearAllMocks();
-
-    globalErrorMock = {
-      handleError: vi.fn(),
-    };
 
     TestBed.configureTestingModule({
       providers: [
@@ -55,7 +45,7 @@ describe('RoomService', () => {
             deferObservable$: (task: () => unknown) => task(),
           },
         },
-        { provide: GlobalErrorHandlerService, useValue: globalErrorMock },
+        { provide: GlobalErrorHandlerService, useValue: { handleError: vi.fn() } },
       ],
     });
 
@@ -69,39 +59,25 @@ describe('RoomService', () => {
   it('countUserRooms retorna a contagem de salas ativas', async () => {
     firestoreMocks.getDocs.mockResolvedValue({
       docs: [
-        { id: 'r1', data: () => ({ status: 'active' }) },
-        { id: 'r2', data: () => ({ status: 'archived' }) },
-        { id: 'r3', data: () => ({}) },
+        { data: () => ({ status: 'active' }) },
+        { data: () => ({ status: 'archived' }) },
+        { data: () => ({}) },
       ],
     });
 
-    const total = await service.countUserRooms('u1');
-
-    expect(total).toBe(2);
+    await expect(service.countUserRooms('u1')).resolves.toBe(2);
     expect(firestoreMocks.getDocs).toHaveBeenCalled();
   });
 
   it('getUserRooms emite lista owner-only normalizada', async () => {
     firestoreMocks.collectionData.mockReturnValueOnce(
       of([
-        {
-          id: 'r1',
-          roomName: 'Sala 1',
-          createdBy: 'u1',
-          participants: ['u1'],
-          lastActivity: new Date('2026-01-01T10:00:00Z'),
-        },
-        {
-          id: 'r2',
-          roomName: 'Sala 2',
-          createdBy: 'u1',
-          participants: ['u1', 'u2'],
-          lastActivity: new Date('2026-01-01T09:00:00Z'),
-        },
+        { id: 'r1', roomName: 'Sala 1', createdBy: 'u1', participants: ['u1'] },
+        { id: 'r2', roomName: 'Sala 2', createdBy: 'u1', participants: ['u1', 'u2'] },
       ])
     );
 
-    const rooms = await firstValueFrom(service.getUserRooms('u1'));
+    const rooms = await firstValueFrom(service.getUserRooms('u1')) as RoomSpecItem[];
 
     expect(rooms.length).toBe(2);
     expect(rooms[0].id).toBe('r1');
@@ -111,17 +87,10 @@ describe('RoomService', () => {
 
   it('getRooms emite lista por membership', async () => {
     firestoreMocks.collectionData.mockReturnValueOnce(
-      of([
-        {
-          id: 'r10',
-          roomName: 'Sala A',
-          createdBy: 'u9',
-          participants: ['u1', 'u9'],
-        },
-      ])
+      of([{ id: 'r10', roomName: 'Sala A', createdBy: 'u9', participants: ['u1', 'u9'] }])
     );
 
-    const rooms = await firstValueFrom(service.getRooms('u1'));
+    const rooms = await firstValueFrom(service.getRooms('u1')) as RoomSpecItem[];
 
     expect(rooms.length).toBe(1);
     expect(rooms[0].id).toBe('r10');
@@ -130,15 +99,10 @@ describe('RoomService', () => {
 
   it('getRoomById emite documento único', async () => {
     firestoreMocks.docData.mockReturnValueOnce(
-      of({
-        id: 'room-xyz',
-        roomName: 'X',
-        createdBy: 'u9',
-        participants: ['a', 'b'],
-      })
+      of({ id: 'room-xyz', roomName: 'X', createdBy: 'u9', participants: ['a', 'b'] })
     );
 
-    const room = await firstValueFrom(service.getRoomById('room-xyz'));
+    const room = await firstValueFrom(service.getRoomById('room-xyz')) as RoomSpecItem;
 
     expect(room.id).toBe('room-xyz');
     expect(room.roomName).toBe('X');
@@ -146,14 +110,10 @@ describe('RoomService', () => {
   });
 
   it('deve falhar ao contar salas sem uid', async () => {
-    await expect(service.countUserRooms('')).rejects.toThrow(
-      'UID ausente para consulta de salas.'
-    );
+    await expect(service.countUserRooms('')).rejects.toThrow('UID ausente para consulta de salas.');
   });
 
   it('deve falhar ao buscar roomId vazio', async () => {
-    await expect(firstValueFrom(service.getRoomById(''))).rejects.toThrow(
-      'roomId ausente para consulta da sala.'
-    );
+    await expect(firstValueFrom(service.getRoomById(''))).rejects.toThrow('roomId ausente para consulta da sala.');
   });
 });

--- a/src/app/core/services/batepapo/room-services/room.service.spec.ts
+++ b/src/app/core/services/batepapo/room-services/room.service.spec.ts
@@ -1,6 +1,4 @@
 // src/app/core/services/batepapo/room-services/room.service.spec.ts
-import { TestBed } from '@angular/core/testing';
-import { firstValueFrom, from, of } from 'rxjs';
 import { describe, beforeEach, it, expect, vi } from 'vitest';
 
 const firestoreMocks = vi.hoisted(() => ({
@@ -17,6 +15,8 @@ const firestoreMocks = vi.hoisted(() => ({
 
 vi.mock('@angular/fire/firestore', () => firestoreMocks);
 
+import { TestBed } from '@angular/core/testing';
+import { firstValueFrom, from, of } from 'rxjs';
 import { Firestore } from '@angular/fire/firestore';
 import { RoomService } from './room.service';
 import { GlobalErrorHandlerService } from '../../error-handler/global-error-handler.service';

--- a/src/app/core/services/geolocation/near-profile.service.spec.ts
+++ b/src/app/core/services/geolocation/near-profile.service.spec.ts
@@ -1,10 +1,5 @@
 // src/app/core/services/geolocation/near-profile.service.spec.ts
-import { TestBed } from '@angular/core/testing';
 import { describe, beforeAll, beforeEach, it, expect, vi } from 'vitest';
-
-import { Firestore } from '@angular/fire/firestore';
-import { NearbyProfilesService } from './near-profile.service';
-import { DistanceCalculationService } from './distance-calculation.service';
 
 const firestoreMocks = vi.hoisted(() => ({
   collection: vi.fn(() => ({})),
@@ -37,6 +32,11 @@ const geofireMocks = vi.hoisted(() => ({
 
 vi.mock('@firebase/firestore', () => firestoreMocks);
 vi.mock('geofire-common', () => geofireMocks);
+
+import { TestBed } from '@angular/core/testing';
+import { Firestore } from '@angular/fire/firestore';
+import { NearbyProfilesService } from './near-profile.service';
+import { DistanceCalculationService } from './distance-calculation.service';
 
 class DistanceCalculationServiceStub {
   calculateDistanceInKm = vi.fn(

--- a/src/app/core/services/geolocation/near-profile.service.spec.ts
+++ b/src/app/core/services/geolocation/near-profile.service.spec.ts
@@ -1,14 +1,16 @@
 // src/app/core/services/geolocation/near-profile.service.spec.ts
-const firestoreMocks = vi.hoisted(() => ({
+import { TestBed } from '@angular/core/testing';
+
+const firestoreMocks = {
   collection: vi.fn(() => ({})),
   where: vi.fn(() => ({})),
   query: vi.fn(() => ({})),
   getDocs: vi.fn(),
   startAt: vi.fn(() => ({})),
   limit: vi.fn((_n: number) => ({})),
-}));
+};
 
-const geofireMocks = vi.hoisted(() => ({
+const geofireMocks = {
   geohashQueryBounds: vi.fn((_center: [number, number], _radiusM: number) => [
     ['aaaa', 'zzzz'],
   ]),
@@ -26,34 +28,41 @@ const geofireMocks = vi.hoisted(() => ({
 
     return earthRadiusKm * c;
   }),
-}));
+};
 
-vi.mock('@firebase/firestore', () => firestoreMocks);
-vi.mock('geofire-common', () => geofireMocks);
-
-import { TestBed } from '@angular/core/testing';
-import { Firestore } from '@angular/fire/firestore';
-import { NearbyProfilesService } from './near-profile.service';
-import { DistanceCalculationService } from './distance-calculation.service';
-
-class DistanceCalculationServiceStub {
-  calculateDistanceInKm = vi.fn(
-    (lat1: number, _lon1: number, _lat2: number, _lon2: number, _maxKm?: number) => {
-      if (lat1 === 10) return 5;
-      if (lat1 === 20) return null;
-      return 1;
-    }
-  );
-}
+vi.doMock('@firebase/firestore', () => firestoreMocks);
+vi.doMock('geofire-common', () => geofireMocks);
 
 describe('NearbyProfilesService', () => {
-  let service: NearbyProfilesService;
+  let service: any;
+  let NearbyProfilesServiceToken: any;
+  let DistanceCalculationServiceToken: any;
+  let FirestoreToken: any;
 
-  beforeAll(() => {
+  class DistanceCalculationServiceStub {
+    calculateDistanceInKm = vi.fn(
+      (lat1: number, _lon1: number, _lat2: number, _lon2: number, _maxKm?: number) => {
+        if (lat1 === 10) return 5;
+        if (lat1 === 20) return null;
+        return 1;
+      }
+    );
+  }
+
+  beforeAll(async () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const firestoreModule = await import('@angular/fire/firestore');
+    const serviceModule = await import('./near-profile.service');
+    const distanceModule = await import('./distance-calculation.service');
+
+    FirestoreToken = firestoreModule.Firestore;
+    NearbyProfilesServiceToken = serviceModule.NearbyProfilesService;
+    DistanceCalculationServiceToken = distanceModule.DistanceCalculationService;
   });
 
   beforeEach(() => {
+    TestBed.resetTestingModule();
     firestoreMocks.getDocs.mockReset();
     firestoreMocks.query.mockReset();
     firestoreMocks.where.mockReset();
@@ -71,13 +80,13 @@ describe('NearbyProfilesService', () => {
 
     TestBed.configureTestingModule({
       providers: [
-        NearbyProfilesService,
-        { provide: Firestore, useValue: {} as Firestore },
-        { provide: DistanceCalculationService, useClass: DistanceCalculationServiceStub },
+        NearbyProfilesServiceToken,
+        { provide: FirestoreToken, useValue: {} },
+        { provide: DistanceCalculationServiceToken, useClass: DistanceCalculationServiceStub },
       ],
     });
 
-    service = TestBed.inject(NearbyProfilesService);
+    service = TestBed.inject(NearbyProfilesServiceToken);
   });
 
   function makeDoc(data: any) {

--- a/src/app/core/services/geolocation/near-profile.service.spec.ts
+++ b/src/app/core/services/geolocation/near-profile.service.spec.ts
@@ -1,6 +1,4 @@
 // src/app/core/services/geolocation/near-profile.service.spec.ts
-import { describe, beforeAll, beforeEach, it, expect, vi } from 'vitest';
-
 const firestoreMocks = vi.hoisted(() => ({
   collection: vi.fn(() => ({})),
   where: vi.fn(() => ({})),

--- a/src/app/core/services/interactions/friendship/repo/requests.repo.spec.ts
+++ b/src/app/core/services/interactions/friendship/repo/requests.repo.spec.ts
@@ -1,11 +1,12 @@
 // src/app/core/services/interactions/friendship/repo/requests.repo.spec.ts
-const firestoreTest = vi.hoisted(() => {
+import { EnvironmentInjector } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+
+const firestoreTest = (() => {
   type DocRef = { path: string };
   type ColRef = { path: string };
 
   const store = new Map<string, any>();
-
-  const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value));
 
   const materializeTs = (value: any): any => {
     if (!value || typeof value !== 'object') return value;
@@ -25,9 +26,9 @@ const firestoreTest = vi.hoisted(() => {
     doc: (_db: unknown, path: string): DocRef => ({ path }),
     collection: (_db: unknown, path: string): ColRef => ({ path }),
   };
-});
+})();
 
-vi.mock('@angular/fire/firestore', () => {
+vi.doMock('@angular/fire/firestore', () => {
   return {
     Timestamp: class {},
     Firestore: class {},
@@ -110,10 +111,6 @@ vi.mock('@angular/fire/firestore', () => {
   };
 });
 
-import { EnvironmentInjector } from '@angular/core';
-import { firstValueFrom } from 'rxjs';
-import { RequestsRepo } from './requests.repo';
-
 class FakeCooldownRepo {
   getCooldownRef() {
     return { path: 'cooldown/noop' };
@@ -121,7 +118,8 @@ class FakeCooldownRepo {
 }
 
 describe('RequestsRepo.acceptRequestBatch', () => {
-  let repo: RequestsRepo;
+  let RequestsRepoToken: any;
+  let repo: any;
 
   const db = {} as any;
   const env = {
@@ -132,9 +130,14 @@ describe('RequestsRepo.acceptRequestBatch', () => {
   const requesterUid = 'alice';
   const targetUid = 'bob';
 
+  beforeAll(async () => {
+    const repoModule = await import('./requests.repo');
+    RequestsRepoToken = repoModule.RequestsRepo;
+  });
+
   beforeEach(() => {
     firestoreTest.store.clear();
-    repo = new RequestsRepo(db, env, new FakeCooldownRepo() as any);
+    repo = new RequestsRepoToken(db, env, new FakeCooldownRepo() as any);
   });
 
   it('deve aceitar uma solicitação pendente e criar as duas arestas', async () => {

--- a/src/app/core/services/interactions/friendship/repo/requests.repo.spec.ts
+++ b/src/app/core/services/interactions/friendship/repo/requests.repo.spec.ts
@@ -1,6 +1,4 @@
 // src/app/core/services/interactions/friendship/repo/requests.repo.spec.ts
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-
 const firestoreTest = vi.hoisted(() => {
   type DocRef = { path: string };
   type ColRef = { path: string };

--- a/src/app/core/services/interactions/friendship/repo/requests.repo.spec.ts
+++ b/src/app/core/services/interactions/friendship/repo/requests.repo.spec.ts
@@ -1,6 +1,4 @@
 // src/app/core/services/interactions/friendship/repo/requests.repo.spec.ts
-import { EnvironmentInjector } from '@angular/core';
-import { firstValueFrom } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const firestoreTest = vi.hoisted(() => {
@@ -114,6 +112,8 @@ vi.mock('@angular/fire/firestore', () => {
   };
 });
 
+import { EnvironmentInjector } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
 import { RequestsRepo } from './requests.repo';
 
 class FakeCooldownRepo {

--- a/src/app/messaging/direct-chat/services/direct-thread.service.spec.ts
+++ b/src/app/messaging/direct-chat/services/direct-thread.service.spec.ts
@@ -1,50 +1,47 @@
 // src/app/messaging/direct-chat/services/direct-thread.service.spec.ts
-import { describe, beforeEach, it, expect, vi, type Mock } from 'vitest';
 import { BehaviorSubject, firstValueFrom, of, throwError } from 'rxjs';
-import type { Functions } from '@angular/fire/functions';
 
-import { DirectThreadService } from './direct-thread.service';
-import { ChatService } from '../../../core/services/batepapo/chat-service/chat.service';
-import { AccessControlService } from '../../../core/services/autentication/auth/access-control.service';
-import { GlobalErrorHandlerService } from '../../../core/services/error-handler/global-error-handler.service';
-import { ErrorNotificationService } from '../../../core/services/error-handler/error-notification.service';
-import { PrivacyDebugLoggerService } from '../../../core/services/privacy/privacy-debug-logger.service';
-
-const functionsMocks = vi.hoisted(() => ({
+const functionsMocks = {
   httpsCallable: vi.fn(),
-}));
+};
 
-vi.mock('@angular/fire/functions', () => functionsMocks);
+vi.doMock('@angular/fire/functions', () => functionsMocks);
+
+type MockFn = ReturnType<typeof vi.fn>;
 
 describe('DirectThreadService', () => {
-  let service: DirectThreadService;
+  let service: any;
+  let DirectThreadServiceToken: any;
 
   let canListenRealtime$: BehaviorSubject<boolean>;
-
-  let sendDirectMessageMock: Mock;
+  let sendCallableMock: MockFn;
 
   let chatServiceMock: {
-    monitorChat: Mock;
-    deleteMessage: Mock;
+    monitorChat: MockFn;
+    deleteMessage: MockFn;
   };
 
   let globalErrorHandlerMock: {
-    handleError: Mock;
+    handleError: MockFn;
   };
 
   let errorNotifierMock: {
-    showWarning: Mock;
-    showError: Mock;
+    showWarning: MockFn;
+    showError: MockFn;
   };
 
   let privacyDebugMock: {
-    log: Mock;
+    log: MockFn;
   };
+
+  beforeAll(async () => {
+    const serviceModule = await import('./direct-thread.service');
+    DirectThreadServiceToken = serviceModule.DirectThreadService;
+  });
 
   beforeEach(() => {
     canListenRealtime$ = new BehaviorSubject<boolean>(true);
-
-    sendDirectMessageMock = vi.fn();
+    sendCallableMock = vi.fn();
 
     chatServiceMock = {
       monitorChat: vi.fn(),
@@ -65,17 +62,17 @@ describe('DirectThreadService', () => {
     };
 
     functionsMocks.httpsCallable.mockReset();
-    functionsMocks.httpsCallable.mockReturnValue(sendDirectMessageMock as any);
+    functionsMocks.httpsCallable.mockReturnValue(sendCallableMock as any);
 
-    service = new DirectThreadService(
-      {} as Functions,
-      chatServiceMock as unknown as ChatService,
+    service = new DirectThreadServiceToken(
+      {},
+      chatServiceMock,
       {
         canListenRealtime$: canListenRealtime$.asObservable(),
-      } as unknown as AccessControlService,
-      globalErrorHandlerMock as unknown as GlobalErrorHandlerService,
-      errorNotifierMock as unknown as ErrorNotificationService,
-      privacyDebugMock as unknown as PrivacyDebugLoggerService
+      },
+      globalErrorHandlerMock,
+      errorNotifierMock,
+      privacyDebugMock
     );
   });
 
@@ -83,7 +80,7 @@ describe('DirectThreadService', () => {
     expect(service).toBeTruthy();
 
     expect(functionsMocks.httpsCallable).toHaveBeenCalledWith(
-      {} as Functions,
+      {},
       'sendDirectMessage'
     );
   });
@@ -109,7 +106,7 @@ describe('DirectThreadService', () => {
       {
         id: 'msg-1',
         chatId: 'chat-1',
-        content: 'mensagem não deve ir para log',
+        content: 'conteudo de teste',
       },
     ];
 
@@ -148,7 +145,7 @@ describe('DirectThreadService', () => {
     );
 
     expect(result).toBeNull();
-    expect(sendDirectMessageMock).not.toHaveBeenCalled();
+    expect(sendCallableMock).not.toHaveBeenCalled();
   });
 
   it('sendMessage$ deve retornar null quando conteúdo vier vazio', async () => {
@@ -157,7 +154,7 @@ describe('DirectThreadService', () => {
     );
 
     expect(result).toBeNull();
-    expect(sendDirectMessageMock).not.toHaveBeenCalled();
+    expect(sendCallableMock).not.toHaveBeenCalled();
   });
 
   it('sendMessage$ deve bloquear mensagem acima de 1000 caracteres', async () => {
@@ -168,7 +165,7 @@ describe('DirectThreadService', () => {
     );
 
     expect(result).toBeNull();
-    expect(sendDirectMessageMock).not.toHaveBeenCalled();
+    expect(sendCallableMock).not.toHaveBeenCalled();
     expect(errorNotifierMock.showWarning).toHaveBeenCalledWith(
       'A mensagem deve ter no máximo 1000 caracteres.'
     );
@@ -180,14 +177,14 @@ describe('DirectThreadService', () => {
     );
 
     expect(result).toBeNull();
-    expect(sendDirectMessageMock).not.toHaveBeenCalled();
+    expect(sendCallableMock).not.toHaveBeenCalled();
     expect(errorNotifierMock.showError).toHaveBeenCalledWith(
       'Não foi possível preparar o envio da mensagem.'
     );
   });
 
   it('sendMessage$ deve chamar callable e retornar messageId no sucesso', async () => {
-    sendDirectMessageMock.mockResolvedValueOnce({
+    sendCallableMock.mockResolvedValueOnce({
       data: {
         chatId: 'chat-1',
         messageId: 'msg-1',
@@ -199,7 +196,7 @@ describe('DirectThreadService', () => {
       service.sendMessage$(' chat-1 ', ' olá ', ' req-1 ')
     );
 
-    expect(sendDirectMessageMock).toHaveBeenCalledWith({
+    expect(sendCallableMock).toHaveBeenCalledWith({
       chatId: 'chat-1',
       content: 'olá',
       clientRequestId: 'req-1',
@@ -219,7 +216,7 @@ describe('DirectThreadService', () => {
   });
 
   it('sendMessage$ deve retornar null, notificar e registrar erro quando callable falhar', async () => {
-    sendDirectMessageMock.mockRejectedValueOnce({
+    sendCallableMock.mockRejectedValueOnce({
       code: 'permission-denied',
       message: 'denied',
     });
@@ -236,7 +233,7 @@ describe('DirectThreadService', () => {
   });
 
   it('sendMessage$ deve retornar null quando callable responder sem messageId', async () => {
-    sendDirectMessageMock.mockResolvedValueOnce({
+    sendCallableMock.mockResolvedValueOnce({
       data: {
         chatId: 'chat-1',
         messageId: '',


### PR DESCRIPTION
Limpa warnings de mocks do Vitest em specs de chat, geolocalizacao e amizades. Substitui vi.hoisted/vi.mock por vi.doMock com imports dinamicos quando necessario.

Validacao local informada: build, functions:build e test:ci passaram. Resultado do test:ci: 128 arquivos e 343 testes. Warnings de vi.hoisted/vi.mock nao apareceram no log enviado.