### PR TITLE
fix(store): serialize public media metrics timestamp

### DIFF
--- a/src/app/store/utils/user-store.serializer.spec.ts
+++ b/src/app/store/utils/user-store.serializer.spec.ts
@@ -1,0 +1,36 @@
+import { sanitizeUserForStore } from './user-store.serializer';
+
+describe('sanitizeUserForStore', () => {
+  it('deve converter mediaMetricsUpdatedAt do Firestore para epoch serializável', () => {
+    const source = {
+      uid: 'user-1',
+      lastLogin: 0,
+      mediaMetricsUpdatedAt: {
+        toMillis: () => 1_721_234_567_890,
+      },
+    } as any;
+
+    const result = sanitizeUserForStore(source) as any;
+
+    expect(result.mediaMetricsUpdatedAt).toBe(1_721_234_567_890);
+    expect(typeof result.mediaMetricsUpdatedAt).toBe('number');
+    expect(() => JSON.stringify(result)).not.toThrow();
+  });
+
+  it('deve preservar epoch numérico e normalizar valor inválido para null', () => {
+    const valid = sanitizeUserForStore({
+      uid: 'user-1',
+      lastLogin: 0,
+      mediaMetricsUpdatedAt: 1_700_000_000_000,
+    } as any) as any;
+
+    const invalid = sanitizeUserForStore({
+      uid: 'user-2',
+      lastLogin: 0,
+      mediaMetricsUpdatedAt: { unexpected: true },
+    } as any) as any;
+
+    expect(valid.mediaMetricsUpdatedAt).toBe(1_700_000_000_000);
+    expect(invalid.mediaMetricsUpdatedAt).toBeNull();
+  });
+});

--- a/src/app/store/utils/user-store.serializer.ts
+++ b/src/app/store/utils/user-store.serializer.ts
@@ -47,6 +47,19 @@ export function sanitizeUserForStore(u: IUserDados): IUserDados {
     singleRoomCreationRightExpires: toSerializableEpoch(anyU.singleRoomCreationRightExpires),
 
     lastStateChangeAt: toSerializableEpoch(anyU.lastStateChangeAt),
+
+    /**
+     * Métrica agregada gravada em public_profiles/{uid} pelo backend.
+     *
+     * SUPRESSÃO EXPLÍCITA:
+     * - o Timestamp original do Firestore não entra no NgRx.
+     *
+     * Motivo:
+     * - actions e state precisam permanecer serializáveis;
+     * - o valor em epoch preserva ordenação e comparação sem acoplar o Store ao SDK.
+     */
+    mediaMetricsUpdatedAt: toSerializableEpoch(anyU.mediaMetricsUpdatedAt),
+
     adultConsent: sanitizeConsent(anyU.adultConsent),
   } as IUserDados;
 }


### PR DESCRIPTION
## O que mudou

- converte `mediaMetricsUpdatedAt` para epoch antes de qualquer usuário entrar em action/state/cache do NgRx;
- mantém o Store desacoplado de `Timestamp` do Firestore;
- adiciona testes para Timestamp compatível, epoch numérico e valor inválido.

## Causa raiz

`UserDiscoveryQueryService` repassa `mediaMetricsUpdatedAt` da projeção `public_profiles/{uid}`. O campo pode chegar como `Timestamp` do Firestore. `sanitizeUserForStore` já normalizava as demais datas, mas não incluía essa métrica, resultando em:

`Detected unserializable action at "user.mediaMetricsUpdatedAt"`

## Supressão intencional

O objeto `Timestamp` original deixa de entrar no NgRx e é substituído por epoch em milissegundos.

Motivo: preservar serialização, cache, DevTools, comparação e persistência sem transportar instâncias do SDK.

## Validação concluída em 16/07/2026

- `npm run build:safe`: aprovado;
- Firestore Rules: `FINAL total: 0 (0 = OK)`;
- build Angular: aprovado;
- teste direcionado do serializer: 1 arquivo e 2 testes aprovados;
- aviso de depreciação de `punycode` não afetou build ou testes.

PR pronta para revisão final. O merge ainda não foi executado.