### PR TITLE
fix(store): serializar timestamp de métricas públicas

### DIFF
--- a/src/app/store/utils/user-store.serializer.spec.ts
+++ b/src/app/store/utils/user-store.serializer.spec.ts
@@ -1,0 +1,36 @@
+import { sanitizeUserForStore } from './user-store.serializer';
+
+describe('sanitizeUserForStore', () => {
+  it('deve converter mediaMetricsUpdatedAt do Firestore para epoch serializável', () => {
+    const source = {
+      uid: 'user-1',
+      lastLogin: 0,
+      mediaMetricsUpdatedAt: {
+        toMillis: () => 1_721_234_567_890,
+      },
+    } as any;
+
+    const result = sanitizeUserForStore(source) as any;
+
+    expect(result.mediaMetricsUpdatedAt).toBe(1_721_234_567_890);
+    expect(typeof result.mediaMetricsUpdatedAt).toBe('number');
+    expect(() => JSON.stringify(result)).not.toThrow();
+  });
+
+  it('deve preservar epoch numérico e normalizar valor inválido para null', () => {
+    const valid = sanitizeUserForStore({
+      uid: 'user-1',
+      lastLogin: 0,
+      mediaMetricsUpdatedAt: 1_700_000_000_000,
+    } as any) as any;
+
+    const invalid = sanitizeUserForStore({
+      uid: 'user-2',
+      lastLogin: 0,
+      mediaMetricsUpdatedAt: { unexpected: true },
+    } as any) as any;
+
+    expect(valid.mediaMetricsUpdatedAt).toBe(1_700_000_000_000);
+    expect(invalid.mediaMetricsUpdatedAt).toBeNull();
+  });
+});

--- a/src/app/store/utils/user-store.serializer.ts
+++ b/src/app/store/utils/user-store.serializer.ts
@@ -47,6 +47,19 @@ export function sanitizeUserForStore(u: IUserDados): IUserDados {
     singleRoomCreationRightExpires: toSerializableEpoch(anyU.singleRoomCreationRightExpires),
 
     lastStateChangeAt: toSerializableEpoch(anyU.lastStateChangeAt),
+
+    /**
+     * Métrica agregada gravada em public_profiles/{uid} pelo backend.
+     *
+     * SUPRESSÃO EXPLÍCITA:
+     * - o Timestamp original do Firestore não entra no NgRx.
+     *
+     * Motivo:
+     * - actions e state precisam permanecer serializáveis;
+     * - o valor em epoch preserva ordenação e comparação sem acoplar o Store ao SDK.
+     */
+    mediaMetricsUpdatedAt: toSerializableEpoch(anyU.mediaMetricsUpdatedAt),
+
     adultConsent: sanitizeConsent(anyU.adultConsent),
   } as IUserDados;
 }


### PR DESCRIPTION
## Objetivo

Garantir que `mediaMetricsUpdatedAt`, recebido da projeção `public_profiles/{uid}`, nunca introduza uma instância `Timestamp` do Firestore nas actions ou no estado do NgRx.

## Alteração

- normaliza `mediaMetricsUpdatedAt` com o mesmo conversor de epoch usado pelas demais datas do usuário;
- preserva valores numéricos válidos;
- converte valores ausentes ou inválidos para `null`;
- adiciona testes para objeto compatível com `Timestamp`, epoch numérico e valor inválido.

## Supressão explícita

A instância original de `Timestamp` deixa de ser transportada para o NgRx e é substituída por epoch em milissegundos.

Motivo: manter actions, state, DevTools e eventuais persistências serializáveis, sem acoplar o Store ao SDK do Firestore.

## Base reconstruída

Esta PR substitui a PR #35. A correção foi reaplicada diretamente sobre a `main` atual, sem carregar commits antigos ou alterações da arquitetura de cache já integradas.

## Limites

- dois arquivos alterados;
- nenhuma alteração em componentes, regras, Functions, cache ou backend;
- nenhuma dependência alterada;
- nenhuma nomenclatura pública modificada.