### PR TITLE
test(data): firestore query injection context

### DIFF
--- a/src/app/core/services/data-handling/firestore-query.service.spec.ts
+++ b/src/app/core/services/data-handling/firestore-query.service.spec.ts
@@ -36,7 +36,9 @@ class MockUserPresenceQueryService {
 }
 
 class MockFirestoreContextService {
-  deferObservable$ = vi.fn((task: () => unknown) => task());
+  deferObservable$ = vi.fn((task: () => unknown) =>
+    TestBed.runInInjectionContext(task as () => any)
+  );
 }
 
 describe('FirestoreQueryService', () => {


### PR DESCRIPTION
Ajusta o spec do FirestoreQueryService para executar tasks do mock de FirestoreContextService dentro do injection context do TestBed.

Validação local: build, functions:build e test:ci verdes. Testes: 128 arquivos, 343 testes.

Sem alteração no service real.