### PR TITLE
feat(admin): user review actions

### DIFF
--- a/src/app/admin-dashboard/user-list/user-list.component.css
+++ b/src/app/admin-dashboard/user-list/user-list.component.css
@@ -1,19 +1,246 @@
-/* src\app\admin-dashboard\user-list\user-list.component.css */
-.spacer {
-  flex: 1 1 auto;
+/* src/app/admin-dashboard/user-list/user-list.component.css */
+:host {
+  display: block;
+  min-width: 0;
 }
 
-mat-card-header {
+.user-review-card {
+  display: grid;
+  gap: 14px;
+  min-width: 0;
+  border-radius: 18px;
+}
+
+.user-review-header {
+  display: grid;
+  gap: 14px;
+  align-items: start;
+}
+
+.user-review-header__copy {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+
+.user-review-header__eyebrow {
+  margin: 0;
+  color: var(--primary-color, #d64d4d);
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.user-review-header p:not(.user-review-header__eyebrow) {
+  margin: 0;
+  color: var(--muted-text-color, #6b7280);
+  font-size: 0.92rem;
+  line-height: 1.45;
+}
+
+.user-review-search {
+  width: 100%;
+}
+
+.user-review-summary {
+  display: grid;
+  grid-auto-columns: minmax(128px, 42vw);
+  grid-auto-flow: column;
+  gap: 10px;
+  overflow-x: auto;
+  padding: 0 16px 2px;
+  scroll-snap-type: inline proximity;
+}
+
+.summary-tile {
+  min-width: 0;
+  padding: 12px;
+  border: 1px solid var(--surface-border, rgba(0, 0, 0, 0.1));
+  border-radius: 14px;
+  background: color-mix(in oklab, var(--surface-color, #fff) 94%, var(--text-color, #111827) 4%);
+  scroll-snap-align: start;
+}
+
+.summary-tile span {
+  display: block;
+  color: var(--muted-text-color, #6b7280);
+  font-size: 0.78rem;
+  font-weight: 850;
+}
+
+.summary-tile strong {
+  display: block;
+  margin-top: 4px;
+  color: var(--text-color, #111827);
+  font-size: 1.55rem;
+  font-weight: 950;
+  line-height: 1;
+}
+
+.user-review-controls {
   display: flex;
+  gap: 8px;
+  overflow-x: auto;
+  padding: 0 16px 2px;
+}
+
+.filter-chip {
+  min-height: 36px;
+  display: inline-flex;
+  flex: 0 0 auto;
+  gap: 7px;
   align-items: center;
-  gap: 16px;
+  justify-content: center;
+  padding: 0 12px;
+  border: 1px solid var(--surface-border, rgba(0, 0, 0, 0.12));
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--surface-color, #fff) 96%, var(--text-color, #111827) 4%);
+  color: var(--text-color, #111827);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 850;
+}
+
+.filter-chip span {
+  min-width: 24px;
+  padding: 2px 7px;
+  border-radius: 999px;
+  background: var(--surface-color, #fff);
+  color: var(--muted-text-color, #6b7280);
+  font-size: 0.76rem;
+  font-weight: 950;
+}
+
+.filter-chip.is-active {
+  border-color: color-mix(in oklab, var(--primary-color, #d64d4d) 52%, var(--surface-border, rgba(0, 0, 0, 0.12)));
+  background: color-mix(in oklab, var(--primary-color, #d64d4d) 10%, var(--surface-color, #fff));
+  color: var(--primary-color, #d64d4d);
+}
+
+.filter-chip:focus-visible,
+.row-actions button:focus-visible {
+  outline: 3px solid color-mix(in oklab, var(--primary-color, #d64d4d) 35%, transparent);
+  outline-offset: 3px;
 }
 
 .table-wrapper {
+  position: relative;
+  min-width: 0;
   overflow: auto;
-  max-height: calc(100vh - 280px);
+  max-height: calc(100vh - 320px);
 }
 
-mat-card {
-  display: block;
+table {
+  width: 100%;
+  min-width: 820px;
+}
+
+.user-cell,
+.status-stack {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.user-cell strong {
+  color: var(--text-color, #111827);
+  font-size: 0.92rem;
+  font-weight: 900;
+}
+
+.user-cell span,
+.user-cell small,
+.status-stack time,
+.empty-state span {
+  color: var(--muted-text-color, #6b7280);
+  font-size: 0.82rem;
+  line-height: 1.35;
+}
+
+.status-chip {
+  width: fit-content;
+  min-height: 26px;
+  font-size: 0.74rem;
+  font-weight: 900;
+}
+
+.status-chip--success {
+  background: rgba(4, 120, 87, 0.11) !important;
+  color: #047857 !important;
+}
+
+.status-chip--warning {
+  background: rgba(146, 64, 14, 0.12) !important;
+  color: #92400e !important;
+}
+
+.status-chip--danger {
+  background: rgba(185, 28, 28, 0.1) !important;
+  color: #b91c1c !important;
+}
+
+.status-chip--info {
+  background: rgba(29, 78, 216, 0.1) !important;
+  color: #1d4ed8 !important;
+}
+
+.row-actions {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.row-pending {
+  opacity: 0.72;
+}
+
+.empty-state {
+  display: grid;
+  place-items: center;
+  gap: 8px;
+  min-height: 180px;
+  padding: 22px;
+  border: 1px dashed var(--surface-border, rgba(0, 0, 0, 0.16));
+  border-radius: 14px;
+  background: color-mix(in oklab, var(--surface-color, #fff) 96%, var(--text-color, #111827) 3%);
+  text-align: center;
+}
+
+.empty-state mat-icon {
+  color: var(--primary-color, #d64d4d);
+}
+
+.empty-state strong {
+  color: var(--text-color, #111827);
+  font-size: 0.95rem;
+  font-weight: 900;
+}
+
+@media (min-width: 760px) {
+  .user-review-header {
+    grid-template-columns: minmax(0, 1fr) minmax(260px, 360px);
+  }
+
+  .user-review-summary {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    grid-auto-flow: initial;
+    grid-auto-columns: initial;
+    overflow: visible;
+  }
+}
+
+@media (max-width: 640px) {
+  .user-review-card {
+    border-radius: 14px;
+  }
+
+  .table-wrapper {
+    max-height: none;
+  }
+
+  table {
+    min-width: 720px;
+  }
 }

--- a/src/app/admin-dashboard/user-list/user-list.component.html
+++ b/src/app/admin-dashboard/user-list/user-list.component.html
@@ -1,64 +1,142 @@
-<!-- src\app\admin-dashboard\user-list\user-list.component.html -->
-<mat-card>
-  <mat-card-header>
-    <mat-card-title>Usuários</mat-card-title>
-    <span class="spacer"></span>
-    <mat-form-field appearance="outline" style="width: 280px">
+<!-- src/app/admin-dashboard/user-list/user-list.component.html -->
+<mat-card class="user-review-card">
+  <mat-card-header class="user-review-header">
+    <div class="user-review-header__copy">
+      <p class="user-review-header__eyebrow">Usuários</p>
+      <mat-card-title>Revisão de usuários</mat-card-title>
+      <p>Priorize cadastros pendentes, contas restritas e ações administrativas com feedback imediato.</p>
+    </div>
+
+    <mat-form-field appearance="outline" class="user-review-search">
       <mat-label>Buscar</mat-label>
-      <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Nome ou e-mail" />
+      <input
+        #searchInput
+        matInput
+        [value]="searchTerm"
+        (input)="applyFilter(searchInput.value)"
+        placeholder="Nome, e-mail, UID ou cidade"
+      />
+      <mat-icon matSuffix aria-hidden="true">search</mat-icon>
     </mat-form-field>
   </mat-card-header>
 
-  <mat-progress-bar *ngIf="loading" mode="indeterminate"></mat-progress-bar>
+  <mat-progress-bar *ngIf="loading" mode="indeterminate" aria-label="Carregando usuários"></mat-progress-bar>
+
+  <section class="user-review-summary" aria-label="Resumo de usuários">
+    <article class="summary-tile summary-tile--info">
+      <span>Total</span>
+      <strong>{{ totalUsers }}</strong>
+    </article>
+    <article class="summary-tile summary-tile--warning">
+      <span>Pendentes</span>
+      <strong>{{ pendingProfiles }}</strong>
+    </article>
+    <article class="summary-tile summary-tile--danger">
+      <span>Restritos</span>
+      <strong>{{ restrictedUsers }}</strong>
+    </article>
+    <article class="summary-tile summary-tile--success">
+      <span>Ativos</span>
+      <strong>{{ activeUsers }}</strong>
+    </article>
+  </section>
+
+  <section class="user-review-controls" aria-label="Filtros de usuários">
+    <button
+      type="button"
+      class="filter-chip"
+      [class.is-active]="option.value === activeFilter"
+      [attr.aria-pressed]="option.value === activeFilter"
+      *ngFor="let option of filterOptions; trackBy: trackByFilterValue"
+      (click)="setOperationalFilter(option.value)"
+    >
+      {{ option.label }}
+      <span>{{ option.count }}</span>
+    </button>
+  </section>
 
   <div class="table-wrapper">
     <table mat-table [dataSource]="dataSource" matSort>
-      <ng-container matColumnDef="nome">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>Nome</th>
-        <td mat-cell *matCellDef="let row">{{ row.nome }}</td>
+      <ng-container matColumnDef="usuario">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Usuário</th>
+        <td mat-cell *matCellDef="let row" data-label="Usuário">
+          <div class="user-cell">
+            <strong>{{ row.displayName }}</strong>
+            <span>{{ row.email || 'E-mail não informado' }}</span>
+            <small>{{ row.adminSubtitle }}</small>
+          </div>
+        </td>
       </ng-container>
 
-      <ng-container matColumnDef="email">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>Email</th>
-        <td mat-cell *matCellDef="let row">{{ row.email }}</td>
-      </ng-container>
-
-      <ng-container matColumnDef="status">
-        <th mat-header-cell *matHeaderCellDef>Status</th>
-        <td mat-cell *matCellDef="let row">
-          <mat-chip [color]="row.suspended ? 'warn' : 'primary'" selected>
-            {{ row.suspended ? 'Suspenso' : 'Ativo' }}
+      <ng-container matColumnDef="perfil">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Perfil</th>
+        <td mat-cell *matCellDef="let row" data-label="Perfil">
+          <mat-chip [class]="'status-chip status-chip--' + (row.profileCompleted ? 'success' : 'warning')" selected>
+            {{ row.profileStatusLabel }}
           </mat-chip>
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="risco">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Operação</th>
+        <td mat-cell *matCellDef="let row" data-label="Operação">
+          <div class="status-stack">
+            <mat-chip [class]="'status-chip status-chip--' + row.statusSeverity" selected>
+              {{ row.operationalStatusLabel }}
+            </mat-chip>
+            <time *ngIf="row.lastActivity" [attr.datetime]="row.lastActivity | date: 'yyyy-MM-ddTHH:mm:ss'">
+              Última atividade: {{ row.lastActivity | date: 'dd/MM HH:mm' }}
+            </time>
+          </div>
         </td>
       </ng-container>
 
       <ng-container matColumnDef="acoes">
         <th mat-header-cell *matHeaderCellDef>Ações</th>
-        <td mat-cell *matCellDef="let row">
-          <button mat-icon-button [matMenuTriggerFor]="m" matTooltip="Ações">
-            <mat-icon>more_vert</mat-icon>
-          </button>
-          <mat-menu #m="matMenu">
-            <button mat-menu-item (click)="viewUserDetails(row)">
-              <mat-icon>visibility</mat-icon>
-              <span>Detalhes</span>
+        <td mat-cell *matCellDef="let row" data-label="Ações">
+          <div class="row-actions">
+            <button
+              type="button"
+              mat-stroked-button
+              color="primary"
+              [disabled]="row.actionPending"
+              (click)="viewUserDetails(row)"
+            >
+              Revisar
             </button>
+
+            <button mat-icon-button [matMenuTriggerFor]="m" [disabled]="row.actionPending" matTooltip="Mais ações">
+              <mat-icon>{{ row.actionPending ? 'hourglass_top' : 'more_vert' }}</mat-icon>
+            </button>
+          </div>
+
+          <mat-menu #m="matMenu">
             <button mat-menu-item (click)="toggleSuspend(row)">
-              <mat-icon>{{ row.suspended ? 'lock_open' : 'lock' }}</mat-icon>
-              <span>{{ row.suspended ? 'Reativar' : 'Suspender' }}</span>
+              <mat-icon>{{ row.suspended ? 'lock_open' : 'block' }}</mat-icon>
+              <span>{{ row.suspended ? 'Reativar usuário' : 'Suspender usuário' }}</span>
+            </button>
+            <button mat-menu-item (click)="toggleLock(row)">
+              <mat-icon>{{ row.accountLocked ? 'lock_open' : 'lock' }}</mat-icon>
+              <span>{{ row.accountLocked ? 'Desbloquear conta' : 'Bloquear conta' }}</span>
             </button>
             <button mat-menu-item (click)="deleteUser(row)">
               <mat-icon>delete</mat-icon>
-              <span>Excluir</span>
+              <span>Excluir usuário</span>
             </button>
           </mat-menu>
         </td>
       </ng-container>
 
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns" [class.row-pending]="row.actionPending"></tr>
     </table>
+
+    <div class="empty-state" *ngIf="!loading && !dataSource.filteredData.length" role="status" aria-live="polite">
+      <mat-icon aria-hidden="true">person_search</mat-icon>
+      <strong>Nenhum usuário neste recorte</strong>
+      <span>Altere o filtro ou revise o termo de busca.</span>
+    </div>
   </div>
 
-  <mat-paginator [pageSize]="10" [pageSizeOptions]="[5,10,25,50]"></mat-paginator>
+  <mat-paginator [pageSize]="10" [pageSizeOptions]="[5,10,25,50]" aria-label="Paginação de usuários"></mat-paginator>
 </mat-card>

--- a/src/app/admin-dashboard/user-list/user-list.component.html
+++ b/src/app/admin-dashboard/user-list/user-list.component.html
@@ -71,7 +71,7 @@
       <ng-container matColumnDef="perfil">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>Perfil</th>
         <td mat-cell *matCellDef="let row" data-label="Perfil">
-          <mat-chip [class]="'status-chip status-chip--' + (row.profileCompleted ? 'success' : 'warning')" selected>
+          <mat-chip [ngClass]="['status-chip', 'status-chip--' + (row.profileCompleted ? 'success' : 'warning')]" selected>
             {{ row.profileStatusLabel }}
           </mat-chip>
         </td>
@@ -81,7 +81,7 @@
         <th mat-header-cell *matHeaderCellDef mat-sort-header>Operação</th>
         <td mat-cell *matCellDef="let row" data-label="Operação">
           <div class="status-stack">
-            <mat-chip [class]="'status-chip status-chip--' + row.statusSeverity" selected>
+            <mat-chip [ngClass]="['status-chip', 'status-chip--' + row.statusSeverity]" selected>
               {{ row.operationalStatusLabel }}
             </mat-chip>
             <time *ngIf="row.lastActivity" [attr.datetime]="row.lastActivity | date: 'yyyy-MM-ddTHH:mm:ss'">

--- a/src/app/admin-dashboard/user-list/user-list.component.ts
+++ b/src/app/admin-dashboard/user-list/user-list.component.ts
@@ -1,31 +1,53 @@
-//src\app\admin-dashboard\user-list\user-list.component.ts
-import { Component, OnInit, ViewChild, ChangeDetectionStrategy } from '@angular/core';
+// src/app/admin-dashboard/user-list/user-list.component.ts
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, ViewChild } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
 import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
 import { MatSort, MatSortModule } from '@angular/material/sort';
 import { MatDialog } from '@angular/material/dialog';
-import { MatSnackBar } from '@angular/material/snack-bar';
-import { Router } from '@angular/router';
-import { finalize } from 'rxjs/operators';
-
-
-import { IUserDados } from 'src/app/core/interfaces/iuser-dados';
-import { UserManagementService } from 'src/app/core/services/account-moderation/user-management.service';
-import { UserModerationService } from 'src/app/core/services/account-moderation/user-moderation.service';
-import { ConfirmDialogComponent } from '../shared/confirm-dialog/confirm-dialog.component';
-import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatMenuModule } from '@angular/material/menu';
-import { MatChip } from "@angular/material/chips";
-import { MatProgressBar } from "@angular/material/progress-bar";
-import { MatCardTitle, MatCardHeader, MatCard } from "@angular/material/card";
+import { MatChipsModule } from '@angular/material/chips';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatCardModule } from '@angular/material/card';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { Observable } from 'rxjs';
+import { finalize } from 'rxjs/operators';
 
-interface IUserDadosExtended extends IUserDados { suspended: boolean; }
+import { IUserDados } from 'src/app/core/interfaces/iuser-dados';
+import { UserManagementService } from 'src/app/core/services/account-moderation/user-management.service';
+import { UserModerationService } from 'src/app/core/services/account-moderation/user-moderation.service';
+import { ErrorNotificationService } from 'src/app/core/services/error-handler/error-notification.service';
+import { ConfirmDialogComponent } from '../shared/confirm-dialog/confirm-dialog.component';
+
+type AdminUserFilter = 'pending' | 'restricted' | 'active' | 'all';
+type UserStatusSeverity = 'success' | 'warning' | 'danger' | 'info';
+
+interface IUserDadosExtended extends IUserDados {
+  suspended: boolean;
+  accountLocked: boolean;
+  profileCompleted: boolean;
+  actionPending: boolean;
+  displayName: string;
+  adminSubtitle: string;
+  profileStatusLabel: string;
+  operationalStatusLabel: string;
+  statusSeverity: UserStatusSeverity;
+  lastActivity: number;
+  operationalPriority: number;
+}
+
+interface AdminUserFilterOption {
+  value: AdminUserFilter;
+  label: string;
+  count: number;
+}
 
 @Component({
   selector: 'app-user-list',
@@ -34,101 +56,402 @@ interface IUserDadosExtended extends IUserDados { suspended: boolean; }
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
-    CommonModule, FormsModule,
-    MatTableModule, MatPaginatorModule, MatSortModule,
-    MatFormFieldModule, MatInputModule, MatSelectModule,
-    MatButtonModule, MatIconModule, MatMenuModule,
-    MatChip,
-    MatProgressBar,
-    MatCardTitle,
-    MatCardHeader,
-    MatCard
-]
+    CommonModule,
+    FormsModule,
+    MatTableModule,
+    MatPaginatorModule,
+    MatSortModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatButtonModule,
+    MatIconModule,
+    MatMenuModule,
+    MatChipsModule,
+    MatProgressBarModule,
+    MatCardModule,
+    MatTooltipModule,
+  ],
 })
-
 export class UserListComponent implements OnInit {
-  displayedColumns = ['nome', 'email', 'status', 'acoes'];
+  displayedColumns = ['usuario', 'perfil', 'risco', 'acoes'];
   dataSource = new MatTableDataSource<IUserDadosExtended>([]);
   loading = false;
+  activeFilter: AdminUserFilter = 'pending';
+  searchTerm = '';
 
+  private allUsers: IUserDadosExtended[] = [];
+  private readonly pendingActionUids = new Set<string>();
 
   @ViewChild(MatPaginator) paginator!: MatPaginator;
   @ViewChild(MatSort) sort!: MatSort;
 
   constructor(
-              private userManagementService: UserManagementService,
-              private userModeration: UserModerationService,
-              private snack: MatSnackBar,
-              private dialog: MatDialog,
-              private router: Router,
-          ) { }
+    private readonly userManagementService: UserManagementService,
+    private readonly userModeration: UserModerationService,
+    private readonly notifications: ErrorNotificationService,
+    private readonly dialog: MatDialog,
+    private readonly router: Router,
+    private readonly cdr: ChangeDetectorRef
+  ) { }
 
-ngOnInit(): void { this.loadUsers(); }
+  get totalUsers(): number {
+    return this.allUsers.length;
+  }
 
-applyFilter(value: string) {
-  this.dataSource.filter = value.trim().toLowerCase();
-}
+  get pendingProfiles(): number {
+    return this.allUsers.filter((user) => !user.profileCompleted).length;
+  }
 
-loadUsers(): void {
-  this.loading = true;
-  this.userManagementService.getAllUsers()
-    .pipe(finalize(() => (this.loading = false)))
-    .subscribe({
-      next: (users) => {
-        const rows = users.map(u => ({ ...u, suspended: u.suspended ?? false }));
-        this.dataSource.data = rows;
-        // init após setar dados
-        Promise.resolve().then(() => {
-          if (this.paginator) this.dataSource.paginator = this.paginator;
-          if (this.sort) this.dataSource.sort = this.sort;
-        });
+  get restrictedUsers(): number {
+    return this.allUsers.filter((user) => this.isRestrictedUser(user)).length;
+  }
+
+  get activeUsers(): number {
+    return this.allUsers.filter((user) => user.profileCompleted && !this.isRestrictedUser(user)).length;
+  }
+
+  get filterOptions(): AdminUserFilterOption[] {
+    return [
+      { value: 'pending', label: 'Cadastros pendentes', count: this.pendingProfiles },
+      { value: 'restricted', label: 'Contas restritas', count: this.restrictedUsers },
+      { value: 'active', label: 'Ativos', count: this.activeUsers },
+      { value: 'all', label: 'Todos', count: this.totalUsers },
+    ];
+  }
+
+  ngOnInit(): void {
+    this.configureDataSource();
+    this.loadUsers();
+  }
+
+  applyFilter(value: string): void {
+    this.searchTerm = value;
+    this.dataSource.filter = value.trim().toLowerCase();
+  }
+
+  setOperationalFilter(filter: AdminUserFilter): void {
+    this.activeFilter = filter;
+    this.renderRows();
+  }
+
+  loadUsers(): void {
+    this.loading = true;
+    this.cdr.markForCheck();
+
+    this.userManagementService.getAllUsers()
+      .pipe(finalize(() => {
+        this.loading = false;
+        this.cdr.markForCheck();
+      }))
+      .subscribe({
+        next: (users) => {
+          this.allUsers = users.map((user) => this.toAdminRow(user));
+          this.renderRows();
+        },
+        error: (error) => this.notifications.showError(
+          'Falha ao carregar usuários.',
+          error instanceof Error ? error.message : undefined
+        ),
+      });
+  }
+
+  viewUserDetails(row: IUserDadosExtended): void {
+    this.router.navigate(['/admin-dashboard/users', row.uid]);
+  }
+
+  toggleSuspend(row: IUserDadosExtended): void {
+    const willSuspend = !row.suspended;
+    const ref = this.dialog.open(ConfirmDialogComponent, {
+      data: {
+        title: willSuspend ? 'Suspender usuário' : 'Reativar usuário',
+        message: willSuspend
+          ? 'Confirmar suspensão deste usuário? O perfil deve sair da operação normal.'
+          : 'Confirmar reativação deste usuário?',
       },
-      error: () => this.snack.open('Falha ao carregar usuários', 'Fechar', { duration: 3000 }),
     });
-}
 
-viewUserDetails(row: IUserDadosExtended): void {
-  this.router.navigate(['./users', row.uid]);
-}
+    ref.afterClosed().subscribe((ok) => {
+      if (!ok) {
+        return;
+      }
 
-toggleSuspend(row: IUserDadosExtended) {
-  const willSuspend = !row.suspended;
-  const ref = this.dialog.open(ConfirmDialogComponent, {
-    data: {
-      title: willSuspend ? 'Suspender usuário' : 'Reativar usuário',
-      message: willSuspend ? 'Confirmar suspensão deste usuário?' : 'Confirmar reativação deste usuário?',
-    },
-  });
-  ref.afterClosed().subscribe((ok) => {
-    if (!ok) return;
-    const op$ = willSuspend
-      ? this.userModeration.suspendUser(row.uid, 'Ação administrativa', 'ADMIN_UID')
-      : this.userModeration.unsuspendUser(row.uid, 'ADMIN_UID');
+      const action$ = willSuspend
+        ? this.userModeration.suspendUser(row.uid, 'Ação administrativa', '')
+        : this.userModeration.unsuspendUser(row.uid, '');
 
-    op$.subscribe({
+      this.runUserAction(
+        row,
+        action$,
+        willSuspend ? 'Usuário suspenso.' : 'Usuário reativado.',
+        willSuspend ? 'Não foi possível suspender o usuário.' : 'Não foi possível reativar o usuário.',
+        () => this.updateLocalUser(row.uid, {
+          suspended: willSuspend,
+          accountStatus: willSuspend ? 'moderation_suspended' : 'active',
+          statusUpdatedAt: Date.now(),
+        })
+      );
+    });
+  }
+
+  toggleLock(row: IUserDadosExtended): void {
+    const willLock = !row.accountLocked;
+    const ref = this.dialog.open(ConfirmDialogComponent, {
+      data: {
+        title: willLock ? 'Bloquear conta' : 'Desbloquear conta',
+        message: willLock
+          ? 'Confirmar bloqueio técnico desta conta? Use para risco operacional imediato.'
+          : 'Confirmar desbloqueio desta conta?',
+      },
+    });
+
+    ref.afterClosed().subscribe((ok) => {
+      if (!ok) {
+        return;
+      }
+
+      const action$ = willLock
+        ? this.userModeration.lockAccount(row.uid)
+        : this.userModeration.unlockAccount(row.uid);
+
+      this.runUserAction(
+        row,
+        action$,
+        willLock ? 'Conta bloqueada.' : 'Conta desbloqueada.',
+        willLock ? 'Não foi possível bloquear a conta.' : 'Não foi possível desbloquear a conta.',
+        () => this.updateLocalUser(row.uid, {
+          accountLocked: willLock,
+          statusUpdatedAt: Date.now(),
+        })
+      );
+    });
+  }
+
+  deleteUser(row: IUserDadosExtended): void {
+    const ref = this.dialog.open(ConfirmDialogComponent, {
+      data: {
+        title: 'Excluir usuário',
+        message: 'Esta ação remove o documento de usuário e pode exigir rotina administrativa separada para Auth. Confirmar exclusão?',
+      },
+    });
+
+    ref.afterClosed().subscribe((ok) => {
+      if (!ok) {
+        return;
+      }
+
+      this.runUserAction(
+        row,
+        this.userManagementService.deleteUserAccount(row.uid),
+        'Usuário excluído.',
+        'Falha ao excluir usuário.',
+        () => {
+          this.allUsers = this.allUsers.filter((user) => user.uid !== row.uid);
+          this.renderRows();
+        }
+      );
+    });
+  }
+
+  trackByFilterValue(_: number, option: AdminUserFilterOption): string {
+    return option.value;
+  }
+
+  private configureDataSource(): void {
+    this.dataSource.filterPredicate = (row, filter) => [
+      row.displayName,
+      row.email,
+      row.uid,
+      row.municipio,
+      row.estado,
+      row.profileStatusLabel,
+      row.operationalStatusLabel,
+    ]
+      .join(' ')
+      .toLowerCase()
+      .includes(filter);
+
+    this.dataSource.sortingDataAccessor = (row, property) => {
+      switch (property) {
+        case 'usuario':
+          return row.displayName.toLowerCase();
+        case 'perfil':
+          return row.profileCompleted ? 1 : 0;
+        case 'risco':
+          return row.operationalPriority;
+        default:
+          return String((row as any)[property] ?? '').toLowerCase();
+      }
+    };
+  }
+
+  private renderRows(): void {
+    this.dataSource.data = this.applyOperationalFilter(this.allUsers)
+      .map((user) => ({
+        ...user,
+        actionPending: this.pendingActionUids.has(user.uid),
+      }));
+    this.dataSource.filter = this.searchTerm.trim().toLowerCase();
+    this.bindTableTools();
+    this.cdr.markForCheck();
+  }
+
+  private bindTableTools(): void {
+    Promise.resolve().then(() => {
+      if (this.paginator) {
+        this.dataSource.paginator = this.paginator;
+      }
+
+      if (this.sort) {
+        this.dataSource.sort = this.sort;
+      }
+    });
+  }
+
+  private applyOperationalFilter(users: IUserDadosExtended[]): IUserDadosExtended[] {
+    switch (this.activeFilter) {
+      case 'pending':
+        return users.filter((user) => !user.profileCompleted);
+      case 'restricted':
+        return users.filter((user) => this.isRestrictedUser(user));
+      case 'active':
+        return users.filter((user) => user.profileCompleted && !this.isRestrictedUser(user));
+      case 'all':
+      default:
+        return users;
+    }
+  }
+
+  private runUserAction(
+    row: IUserDadosExtended,
+    action$: Observable<void>,
+    successMessage: string,
+    errorMessage: string,
+    afterSuccess: () => void
+  ): void {
+    const uid = String(row.uid ?? '').trim();
+
+    if (!uid || this.pendingActionUids.has(uid)) {
+      return;
+    }
+
+    this.setActionPending(uid, true);
+
+    action$.pipe(
+      finalize(() => this.setActionPending(uid, false))
+    ).subscribe({
       next: () => {
-        row.suspended = willSuspend;
-        this.dataSource.data = [...this.dataSource.data];
-        this.snack.open(willSuspend ? 'Usuário suspenso' : 'Usuário reativado', 'Fechar', { duration: 3000 });
+        afterSuccess();
+        this.notifications.showSuccess(successMessage);
       },
-      error: () => this.snack.open('Ação falhou', 'Fechar', { duration: 3000 }),
+      error: (error) => this.notifications.showError(
+        errorMessage,
+        error instanceof Error ? error.message : undefined
+      ),
     });
-  });
-}
+  }
 
-deleteUser(row: IUserDadosExtended) {
-  const ref = this.dialog.open(ConfirmDialogComponent, {
-    data: { title: 'Excluir usuário', message: 'Esta ação é permanente. Confirmar exclusão?' },
-  });
-  ref.afterClosed().subscribe((ok) => {
-    if (!ok) return;
-    this.userManagementService.deleteUserAccount(row.uid).subscribe({
-      next: () => {
-        this.dataSource.data = this.dataSource.data.filter(u => u.uid !== row.uid);
-        this.snack.open('Usuário excluído', 'Fechar', { duration: 3000 });
-      },
-      error: () => this.snack.open('Falha ao excluir usuário', 'Fechar', { duration: 3000 }),
-    });
-  });
-}
+  private setActionPending(uid: string, pending: boolean): void {
+    if (pending) {
+      this.pendingActionUids.add(uid);
+    } else {
+      this.pendingActionUids.delete(uid);
+    }
+
+    this.renderRows();
+  }
+
+  private updateLocalUser(uid: string, patch: Partial<IUserDados>): void {
+    this.allUsers = this.allUsers.map((user) => user.uid === uid
+      ? this.toAdminRow({ ...user, ...patch })
+      : user
+    );
+    this.renderRows();
+  }
+
+  private toAdminRow(user: IUserDados): IUserDadosExtended {
+    const uid = String(user.uid ?? '').trim();
+    const suspended = user.suspended === true || user.accountStatus === 'moderation_suspended';
+    const accountLocked = user.accountLocked === true;
+    const profileCompleted = user.profileCompleted === true;
+    const displayName = String(user.nickname || user.nome || user.email || 'Usuário sem identificação').trim();
+    const region = [user.municipio, user.estado].filter(Boolean).join(' / ');
+    const isSubscriber = user.isSubscriber === true || user.subscriptionStatus === 'active' || ['premium', 'vip'].includes(String(user.role ?? ''));
+    const statusSeverity = this.userStatusSeverity({ ...user, suspended, accountLocked, profileCompleted });
+
+    return {
+      ...user,
+      uid,
+      suspended,
+      accountLocked,
+      profileCompleted,
+      actionPending: this.pendingActionUids.has(uid),
+      displayName,
+      adminSubtitle: [region || 'Região não informada', isSubscriber ? 'Assinante' : 'Sem assinatura ativa'].join(' · '),
+      profileStatusLabel: profileCompleted ? 'Perfil completo' : 'Cadastro pendente',
+      operationalStatusLabel: this.userStatusLabel({ ...user, suspended, accountLocked, profileCompleted }),
+      statusSeverity,
+      lastActivity: this.userTime(user),
+      operationalPriority: this.userOperationalPriority({ ...user, suspended, accountLocked, profileCompleted }),
+    };
+  }
+
+  private userStatusLabel(user: Pick<IUserDadosExtended, 'suspended' | 'accountLocked' | 'accountStatus' | 'interactionBlocked'>): string {
+    if (user.accountLocked) {
+      return 'Conta bloqueada';
+    }
+
+    if (user.suspended || user.accountStatus === 'moderation_suspended') {
+      return 'Suspenso';
+    }
+
+    if (user.interactionBlocked) {
+      return 'Interação bloqueada';
+    }
+
+    if (user.accountStatus === 'pending_deletion') {
+      return 'Exclusão pendente';
+    }
+
+    return 'Ativo';
+  }
+
+  private userStatusSeverity(user: Pick<IUserDadosExtended, 'suspended' | 'accountLocked' | 'accountStatus' | 'interactionBlocked' | 'profileCompleted'>): UserStatusSeverity {
+    if (user.accountLocked || user.suspended || user.accountStatus === 'moderation_suspended' || user.accountStatus === 'pending_deletion') {
+      return 'danger';
+    }
+
+    if (user.interactionBlocked || !user.profileCompleted) {
+      return 'warning';
+    }
+
+    return 'success';
+  }
+
+  private userOperationalPriority(user: Pick<IUserDadosExtended, 'suspended' | 'accountLocked' | 'accountStatus' | 'interactionBlocked' | 'profileCompleted'>): number {
+    if (user.accountLocked || user.suspended || user.accountStatus === 'moderation_suspended') {
+      return 4;
+    }
+
+    if (user.accountStatus === 'pending_deletion' || user.interactionBlocked) {
+      return 3;
+    }
+
+    if (!user.profileCompleted) {
+      return 2;
+    }
+
+    return 1;
+  }
+
+  private isRestrictedUser(user: Pick<IUserDadosExtended, 'suspended' | 'accountLocked' | 'accountStatus' | 'interactionBlocked'>): boolean {
+    return user.suspended === true
+      || user.accountLocked === true
+      || user.interactionBlocked === true
+      || ['self_suspended', 'moderation_suspended', 'pending_deletion'].includes(String(user.accountStatus ?? ''));
+  }
+
+  private userTime(user: IUserDados): number {
+    return Number(user.lastLogin ?? user.createdAt ?? user.registrationDate ?? user.firstLogin ?? 0) || 0;
+  }
 }

--- a/src/app/admin-dashboard/user-list/user-list.component.ts
+++ b/src/app/admin-dashboard/user-list/user-list.component.ts
@@ -396,7 +396,7 @@ export class UserListComponent implements OnInit {
     };
   }
 
-  private userStatusLabel(user: Pick<IUserDadosExtended, 'suspended' | 'accountLocked' | 'accountStatus' | 'interactionBlocked'>): string {
+  private userStatusLabel(user: Pick<IUserDadosExtended, 'suspended' | 'accountLocked' | 'accountStatus' | 'interactionBlocked' | 'profileCompleted'>): string {
     if (user.accountLocked) {
       return 'Conta bloqueada';
     }


### PR DESCRIPTION
Evolui a tela de usuários do admin para fila operacional de revisão.

Inclui filtros por cadastros pendentes, contas restritas, ativos e todos; resumo superior; busca ampliada; ações de revisar, suspender/reativar, bloquear/desbloquear e excluir; loading por usuário; feedback via ErrorNotificationService; layout mobile-first.

Validação local informada: ng build e functions:build passaram.

Sem alteração em specs.