### PR TITLE
test: load vitest browser setup

### DIFF
--- a/vitest.angular.config.ts
+++ b/vitest.angular.config.ts
@@ -1,18 +1,3 @@
-// vitest.angular.config.ts
-// -----------------------------------------------------------------------------
-// VITEST CONFIG — ANGULAR CLI TEST RUNNER
-// -----------------------------------------------------------------------------
-// Usada pelo comando:
-//
-//   npx ng test --watch=false
-//
-// Importante:
-// - não usa setupFiles;
-// - não carrega setup-vitest-direct.ts;
-// - não chama getTestBed().initTestEnvironment();
-// - deixa o Angular CLI inicializar o TestBed.
-// -----------------------------------------------------------------------------
-
 import { fileURLToPath, URL } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
@@ -27,10 +12,10 @@ export default defineConfig({
       '@store': fileURLToPath(new URL('./src/app/store', import.meta.url)),
     },
   },
-
   test: {
     globals: true,
     environment: 'jsdom',
     css: true,
+    setupFiles: [fileURLToPath(new URL('./src/test/setup-vitest.ts', import.meta.url))],
   },
 });


### PR DESCRIPTION
Carrega o setup global do Vitest no runner Angular para aplicar mocks de ambiente jsdom, incluindo Canvas.

Validação local informada: build, functions:build e test:ci passaram. Resultado do test:ci: 128 arquivos e 343 testes. O erro de HTMLCanvasElement.prototype.getContext não apareceu no log enviado.

Não altera a lógica do PhotoEditorComponent nem a integração do Pintura em runtime.