### PR TITLE
fix(chat): prevent direct receipt permission races

### DIFF
--- a/src/app/core/services/data-handling/firestore/repositories/chat-messages.repository.ts
+++ b/src/app/core/services/data-handling/firestore/repositories/chat-messages.repository.ts
@@ -12,6 +12,7 @@
 // - remove warning de query/collection/doc fora de injection context
 // - mantém compat com paginação e status de mensagem
 // - permite persistir reação por usuário em mensagens diretas
+// - consolida avanço de receipts em transação para evitar disputas entre snapshots
 
 import { Injectable } from '@angular/core';
 import { Observable, defer, from, of } from 'rxjs';
@@ -29,6 +30,7 @@ import {
   limit,
   orderBy,
   query,
+  runTransaction,
   setDoc,
   startAfter,
   updateDoc,
@@ -159,6 +161,88 @@ export class ChatMessagesRepository {
       catchError((err) => {
         this.reportSilent('updateMessageStatus$', err);
         return of(void 0);
+      })
+    );
+  }
+
+  /**
+   * Avança receipts de mensagens recebidas usando o estado atual do Firestore.
+   *
+   * A transação evita que snapshots concorrentes tentem repetir uma transição
+   * já concluída. Mensagens legadas sem status explícito são ignoradas porque as
+   * Rules exigem que o estado anterior seja exatamente sent ou delivered.
+   */
+  advanceMessageReceipts$(
+    chatId: string,
+    currentUserUid: string,
+    messageIds: readonly string[]
+  ): Observable<number> {
+    const cid = this.normChatId(chatId);
+    const safeUid = String(currentUserUid ?? '').trim();
+    const safeMessageIds = Array.from(
+      new Set(
+        (messageIds ?? [])
+          .map((messageId) => this.normMessageId(messageId))
+          .filter(Boolean)
+      )
+    ).slice(0, 50);
+
+    if (!cid || !safeUid || !safeMessageIds.length) {
+      return of(0);
+    }
+
+    return defer(() =>
+      from(
+        this.ctx.run(() =>
+          runTransaction(this.db, async (transaction) => {
+            const messageRefs = safeMessageIds.map((messageId) =>
+              this.messageRef(cid, messageId)
+            );
+            const snapshots = await Promise.all(
+              messageRefs.map((messageRef) => transaction.get(messageRef))
+            );
+
+            let updatedCount = 0;
+
+            snapshots.forEach((snapshot, index) => {
+              if (!snapshot.exists()) {
+                return;
+              }
+
+              const data = snapshot.data() as Partial<Message>;
+              const senderUid = String(
+                data.senderUid ?? data.senderId ?? ''
+              ).trim();
+              const currentStatus = data.status;
+
+              if (!senderUid || senderUid === safeUid) {
+                return;
+              }
+
+              const nextStatus =
+                currentStatus === 'sent'
+                  ? 'delivered'
+                  : currentStatus === 'delivered'
+                    ? 'read'
+                    : null;
+
+              if (!nextStatus) {
+                return;
+              }
+
+              transaction.update(messageRefs[index], { status: nextStatus });
+              updatedCount += 1;
+            });
+
+            return updatedCount;
+          })
+        )
+      )
+    ).pipe(
+      map((updatedCount) => Math.max(0, Number(updatedCount ?? 0))),
+      catchError((err) => {
+        this.reportSilent('advanceMessageReceipts$', err);
+        return of(0);
       })
     );
   }

--- a/src/app/core/services/data-handling/firestore/repositories/chat-messages.repository.ts
+++ b/src/app/core/services/data-handling/firestore/repositories/chat-messages.repository.ts
@@ -210,9 +210,9 @@ export class ChatMessagesRepository {
               }
 
               const data = snapshot.data() as Partial<Message>;
