### PR TITLE
test(profile): mock sidebar navigation streams

### DIFF
--- a/src/app/user-profile/user-profile-view/user-profile-sidebar/user-profile-sidebar.component.spec.ts
+++ b/src/app/user-profile/user-profile-view/user-profile-sidebar/user-profile-sidebar.component.spec.ts
@@ -1,34 +1,28 @@
 // src/app/user-profile/user-profile-view/user-profile-sidebar/user-profile-sidebar.component.spec.ts
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { BehaviorSubject, of } from 'rxjs';
+import { MatDialog } from '@angular/material/dialog';
 import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs';
 
 import { UserProfileSidebarComponent } from './user-profile-sidebar.component';
-
-// ✅ IMPORTS RELATIVOS (sem aliases tipo 'src/...'):
-import { CurrentUserStoreService } from '../../../core/services/autentication/auth/current-user-store.service';
-import { AuthSessionService } from '../../../core/services/autentication/auth/auth-session.service';
-import { FirestoreUserQueryService } from '../../../core/services/data-handling/firestore-user-query.service';
 import { ErrorNotificationService } from '../../../core/services/error-handler/error-notification.service';
 import { RoomManagementService } from '../../../core/services/batepapo/room-services/room-management.service';
+import { AuthenticatedNavigationService } from '../../../core/services/navigation/authenticated-navigation.service';
 
-// ===== STUBS =====
-class MockCurrentUserStoreService {
-  user$ = new BehaviorSubject<any>({ uid: 'u1', role: 'premium' });
-}
-class MockAuthSessionService {
-  signOut$ = vi.fn(() => of(void 0));
-}
-class MockFirestoreUserQueryService {
-  getUser = vi.fn(() => of({ uid: 'u1', nickname: 'Alex', photoURL: '' }));
-}
-class MockErrorNotificationService {
-  showError = vi.fn();
-  showSuccess = vi.fn();
-}
-class MockRoomManagementService {
-  createRoom = vi.fn(() => of({ id: 'room-1' }));
-}
+const navigationVm = {
+  ready: true,
+  uid: 'u1',
+  usuario: {
+    uid: 'u1',
+    nickname: 'Alex',
+    photoURL: '',
+    role: 'premium',
+  },
+  currentUrl: '/perfil/u1',
+  viewedUid: 'u1',
+  isProfileRoute: true,
+  isOwnProfileRoute: true,
+};
 
 describe('UserProfileSidebarComponent', () => {
   let component: UserProfileSidebarComponent;
@@ -37,23 +31,42 @@ describe('UserProfileSidebarComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
-        UserProfileSidebarComponent,     // standalone
+        UserProfileSidebarComponent,
         RouterTestingModule.withRoutes([]),
       ],
       providers: [
-        { provide: CurrentUserStoreService, useClass: MockCurrentUserStoreService },
-        { provide: AuthSessionService, useClass: MockAuthSessionService },
-        { provide: FirestoreUserQueryService, useClass: MockFirestoreUserQueryService },
-        { provide: ErrorNotificationService, useClass: MockErrorNotificationService },
-        { provide: RoomManagementService, useClass: MockRoomManagementService },
-        // MatDialog não é usado no teste (apenas injetado). Se precisar, stub:
-        { provide: (class MatDialog { } as any), useValue: { open: vi.fn() } },
+        {
+          provide: AuthenticatedNavigationService,
+          useValue: {
+            vm$: of(navigationVm),
+            items$: of([]),
+          },
+        },
+        {
+          provide: ErrorNotificationService,
+          useValue: {
+            showError: vi.fn(),
+            showSuccess: vi.fn(),
+          },
+        },
+        {
+          provide: RoomManagementService,
+          useValue: {
+            createRoom: vi.fn(() => of({ id: 'room-1' })),
+          },
+        },
+        {
+          provide: MatDialog,
+          useValue: {
+            open: vi.fn(),
+          },
+        },
       ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(UserProfileSidebarComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges(); // aciona o pipe da stream do usuário e o getUser()
+    fixture.detectChanges();
   });
 
   it('should create', () => {


### PR DESCRIPTION
Corrige o spec do UserProfileSidebarComponent para mockar diretamente AuthenticatedNavigationService.vm$ e items$.

Validação local informada: build, functions:build e test:ci passaram. Resultado do test:ci: 128 arquivos e 343 testes. O erro de stream undefined no combineLatest não apareceu no log enviado.

Não altera o componente real.