-              const senderUid = String(
-                data.senderUid ?? data.senderId ?? ''
-              ).trim();
+              const senderUid =
+                String(data.senderUid ?? '').trim() ||
+                String(data.senderId ?? '').trim();
               const currentStatus = data.status;
 
               if (!senderUid || senderUid === safeUid) {

--- a/src/app/messaging/direct-chat/services/direct-receipts.service.spec.ts
+++ b/src/app/messaging/direct-chat/services/direct-receipts.service.spec.ts
@@ -1,0 +1,181 @@
+// src/app/messaging/direct-chat/services/direct-receipts.service.spec.ts
+import { firstValueFrom, of, throwError } from 'rxjs';
+
+import { DirectReceiptsService } from './direct-receipts.service';
+
+type MockFn = ReturnType<typeof vi.fn>;
+
+describe('DirectReceiptsService', () => {
+  let service: DirectReceiptsService;
+
+  let messagesRepositoryMock: {
+    advanceMessageReceipts$: MockFn;
+  };
+
+  let globalErrorHandlerMock: {
+    handleError: MockFn;
+  };
+
+  let privacyDebugMock: {
+    log: MockFn;
+  };
+
+  beforeEach(() => {
+    messagesRepositoryMock = {
+      advanceMessageReceipts$: vi.fn(),
+    };
+
+    globalErrorHandlerMock = {
+      handleError: vi.fn(),
+    };
+
+    privacyDebugMock = {
+      log: vi.fn(),
+    };
+
+    service = new DirectReceiptsService(
+      messagesRepositoryMock as any,
+      globalErrorHandlerMock as any,
+      privacyDebugMock as any
+    );
+  });
+
+  it('deve retornar 0 quando chat, uid ou mensagens forem inválidos', async () => {
+    await expect(
+      firstValueFrom(service.markDeliveredAsRead$(' ', 'user-1', []))
+    ).resolves.toBe(0);
+
+    await expect(
+      firstValueFrom(service.markDeliveredAsRead$('chat-1', ' ', []))
+    ).resolves.toBe(0);
+
+    expect(messagesRepositoryMock.advanceMessageReceipts$).not.toHaveBeenCalled();
+  });
+
+  it('deve ignorar mensagens próprias, lidas, sem id e legadas sem status', async () => {
+    const messages = [
+      {
+        id: 'own-by-sender-id',
+        senderId: 'user-1',
+        status: 'sent',
+      },
+      {
+        id: 'own-by-sender-uid',
+        senderId: 'legacy-other',
+        senderUid: 'user-1',
+        status: 'delivered',
+      },
+      {
+        id: 'already-read',
+        senderId: 'user-2',
+        status: 'read',
+      },
+      {
+        id: 'legacy-without-status',
+        senderId: 'user-2',
+      },
+      {
+        senderId: 'user-2',
+        status: 'sent',
+      },
+    ] as any;
+
+    const result = await firstValueFrom(
+      service.markDeliveredAsRead$('chat-1', 'user-1', messages)
+    );
+
+    expect(result).toBe(0);
+    expect(messagesRepositoryMock.advanceMessageReceipts$).not.toHaveBeenCalled();
+  });
+
+  it('deve enviar ids únicos de mensagens recebidas com status explícito', async () => {
+    messagesRepositoryMock.advanceMessageReceipts$.mockReturnValueOnce(of(2));
+
+    const messages = [
+      {
+        id: 'msg-1',
+        senderId: 'user-2',
+        status: 'sent',
+      },
+      {
+        id: 'msg-1',
+        senderUid: 'user-2',
+        senderId: 'legacy-value',
+        status: 'sent',
+      },
+      {
+        id: 'msg-2',
+        senderUid: 'user-3',
+        senderId: '',
+        status: 'delivered',
+      },
+    ] as any;
+
+    const result = await firstValueFrom(
+      service.markDeliveredAsRead$(' chat-1 ', ' user-1 ', messages)
+    );
+
+    expect(result).toBe(2);
+    expect(messagesRepositoryMock.advanceMessageReceipts$).toHaveBeenCalledWith(
+      'chat-1',
+      'user-1',
+      ['msg-1', 'msg-2']
+    );
+    expect(privacyDebugMock.log).toHaveBeenCalledWith(
+      'chat',
+      'DirectReceiptsService: markDeliveredAsRead$',
+      {
+        chatId: 'chat-1',
+        candidateCount: 2,
+        updatedCount: 2,
+      }
+    );
+  });
+
+  it('deve limitar o lote a 50 mensagens', async () => {
+    messagesRepositoryMock.advanceMessageReceipts$.mockReturnValueOnce(of(50));
+
+    const messages = Array.from({ length: 65 }, (_, index) => ({
+      id: `msg-${index + 1}`,
+      senderId: 'user-2',
+      status: 'sent',
+    })) as any;
+
+    const result = await firstValueFrom(
+      service.markDeliveredAsRead$('chat-1', 'user-1', messages)
+    );
+
+    expect(result).toBe(50);
+
+    const ids = messagesRepositoryMock.advanceMessageReceipts$.mock.calls[0][2];
+    expect(ids).toHaveLength(50);
+    expect(ids[0]).toBe('msg-1');
+    expect(ids[49]).toBe('msg-50');
+  });
+
+  it('deve retornar 0 e registrar erro silencioso quando o repository falhar', async () => {
+    messagesRepositoryMock.advanceMessageReceipts$.mockReturnValueOnce(
+      throwError(() => new Error('transaction failed'))
+    );
+
+    const result = await firstValueFrom(
+      service.markDeliveredAsRead$('chat-1', 'user-1', [
+        {
+          id: 'msg-1',
+          senderId: 'user-2',
+          status: 'sent',
+        } as any,
+      ])
+    );
+
+    expect(result).toBe(0);
+    expect(globalErrorHandlerMock.handleError).toHaveBeenCalledTimes(1);
+
+    const handledError = globalErrorHandlerMock.handleError.mock.calls[0][0] as any;
+    expect(handledError.silent).toBe(true);
+    expect(handledError.skipUserNotification).toBe(true);
+    expect(handledError.context).toBe(
+      'DirectReceiptsService.markDeliveredAsRead$'
+    );
+  });
+});

--- a/src/app/messaging/direct-chat/services/direct-receipts.service.ts
+++ b/src/app/messaging/direct-chat/services/direct-receipts.service.ts
@@ -10,162 +10,118 @@
 //
 // Importante:
 // - o cliente NÃO pode fazer sent -> read diretamente;
-// - por isso o avanço precisa ser progressivo;
+// - o avanço usa transação e o estado atual persistido;
+// - mensagens legadas sem status explícito são ignoradas;
 // - falha de receipts é best-effort e não deve quebrar a thread.
 // ============================================================================
 
 import { Injectable } from '@angular/core';
 
-import { forkJoin, Observable, of } from 'rxjs';
-import { catchError, map, tap } from 'rxjs/operators';
+import { Observable, of } from 'rxjs';
+import { catchError, tap } from 'rxjs/operators';
 
 import { Message } from 'src/app/core/interfaces/interfaces-chat/message.interface';
 
-import { ChatService } from '@core/services/batepapo/chat-service/chat.service';
+import { ChatMessagesRepository } from '@core/services/data-handling/firestore/repositories/chat-messages.repository';
 import { GlobalErrorHandlerService } from '@core/services/error-handler/global-error-handler.service';
 import { PrivacyDebugLoggerService } from '@core/services/privacy/privacy-debug-logger.service';
-
-type ReceiptTransitionTarget = 'delivered' | 'read';
-
-type ReceiptTransition = {
-  messageId: string;
-  nextStatus: ReceiptTransitionTarget;
-};
 
 @Injectable({ providedIn: 'root' })
 export class DirectReceiptsService {
   private readonly maxUpdatesPerTick = 50;
 
   constructor(
-    private readonly chatService: ChatService,
+    private readonly messagesRepository: ChatMessagesRepository,
     private readonly globalErrorHandler: GlobalErrorHandlerService,
     private readonly privacyDebug: PrivacyDebugLoggerService
   ) {}
 
   /**
-   * Avança recibos das mensagens recebidas.
+   * Avança receipts das mensagens recebidas.
    *
-   * Regras:
+   * Regras defensivas:
    * - mensagem minha: nunca altera;
    * - mensagem sem id: ignora;
+   * - mensagem sem status explícito: ignora;
    * - read: ignora;
-   * - sent: avança para delivered;
-   * - delivered: avança para read.
+   * - sent/delivered: encaminha para transação no repository.
    *
-   * Observação:
-   * - uma mensagem sent não vira read diretamente por causa das Rules;
-   * - depois que o snapshot atualizar para delivered, esta função pode avançar
-   *   novamente para read.
+   * A decisão final usa o snapshot lido dentro da transação. Assim, emissões
+   * concorrentes do listener não repetem uma escrita com estado já vencido.
    */
   markDeliveredAsRead$(
     chatId: string,
     currentUserUid: string,
     messages: Message[]
   ): Observable<number> {
-    const safeChatId = (chatId ?? '').trim();
-    const safeUid = (currentUserUid ?? '').trim();
+    const safeChatId = String(chatId ?? '').trim();
+    const safeUid = String(currentUserUid ?? '').trim();
     const safeMessages = Array.isArray(messages) ? messages : [];
 
     if (!safeChatId || !safeUid || !safeMessages.length) {
       return of(0);
     }
 
-    const transitions = this.pickReceiptTransitions(safeUid, safeMessages);
+    const messageIds = this.pickReceiptMessageIds(safeUid, safeMessages);
 
-    if (!transitions.length) {
+    if (!messageIds.length) {
       return of(0);
     }
 
-    return forkJoin(
-      transitions.map((transition) =>
-        this.chatService
-          .updateMessageStatus(
-            safeChatId,
-            transition.messageId,
-            transition.nextStatus
-          )
-          .pipe(
-            catchError((error) => {
-              this.reportSilent(
-                error,
-                'DirectReceiptsService.markDeliveredAsRead$.updateMessageStatus',
-                {
-                  chatId: safeChatId,
-                  messageId: transition.messageId,
-                  nextStatus: transition.nextStatus,
-                }
-              );
+    return this.messagesRepository
+      .advanceMessageReceipts$(safeChatId, safeUid, messageIds)
+      .pipe(
+        tap((updatedCount) => {
+          this.dbg('markDeliveredAsRead$', {
+            chatId: safeChatId,
+            candidateCount: messageIds.length,
+            updatedCount,
+          });
+        }),
+        catchError((error) => {
+          this.reportSilent(
+            error,
+            'DirectReceiptsService.markDeliveredAsRead$',
+            {
+              chatId: safeChatId,
+              candidateCount: messageIds.length,
+            }
+          );
 
-              return of(void 0);
-            })
-          )
-      )
-    ).pipe(
-      tap(() => {
-        this.dbg('markDeliveredAsRead$', {
-          chatId: safeChatId,
-          count: transitions.length,
-          deliveredCount: transitions.filter(
-            (transition) => transition.nextStatus === 'delivered'
-          ).length,
-          readCount: transitions.filter(
-            (transition) => transition.nextStatus === 'read'
-          ).length,
-        });
-      }),
-      map(() => transitions.length),
-      catchError((error) => {
-        this.reportSilent(
-          error,
-          'DirectReceiptsService.markDeliveredAsRead$',
-          { chatId: safeChatId }
-        );
-
-        return of(0);
-      })
-    );
+          return of(0);
+        })
+      );
   }
 
   // ---------------------------------------------------------------------------
   // Helpers
   // ---------------------------------------------------------------------------
 
-  private pickReceiptTransitions(
+  private pickReceiptMessageIds(
     currentUserUid: string,
     messages: Message[]
-  ): ReceiptTransition[] {
-    return messages
-      .map((message): ReceiptTransition | null => {
+  ): string[] {
+    const messageIds = messages
+      .map((message): string | null => {
         const messageId = String(message?.id ?? '').trim();
+        const senderUid = String(
+          message?.senderUid ?? message?.senderId ?? ''
+        ).trim();
+        const status = message?.status;
 
-        if (!messageId) {
+        if (!messageId || !senderUid || senderUid === currentUserUid) {
           return null;
         }
 
-        if (message?.senderId === currentUserUid) {
+        if (status !== 'sent' && status !== 'delivered') {
           return null;
         }
 
-        const status = message?.status ?? 'sent';
-
-        if (status === 'sent') {
-          return {
-            messageId,
-            nextStatus: 'delivered',
-          };
-        }
-
-        if (status === 'delivered') {
-          return {
-            messageId,
-            nextStatus: 'read',
-          };
-        }
-
-        return null;
+        return messageId;
       })
-      .filter((transition): transition is ReceiptTransition => !!transition)
-      .slice(0, this.maxUpdatesPerTick);
+      .filter((messageId): messageId is string => !!messageId);
+
+    return Array.from(new Set(messageIds)).slice(0, this.maxUpdatesPerTick);
   }
 
   private dbg(message: string, extra?: unknown): void {

--- a/src/app/messaging/direct-chat/services/direct-receipts.service.ts
+++ b/src/app/messaging/direct-chat/services/direct-receipts.service.ts
@@ -104,9 +104,9 @@ export class DirectReceiptsService {
     const messageIds = messages
       .map((message): string | null => {
         const messageId = String(message?.id ?? '').trim();
-        const senderUid = String(
-          message?.senderUid ?? message?.senderId ?? ''
-        ).trim();
+        const senderUid =
+          String(message?.senderUid ?? '').trim() ||
+          String(message?.senderId ?? '').trim();
         const status = message?.status;
 
         if (!messageId || !senderUid || senderUid === currentUserUid) {


### PR DESCRIPTION
## O que mudou

- consolida o avanço de receipts de chat direto em uma transação Firestore;
- relê o estado persistido antes de decidir entre `sent -> delivered` e `delivered -> read`;
- ignora mensagens legadas sem `status` explícito;
- resolve o remetente por `senderUid` ou `senderId`, inclusive quando `senderUid` existe vazio;
- deduplica IDs e limita cada lote a 50 mensagens;
- adiciona testes para mensagens próprias, legadas, duplicadas e falha do repository.

## Causa raiz

O listener da thread recebe um novo snapshot após cada atualização de status. O fluxo anterior iniciava novas escritas usando o estado do snapshot anterior. Com isso, duas emissões podiam tentar a mesma transição simultaneamente. Além disso, mensagens antigas sem `status` eram tratadas no cliente como `sent`, mas as Firestore Rules exigem que `resource.data.status` seja explicitamente `sent` ou `delivered`. Esses dois casos resultavam em `Missing or insufficient permissions`.

## Segurança e arquitetura

- nenhuma Firestore Rule foi afrouxada;
- nenhuma rota ou funcionalidade foi removida;
- o fluxo continua Observable-first;
- erros inesperados continuam centralizados no `GlobalErrorHandlerService`;
- receipts permanecem best-effort e não interrompem a thread.

## Supressões intencionais

- removido o `forkJoin` que disparava uma escrita independente por mensagem;
- removido o fallback `status ?? 'sent'` para documentos legados;
- removida a dependência de `ChatService` em `DirectReceiptsService`.

Motivo: essas três partes foram substituídas pelo lote transacional do `ChatMessagesRepository`, que lê o estado atual antes de escrever e evita transições inválidas ou concorrentes.

## Validação concluída em 16/07/2026

- `npm run build:safe`: aprovado;
- Firestore Rules: `FINAL total: 0 (0 = OK)`;
- build Angular: aprovado;
- `npm run functions:build`: aprovado;
- teste direcionado de `DirectReceiptsService`: 1 arquivo e 5 testes aprovados;
- aviso de depreciação de `punycode` não afetou build ou testes.

PR pronta para revisão final. O merge ainda não foi executado.