### PR TITLE
feat(compliance): criar snapshot KYC/AML fail-closed

### DIFF
--- a/firestore-rules/compliance.rules
+++ b/firestore-rules/compliance.rules
@@ -1,0 +1,56 @@
+// firestore-rules/compliance.rules
+// =========================================================================
+// COMPLIANCE / KYC / AML INTERNAL DATA
+// =========================================================================
+//
+// O navegador nunca é autoridade para:
+// - aprovar idade ou identidade;
+// - classificar risco AML;
+// - registrar eventos de provedor;
+// - alterar elegibilidade de saque;
+// - ler auditorias ou sinais internos.
+//
+// A UI consome somente a projeção sanitizada devolvida pela callable
+// getMyComplianceSnapshot. Cloud Functions com Admin SDK continuam fora do
+// escopo destas permissões do cliente.
+//
+// ✅ ARQUIVO MODULAR: NÃO pode ter `rules_version` nem
+//    `service cloud.firestore`.
+// =========================================================================
+
+match /compliance_profiles/{userId} {
+  /**
+   * Estado interno consolidado de idade, identidade e risco.
+   * Pode conter referências tokenizadas do provedor, mas nunca documentos
+   * brutos ou biometria.
+   */
+  allow read, write: if false;
+}
+
+match /identity_verification_events/{eventId} {
+  /**
+   * Eventos idempotentes de KYC recebidos de provedor ou fluxo interno.
+   */
+  allow read, write: if false;
+}
+
+match /aml_risk_events/{eventId} {
+  /**
+   * Sinais, revisões e decisões AML. Nenhum detalhe de sanções, PEP ou adverse
+   * media deve ser exposto ao cliente.
+   */
+  allow read, write: if false;
+}
+
+match /compliance_audit/{auditId} {
+  /**
+   * Auditoria de consentimento adulto, KYC, AML e elegibilidade.
+   * O handler de consentimento adulto já grava nesta coleção; este bloqueio
+   * explícito impede leitura ou adulteração pelo SDK web/mobile.
+   */
+  allow read, write: if false;
+}
+
+// =========================================================================
+//                    FIM DO COMPLIANCE.RULES
+// =========================================================================

--- a/firestore-rules/tools-rules/build-firestore-rules.mjs
+++ b/firestore-rules/tools-rules/build-firestore-rules.mjs
@@ -8,8 +8,8 @@
 // Decisões:
 // - firestore.rules é artefato gerado; não deve ser editado manualmente;
 // - fragments sensíveis ficam versionados em firestore-rules/;
-// - billing.rules entra logo após users.rules por tratar dados privados e
-//   financeiros internos;
+// - billing.rules e compliance.rules entram logo após users.rules por tratarem
+//   dados privados, financeiros e regulatórios internos;
 // - os marcadores por arquivo permanecem no resultado para diagnóstico.
 
 import fs from 'node:fs';
@@ -30,6 +30,7 @@ const parts = [
   // Documentos privados e domínios internos sensíveis.
   'users.rules',
   'billing.rules',
+  'compliance.rules',
 
   // Discovery, presença e vitrines regionais moderadas.
   'public_profiles.rules',

--- a/functions/src/compliance/compliance.model.ts
+++ b/functions/src/compliance/compliance.model.ts
@@ -1,0 +1,171 @@
+// functions/src/compliance/compliance.model.ts
+// -----------------------------------------------------------------------------
+// COMPLIANCE DOMAIN CONTRACT
+// -----------------------------------------------------------------------------
+//
+// Contrato interno e projeção mínima do estado KYC/AML.
+//
+// Princípios:
+// - o backend é a única autoridade para elegibilidade de saque;
+// - ausência ou valor desconhecido falha de forma fechada;
+// - documentos, biometria, CPF e payloads de provedor nunca fazem parte deste
+//   contrato;
+// - o frontend recebe apenas estados sanitizados e motivos operacionais.
+
+export const AGE_VERIFICATION_STATUS_VALUES = [
+  'not_started',
+  'pending',
+  'approved',
+  'rejected',
+  'expired',
+] as const;
+
+export type AgeVerificationStatus =
+  (typeof AGE_VERIFICATION_STATUS_VALUES)[number];
+
+export const IDENTITY_VERIFICATION_STATUS_VALUES = [
+  'not_started',
+  'pending',
+  'needs_action',
+  'approved',
+  'rejected',
+  'expired',
+] as const;
+
+export type IdentityVerificationStatus =
+  (typeof IDENTITY_VERIFICATION_STATUS_VALUES)[number];
+
+export const PAYOUT_ACCOUNT_STATUS_VALUES = [
+  'not_connected',
+  'pending',
+  'active',
+  'restricted',
+  'disabled',
+] as const;
+
+export type PayoutAccountStatus =
+  (typeof PAYOUT_ACCOUNT_STATUS_VALUES)[number];
+
+export const AML_RISK_TIER_VALUES = [
+  'low',
+  'medium',
+  'high',
+  'blocked',
+] as const;
+
+export type AmlRiskTier = (typeof AML_RISK_TIER_VALUES)[number];
+
+export const ACCOUNT_STATUS_VALUES = [
+  'active',
+  'self_suspended',
+  'moderation_suspended',
+  'pending_deletion',
+  'deleted',
+] as const;
+
+export type ComplianceAccountStatus =
+  (typeof ACCOUNT_STATUS_VALUES)[number];
+
+export type AdultConsentStatus = 'not_accepted' | 'accepted';
+
+export const PAYOUT_ELIGIBILITY_REASON_VALUES = [
+  'adult_consent_required',
+  'age_verification_required',
+  'identity_verification_required',
+  'payout_account_required',
+  'aml_review_required',
+  'aml_risk_blocked',
+  'account_not_active',
+  'account_locked',
+  'account_interactions_blocked',
+  'compliance_snapshot_unavailable',
+] as const;
+
+export type PayoutEligibilityReason =
+  (typeof PAYOUT_ELIGIBILITY_REASON_VALUES)[number];
+
+export interface PayoutEligibility {
+  eligible: boolean;
+  reasons: PayoutEligibilityReason[];
+}
+
+export interface ComplianceEligibilityInput {
+  adultConsentAccepted: boolean;
+  ageVerificationStatus: AgeVerificationStatus;
+  identityVerificationStatus: IdentityVerificationStatus;
+  payoutAccountStatus: PayoutAccountStatus;
+  amlRiskTier: AmlRiskTier | null;
+  accountStatus: ComplianceAccountStatus;
+  accountLocked: boolean;
+  interactionBlocked: boolean;
+}
+
+export interface MyComplianceSnapshot {
+  available: true;
+  adultConsentStatus: AdultConsentStatus;
+  ageVerificationStatus: AgeVerificationStatus;
+  ageVerifiedAt: number | null;
+  identityVerificationStatus: IdentityVerificationStatus;
+  identityVerificationProvider: string | null;
+  identityVerificationUpdatedAt: number | null;
+  payoutAccountStatus: PayoutAccountStatus;
+  amlRiskTier: AmlRiskTier | null;
+  lastRiskReviewAt: number | null;
+  payoutEligibility: PayoutEligibility;
+  generatedAt: number;
+}
+
+/**
+ * Deriva elegibilidade sem aceitar decisões enviadas pelo navegador.
+ *
+ * Política inicial conservadora:
+ * - AML `low` é o único tier automaticamente elegível;
+ * - `medium` e `high` exigem revisão antes de qualquer saque;
+ * - `blocked` impede explicitamente a operação;
+ * - estados ausentes são normalizados antes desta função e permanecem
+ *   inelegíveis.
+ */
+export function derivePayoutEligibility(
+  input: ComplianceEligibilityInput
+): PayoutEligibility {
+  const reasons: PayoutEligibilityReason[] = [];
+
+  if (!input.adultConsentAccepted) {
+    reasons.push('adult_consent_required');
+  }
+
+  if (input.ageVerificationStatus !== 'approved') {
+    reasons.push('age_verification_required');
+  }
+
+  if (input.identityVerificationStatus !== 'approved') {
+    reasons.push('identity_verification_required');
+  }
+
+  if (input.payoutAccountStatus !== 'active') {
+    reasons.push('payout_account_required');
+  }
+
+  if (input.amlRiskTier === 'blocked') {
+    reasons.push('aml_risk_blocked');
+  } else if (input.amlRiskTier !== 'low') {
+    reasons.push('aml_review_required');
+  }
+
+  if (input.accountStatus !== 'active') {
+    reasons.push('account_not_active');
+  }
+
+  if (input.accountLocked) {
+    reasons.push('account_locked');
+  }
+
+  if (input.interactionBlocked) {
+    reasons.push('account_interactions_blocked');
+  }
+
+  return {
+    eligible: reasons.length === 0,
+    reasons,
+  };
+}

--- a/functions/src/compliance/get-my-compliance-snapshot.handler.ts
+++ b/functions/src/compliance/get-my-compliance-snapshot.handler.ts
@@ -1,0 +1,229 @@
+// functions/src/compliance/get-my-compliance-snapshot.handler.ts
+// -----------------------------------------------------------------------------
+// GET MY COMPLIANCE SNAPSHOT
+// -----------------------------------------------------------------------------
+//
+// Devolve somente uma projeção sanitizada do estado adulto, KYC, conta de
+// repasse e AML do usuário autenticado.
+//
+// Nenhum documento, biometria, CPF, referência secreta, flag de sanções ou
+// payload bruto de provedor é retornado ao navegador.
+
+import { HttpsError, onCall } from 'firebase-functions/v2/https';
+
+import { FUNCTIONS_REGION } from '../config/functions-region';
+import { db } from '../firebaseApp';
+import {
+  ACCOUNT_STATUS_VALUES,
+  AGE_VERIFICATION_STATUS_VALUES,
+  AML_RISK_TIER_VALUES,
+  ComplianceAccountStatus,
+  derivePayoutEligibility,
+  IDENTITY_VERIFICATION_STATUS_VALUES,
+  IdentityVerificationStatus,
+  MyComplianceSnapshot,
+  PAYOUT_ACCOUNT_STATUS_VALUES,
+  PayoutAccountStatus,
+  AgeVerificationStatus,
+  AmlRiskTier,
+} from './compliance.model';
+
+interface UserComplianceSource {
+  adultConsent?: {
+    accepted?: unknown;
+  } | null;
+  accountStatus?: unknown;
+  suspended?: unknown;
+  accountLocked?: unknown;
+  interactionBlocked?: unknown;
+}
+
+interface ComplianceProfileSource {
+  ageVerificationStatus?: unknown;
+  ageVerifiedAt?: unknown;
+  identityVerificationStatus?: unknown;
+  identityVerificationProvider?: unknown;
+  identityVerificationUpdatedAt?: unknown;
+  amlRiskTier?: unknown;
+  lastRiskReviewAt?: unknown;
+}
+
+interface PayoutAccountSource {
+  status?: unknown;
+  payoutAccountStatus?: unknown;
+}
+
+function isAllowedValue<T extends string>(
+  value: unknown,
+  allowedValues: readonly T[]
+): value is T {
+  return typeof value === 'string' && allowedValues.includes(value as T);
+}
+
+function normalizeAgeVerificationStatus(
+  value: unknown
+): AgeVerificationStatus {
+  return isAllowedValue(value, AGE_VERIFICATION_STATUS_VALUES)
+    ? value
+    : 'not_started';
+}
+
+function normalizeIdentityVerificationStatus(
+  value: unknown
+): IdentityVerificationStatus {
+  return isAllowedValue(value, IDENTITY_VERIFICATION_STATUS_VALUES)
+    ? value
+    : 'not_started';
+}
+
+function normalizePayoutAccountStatus(value: unknown): PayoutAccountStatus {
+  return isAllowedValue(value, PAYOUT_ACCOUNT_STATUS_VALUES)
+    ? value
+    : 'not_connected';
+}
+
+function normalizeAmlRiskTier(value: unknown): AmlRiskTier | null {
+  return isAllowedValue(value, AML_RISK_TIER_VALUES) ? value : null;
+}
+
+function normalizeAccountStatus(
+  value: unknown,
+  suspended: boolean
+): ComplianceAccountStatus {
+  if (isAllowedValue(value, ACCOUNT_STATUS_VALUES)) {
+    return value;
+  }
+
+  return suspended ? 'moderation_suspended' : 'active';
+}
+
+function toEpochOrNull(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.trunc(value);
+  }
+
+  if (value instanceof Date && Number.isFinite(value.getTime())) {
+    return value.getTime();
+  }
+
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const source = value as {
+    toMillis?: () => unknown;
+    seconds?: unknown;
+    nanoseconds?: unknown;
+  };
+
+  if (typeof source.toMillis === 'function') {
+    try {
+      const epoch = source.toMillis();
+      return typeof epoch === 'number' && Number.isFinite(epoch)
+        ? Math.trunc(epoch)
+        : null;
+    } catch {
+      return null;
+    }
+  }
+
+  if (typeof source.seconds === 'number' && Number.isFinite(source.seconds)) {
+    const nanos =
+      typeof source.nanoseconds === 'number' &&
+      Number.isFinite(source.nanoseconds)
+        ? source.nanoseconds
+        : 0;
+
+    return Math.trunc(source.seconds * 1_000 + nanos / 1_000_000);
+  }
+
+  return null;
+}
+
+function normalizeProvider(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const provider = value.trim().toLowerCase();
+
+  return /^[a-z0-9_-]{1,64}$/.test(provider) ? provider : null;
+}
+
+export const getMyComplianceSnapshot = onCall<Record<string, never>>(
+  { region: FUNCTIONS_REGION },
+  async (request): Promise<MyComplianceSnapshot> => {
+    const uid = request.auth?.uid?.trim() ?? '';
+
+    if (!uid) {
+      throw new HttpsError(
+        'unauthenticated',
+        'Usuário não autenticado.'
+      );
+    }
+
+    const [userSnapshot, complianceSnapshot, payoutAccountSnapshot] =
+      await Promise.all([
+        db.collection('users').doc(uid).get(),
+        db.collection('compliance_profiles').doc(uid).get(),
+        db.collection('payout_accounts').doc(uid).get(),
+      ]);
+
+    const user = (userSnapshot.data() ?? {}) as UserComplianceSource;
+    const compliance = (complianceSnapshot.data() ??
+      {}) as ComplianceProfileSource;
+    const payoutAccount = (payoutAccountSnapshot.data() ??
+      {}) as PayoutAccountSource;
+
+    const adultConsentAccepted = user.adultConsent?.accepted === true;
+    const ageVerificationStatus = normalizeAgeVerificationStatus(
+      compliance.ageVerificationStatus
+    );
+    const identityVerificationStatus =
+      normalizeIdentityVerificationStatus(
+        compliance.identityVerificationStatus
+      );
+    const payoutAccountStatus = normalizePayoutAccountStatus(
+      payoutAccount.payoutAccountStatus ?? payoutAccount.status
+    );
+    const amlRiskTier = normalizeAmlRiskTier(compliance.amlRiskTier);
+    const accountLocked = user.accountLocked === true;
+    const interactionBlocked = user.interactionBlocked === true;
+    const accountStatus = normalizeAccountStatus(
+      user.accountStatus,
+      user.suspended === true
+    );
+
+    const payoutEligibility = derivePayoutEligibility({
+      adultConsentAccepted,
+      ageVerificationStatus,
+      identityVerificationStatus,
+      payoutAccountStatus,
+      amlRiskTier,
+      accountStatus,
+      accountLocked,
+      interactionBlocked,
+    });
+
+    return {
+      available: true,
+      adultConsentStatus: adultConsentAccepted
+        ? 'accepted'
+        : 'not_accepted',
+      ageVerificationStatus,
+      ageVerifiedAt: toEpochOrNull(compliance.ageVerifiedAt),
+      identityVerificationStatus,
+      identityVerificationProvider: normalizeProvider(
+        compliance.identityVerificationProvider
+      ),
+      identityVerificationUpdatedAt: toEpochOrNull(
+        compliance.identityVerificationUpdatedAt
+      ),
+      payoutAccountStatus,
+      amlRiskTier,
+      lastRiskReviewAt: toEpochOrNull(compliance.lastRiskReviewAt),
+      payoutEligibility,
+      generatedAt: Date.now(),
+    };
+  }
+);

--- a/functions/src/compliance/get-my-compliance-snapshot.handler.ts
+++ b/functions/src/compliance/get-my-compliance-snapshot.handler.ts
@@ -36,6 +36,9 @@ interface UserComplianceSource {
   suspended?: unknown;
   accountLocked?: unknown;
   interactionBlocked?: unknown;
+  loginAllowed?: unknown;
+  deletionRequestedAt?: unknown;
+  deletedAt?: unknown;
 }
 
 interface ComplianceProfileSource {
@@ -86,17 +89,6 @@ function normalizeAmlRiskTier(value: unknown): AmlRiskTier | null {
   return isAllowedValue(value, AML_RISK_TIER_VALUES) ? value : null;
 }
 
-function normalizeAccountStatus(
-  value: unknown,
-  suspended: boolean
-): ComplianceAccountStatus {
-  if (isAllowedValue(value, ACCOUNT_STATUS_VALUES)) {
-    return value;
-  }
-
-  return suspended ? 'moderation_suspended' : 'active';
-}
-
 function toEpochOrNull(value: unknown): number | null {
   if (typeof value === 'number' && Number.isFinite(value)) {
     return Math.trunc(value);
@@ -138,6 +130,57 @@ function toEpochOrNull(value: unknown): number | null {
   }
 
   return null;
+}
+
+/**
+ * Consolida o lifecycle atual sem permitir que um campo legado permissivo
+ * neutralize uma restrição mais forte.
+ *
+ * Exemplos fail-closed:
+ * - `accountStatus: active` com `suspended: true` continua suspenso;
+ * - timestamp de exclusão prevalece sobre status ativo legado;
+ * - `loginAllowed: false` impede elegibilidade mesmo sem status migrado.
+ */
+function normalizeAccountStatus(
+  value: unknown,
+  source: {
+    suspended: boolean;
+    loginAllowed: boolean;
+    deletionRequestedAt: unknown;
+    deletedAt: unknown;
+  }
+): ComplianceAccountStatus {
+  const explicitStatus = isAllowedValue(value, ACCOUNT_STATUS_VALUES)
+    ? value
+    : null;
+
+  if (
+    explicitStatus === 'deleted' ||
+    toEpochOrNull(source.deletedAt) !== null
+  ) {
+    return 'deleted';
+  }
+
+  if (
+    explicitStatus === 'pending_deletion' ||
+    toEpochOrNull(source.deletionRequestedAt) !== null
+  ) {
+    return 'pending_deletion';
+  }
+
+  if (explicitStatus === 'self_suspended') {
+    return 'self_suspended';
+  }
+
+  if (
+    explicitStatus === 'moderation_suspended' ||
+    source.suspended ||
+    !source.loginAllowed
+  ) {
+    return 'moderation_suspended';
+  }
+
+  return 'active';
 }
 
 function normalizeProvider(value: unknown): string | null {
@@ -189,10 +232,12 @@ export const getMyComplianceSnapshot = onCall<Record<string, never>>(
     const amlRiskTier = normalizeAmlRiskTier(compliance.amlRiskTier);
     const accountLocked = user.accountLocked === true;
     const interactionBlocked = user.interactionBlocked === true;
-    const accountStatus = normalizeAccountStatus(
-      user.accountStatus,
-      user.suspended === true
-    );
+    const accountStatus = normalizeAccountStatus(user.accountStatus, {
+      suspended: user.suspended === true,
+      loginAllowed: user.loginAllowed !== false,
+      deletionRequestedAt: user.deletionRequestedAt,
+      deletedAt: user.deletedAt,
+    });
 
     const payoutEligibility = derivePayoutEligibility({
       adultConsentAccepted,

--- a/functions/src/compliance/index.ts
+++ b/functions/src/compliance/index.ts
@@ -1,1 +1,2 @@
 export { acceptAdultConsent } from './adult-consent.handler';
+export { getMyComplianceSnapshot } from './get-my-compliance-snapshot.handler';

--- a/src/app/core/interfaces/compliance/compliance-snapshot.interface.spec.ts
+++ b/src/app/core/interfaces/compliance/compliance-snapshot.interface.spec.ts
@@ -1,0 +1,99 @@
+import {
+  createUnavailableComplianceSnapshot,
+  normalizeComplianceSnapshot,
+} from './compliance-snapshot.interface';
+
+describe('compliance snapshot contract', () => {
+  it('deve criar fallback indisponível e inelegível', () => {
+    const snapshot = createUnavailableComplianceSnapshot();
+
+    expect(snapshot.available).toBe(false);
+    expect(snapshot.payoutEligibility.eligible).toBe(false);
+    expect(snapshot.payoutEligibility.reasons).toEqual([
+      'compliance_snapshot_unavailable',
+    ]);
+  });
+
+  it('deve preservar snapshot válido e elegível emitido pelo backend', () => {
+    const snapshot = normalizeComplianceSnapshot({
+      available: true,
+      adultConsentStatus: 'accepted',
+      ageVerificationStatus: 'approved',
+      ageVerifiedAt: 1_700_000_000_000,
+      identityVerificationStatus: 'approved',
+      identityVerificationProvider: ' PROVIDER_1 ',
+      identityVerificationUpdatedAt: 1_700_000_000_100,
+      payoutAccountStatus: 'active',
+      amlRiskTier: 'low',
+      lastRiskReviewAt: 1_700_000_000_200,
+      payoutEligibility: {
+        eligible: true,
+        reasons: [],
+      },
+      generatedAt: 1_700_000_000_300,
+    });
+
+    expect(snapshot.available).toBe(true);
+    expect(snapshot.identityVerificationProvider).toBe('provider_1');
+    expect(snapshot.payoutEligibility).toEqual({
+      eligible: true,
+      reasons: [],
+    });
+  });
+
+  it('deve falhar fechado quando o payload não for um objeto', () => {
+    const snapshot = normalizeComplianceSnapshot('invalid');
+
+    expect(snapshot).toEqual(createUnavailableComplianceSnapshot());
+  });
+
+  it('não deve aceitar elegibilidade incompatível com os estados sanitizados', () => {
+    const snapshot = normalizeComplianceSnapshot({
+      available: true,
+      adultConsentStatus: 'accepted',
+      ageVerificationStatus: 'approved',
+      identityVerificationStatus: 'pending',
+      payoutAccountStatus: 'active',
+      amlRiskTier: 'medium',
+      payoutEligibility: {
+        eligible: true,
+        reasons: [],
+      },
+      generatedAt: 1_700_000_000_000,
+    });
+
+    expect(snapshot.payoutEligibility.eligible).toBe(false);
+    expect(snapshot.payoutEligibility.reasons).toEqual([
+      'identity_verification_required',
+      'aml_review_required',
+    ]);
+  });
+
+  it('deve descartar valores e motivos desconhecidos sem liberar saque', () => {
+    const snapshot = normalizeComplianceSnapshot({
+      available: true,
+      adultConsentStatus: 'unknown',
+      ageVerificationStatus: 'approved-by-client',
+      identityVerificationStatus: 'approved',
+      identityVerificationProvider: 'provider com espaço',
+      payoutAccountStatus: 'enabled',
+      amlRiskTier: 'safe',
+      payoutEligibility: {
+        eligible: true,
+        reasons: ['unknown_reason', 'account_locked', 'account_locked'],
+      },
+      generatedAt: Number.NaN,
+    });
+
+    expect(snapshot.identityVerificationProvider).toBeNull();
+    expect(snapshot.generatedAt).toBeNull();
+    expect(snapshot.payoutEligibility.eligible).toBe(false);
+    expect(snapshot.payoutEligibility.reasons).toEqual([
+      'account_locked',
+      'adult_consent_required',
+      'age_verification_required',
+      'payout_account_required',
+      'aml_review_required',
+    ]);
+  });
+});

--- a/src/app/core/interfaces/compliance/compliance-snapshot.interface.ts
+++ b/src/app/core/interfaces/compliance/compliance-snapshot.interface.ts
@@ -1,0 +1,259 @@
+// src/app/core/interfaces/compliance/compliance-snapshot.interface.ts
+// -----------------------------------------------------------------------------
+// COMPLIANCE SNAPSHOT CONTRACT
+// -----------------------------------------------------------------------------
+//
+// Projeção mínima consumida pelo Angular. O navegador nunca decide KYC, AML ou
+// elegibilidade de saque; apenas normaliza a resposta do backend de forma
+// fail-closed para apresentação e guards futuros.
+
+export const AGE_VERIFICATION_STATUS_VALUES = [
+  'not_started',
+  'pending',
+  'approved',
+  'rejected',
+  'expired',
+] as const;
+
+export type AgeVerificationStatus =
+  (typeof AGE_VERIFICATION_STATUS_VALUES)[number];
+
+export const IDENTITY_VERIFICATION_STATUS_VALUES = [
+  'not_started',
+  'pending',
+  'needs_action',
+  'approved',
+  'rejected',
+  'expired',
+] as const;
+
+export type IdentityVerificationStatus =
+  (typeof IDENTITY_VERIFICATION_STATUS_VALUES)[number];
+
+export const PAYOUT_ACCOUNT_STATUS_VALUES = [
+  'not_connected',
+  'pending',
+  'active',
+  'restricted',
+  'disabled',
+] as const;
+
+export type PayoutAccountStatus =
+  (typeof PAYOUT_ACCOUNT_STATUS_VALUES)[number];
+
+export const AML_RISK_TIER_VALUES = [
+  'low',
+  'medium',
+  'high',
+  'blocked',
+] as const;
+
+export type AmlRiskTier = (typeof AML_RISK_TIER_VALUES)[number];
+
+export type AdultConsentStatus = 'not_accepted' | 'accepted';
+
+export const PAYOUT_ELIGIBILITY_REASON_VALUES = [
+  'adult_consent_required',
+  'age_verification_required',
+  'identity_verification_required',
+  'payout_account_required',
+  'aml_review_required',
+  'aml_risk_blocked',
+  'account_not_active',
+  'account_locked',
+  'account_interactions_blocked',
+  'compliance_snapshot_unavailable',
+] as const;
+
+export type PayoutEligibilityReason =
+  (typeof PAYOUT_ELIGIBILITY_REASON_VALUES)[number];
+
+export interface PayoutEligibilitySnapshot {
+  eligible: boolean;
+  reasons: PayoutEligibilityReason[];
+}
+
+export interface ComplianceSnapshot {
+  available: boolean;
+  adultConsentStatus: AdultConsentStatus;
+  ageVerificationStatus: AgeVerificationStatus;
+  ageVerifiedAt: number | null;
+  identityVerificationStatus: IdentityVerificationStatus;
+  identityVerificationProvider: string | null;
+  identityVerificationUpdatedAt: number | null;
+  payoutAccountStatus: PayoutAccountStatus;
+  amlRiskTier: AmlRiskTier | null;
+  lastRiskReviewAt: number | null;
+  payoutEligibility: PayoutEligibilitySnapshot;
+  generatedAt: number | null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isAllowedValue<T extends string>(
+  value: unknown,
+  allowedValues: readonly T[]
+): value is T {
+  return typeof value === 'string' && allowedValues.includes(value as T);
+}
+
+function toEpochOrNull(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? Math.trunc(value)
+    : null;
+}
+
+function normalizeProvider(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const provider = value.trim().toLowerCase();
+  return /^[a-z0-9_-]{1,64}$/.test(provider) ? provider : null;
+}
+
+function normalizeReasons(value: unknown): PayoutEligibilityReason[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return Array.from(
+    new Set(
+      value.filter((reason): reason is PayoutEligibilityReason =>
+        isAllowedValue(reason, PAYOUT_ELIGIBILITY_REASON_VALUES)
+      )
+    )
+  );
+}
+
+function deriveFailClosedReasons(
+  snapshot: Omit<ComplianceSnapshot, 'payoutEligibility'>
+): PayoutEligibilityReason[] {
+  if (!snapshot.available) {
+    return ['compliance_snapshot_unavailable'];
+  }
+
+  const reasons: PayoutEligibilityReason[] = [];
+
+  if (snapshot.adultConsentStatus !== 'accepted') {
+    reasons.push('adult_consent_required');
+  }
+
+  if (snapshot.ageVerificationStatus !== 'approved') {
+    reasons.push('age_verification_required');
+  }
+
+  if (snapshot.identityVerificationStatus !== 'approved') {
+    reasons.push('identity_verification_required');
+  }
+
+  if (snapshot.payoutAccountStatus !== 'active') {
+    reasons.push('payout_account_required');
+  }
+
+  if (snapshot.amlRiskTier === 'blocked') {
+    reasons.push('aml_risk_blocked');
+  } else if (snapshot.amlRiskTier !== 'low') {
+    reasons.push('aml_review_required');
+  }
+
+  return reasons;
+}
+
+export function createUnavailableComplianceSnapshot(): ComplianceSnapshot {
+  return {
+    available: false,
+    adultConsentStatus: 'not_accepted',
+    ageVerificationStatus: 'not_started',
+    ageVerifiedAt: null,
+    identityVerificationStatus: 'not_started',
+    identityVerificationProvider: null,
+    identityVerificationUpdatedAt: null,
+    payoutAccountStatus: 'not_connected',
+    amlRiskTier: null,
+    lastRiskReviewAt: null,
+    payoutEligibility: {
+      eligible: false,
+      reasons: ['compliance_snapshot_unavailable'],
+    },
+    generatedAt: null,
+  };
+}
+
+export function normalizeComplianceSnapshot(
+  value: unknown
+): ComplianceSnapshot {
+  if (!isRecord(value)) {
+    return createUnavailableComplianceSnapshot();
+  }
+
+  const available = value['available'] === true;
+  const adultConsentStatus: AdultConsentStatus =
+    value['adultConsentStatus'] === 'accepted'
+      ? 'accepted'
+      : 'not_accepted';
+  const ageVerificationStatus: AgeVerificationStatus = isAllowedValue(
+    value['ageVerificationStatus'],
+    AGE_VERIFICATION_STATUS_VALUES
+  )
+    ? value['ageVerificationStatus']
+    : 'not_started';
+  const identityVerificationStatus: IdentityVerificationStatus =
+    isAllowedValue(
+      value['identityVerificationStatus'],
+      IDENTITY_VERIFICATION_STATUS_VALUES
+    )
+      ? value['identityVerificationStatus']
+      : 'not_started';
+  const payoutAccountStatus: PayoutAccountStatus = isAllowedValue(
+    value['payoutAccountStatus'],
+    PAYOUT_ACCOUNT_STATUS_VALUES
+  )
+    ? value['payoutAccountStatus']
+    : 'not_connected';
+  const amlRiskTier: AmlRiskTier | null = isAllowedValue(
+    value['amlRiskTier'],
+    AML_RISK_TIER_VALUES
+  )
+    ? value['amlRiskTier']
+    : null;
+
+  const baseSnapshot: Omit<ComplianceSnapshot, 'payoutEligibility'> = {
+    available,
+    adultConsentStatus,
+    ageVerificationStatus,
+    ageVerifiedAt: toEpochOrNull(value['ageVerifiedAt']),
+    identityVerificationStatus,
+    identityVerificationProvider: normalizeProvider(
+      value['identityVerificationProvider']
+    ),
+    identityVerificationUpdatedAt: toEpochOrNull(
+      value['identityVerificationUpdatedAt']
+    ),
+    payoutAccountStatus,
+    amlRiskTier,
+    lastRiskReviewAt: toEpochOrNull(value['lastRiskReviewAt']),
+    generatedAt: toEpochOrNull(value['generatedAt']),
+  };
+
+  const eligibilitySource = isRecord(value['payoutEligibility'])
+    ? value['payoutEligibility']
+    : {};
+  const serverReasons = normalizeReasons(eligibilitySource['reasons']);
+  const derivedReasons = deriveFailClosedReasons(baseSnapshot);
+  const reasons = Array.from(new Set([...serverReasons, ...derivedReasons]));
+  const eligible =
+    available &&
+    eligibilitySource['eligible'] === true &&
+    reasons.length === 0;
+
+  return {
+    ...baseSnapshot,
+    payoutEligibility: {
+      eligible,
+      reasons,
+    },
+  };
+}

--- a/src/app/core/services/compliance/compliance-snapshot.service.ts
+++ b/src/app/core/services/compliance/compliance-snapshot.service.ts
@@ -1,0 +1,104 @@
+// src/app/core/services/compliance/compliance-snapshot.service.ts
+// -----------------------------------------------------------------------------
+// COMPLIANCE SNAPSHOT SERVICE
+// -----------------------------------------------------------------------------
+//
+// Serviço Observable-first para a projeção sanitizada devolvida pelo backend.
+// Nenhum documento sensível é lido diretamente do Firestore ou persistido no
+// navegador.
+
+import { Injectable } from '@angular/core';
+import { Functions, httpsCallable } from '@angular/fire/functions';
+import {
+  Observable,
+  Subject,
+  defer,
+  from,
+  of,
+} from 'rxjs';
+import {
+  catchError,
+  distinctUntilChanged,
+  map,
+  shareReplay,
+  startWith,
+  switchMap,
+} from 'rxjs/operators';
+
+import {
+  ComplianceSnapshot,
+  createUnavailableComplianceSnapshot,
+  normalizeComplianceSnapshot,
+} from 'src/app/core/interfaces/compliance/compliance-snapshot.interface';
+import { AuthSessionService } from 'src/app/core/services/autentication/auth/auth-session.service';
+import { GlobalErrorHandlerService } from 'src/app/core/services/error-handler/global-error-handler.service';
+
+@Injectable({ providedIn: 'root' })
+export class ComplianceSnapshotService {
+  private readonly refreshSubject = new Subject<void>();
+  private readonly getSnapshotCallable = httpsCallable<
+    Record<string, never>,
+    unknown
+  >(this.functions, 'getMyComplianceSnapshot');
+
+  readonly currentSnapshot$: Observable<ComplianceSnapshot> =
+    this.session.uid$.pipe(
+      map((uid) => String(uid ?? '').trim()),
+      distinctUntilChanged(),
+      switchMap((uid) => {
+        if (!uid) {
+          return of(createUnavailableComplianceSnapshot());
+        }
+
+        return this.refreshSubject.pipe(
+          startWith(undefined),
+          switchMap(() => this.getMyComplianceSnapshot$())
+        );
+      }),
+      shareReplay({ bufferSize: 1, refCount: true })
+    );
+
+  constructor(
+    private readonly functions: Functions,
+    private readonly session: AuthSessionService,
+    private readonly globalError: GlobalErrorHandlerService
+  ) {}
+
+  /**
+   * Consulta a autoridade backend e normaliza o payload de forma fail-closed.
+   * Falhas retornam snapshot indisponível para que guards e telas nunca liberem
+   * saque por ausência de resposta.
+   */
+  getMyComplianceSnapshot$(): Observable<ComplianceSnapshot> {
+    return defer(() => from(this.getSnapshotCallable({}))).pipe(
+      map((result) => normalizeComplianceSnapshot(result.data)),
+      catchError((error) => {
+        this.reportError(error, 'getMyComplianceSnapshot$');
+        return of(createUnavailableComplianceSnapshot());
+      })
+    );
+  }
+
+  refreshCurrentSnapshot(): void {
+    this.refreshSubject.next();
+  }
+
+  private reportError(error: unknown, operation: string): void {
+    try {
+      const err =
+        error instanceof Error
+          ? error
+          : new Error('[ComplianceSnapshotService] operation failed');
+
+      (err as any).context = 'ComplianceSnapshotService';
+      (err as any).operation = operation;
+      (err as any).original = error;
+      (err as any).silent = true;
+      (err as any).skipUserNotification = true;
+
+      this.globalError.handleError(err);
+    } catch {
+      // noop
+    }
+  }
+}


### PR DESCRIPTION
## Objetivo

Criar o primeiro lote técnico do issue #40 para separar consentimento adulto, verificação de idade, identidade, conta de repasse, risco AML e elegibilidade de saque.

Esta entrega não declara conformidade jurídica, não escolhe PSP e não libera pagamentos ou saques reais.

## Backend

- adiciona contrato canônico de estados de compliance;
- adiciona a callable autenticada `getMyComplianceSnapshot`;
- lê `users/{uid}`, `compliance_profiles/{uid}` e `payout_accounts/{uid}` somente no backend;
- devolve projeção mínima, sem documentos, biometria, CPF, referências secretas, flags de sanções ou payloads de provedor;
- deriva `payoutEligibility` exclusivamente no backend;
- usa política fail-closed: ausência, valor desconhecido ou risco não revisado mantém o usuário inelegível;
- aceita automaticamente somente AML `low`; `medium` e `high` exigem revisão, e `blocked` impede a operação.

## Angular

- adiciona contrato sanitizado de `ComplianceSnapshot`;
- normaliza payloads inválidos sem confiar na decisão recebida;
- adiciona `ComplianceSnapshotService` Observable-first;
- mantém o snapshot somente em memória por `shareReplay` com `refCount`;
- permite atualização explícita por `refreshCurrentSnapshot()`;
- em falha, retorna estado indisponível e inelegível, além de registrar o erro no `GlobalErrorHandlerService`.

## Firestore Rules

Bloqueia leitura e escrita do cliente em:

- `compliance_profiles`;
- `identity_verification_events`;
- `aml_risk_events`;
- `compliance_audit`.

`payout_accounts` já permanece fechado em `billing.rules`.

## Testes

Cinco cenários de normalização cobrem:

- fallback indisponível;
- snapshot válido e elegível;
- payload não-objeto;
- conflito entre elegibilidade e estados sanitizados;
- descarte de estados, provedor e motivos desconhecidos.

## Supressões e limites explícitos

Nenhum código existente foi suprimido nesta entrega.

Não foram adicionados:

- upload ou armazenamento de documentos;
- biometria;
- webhook de provedor;
- criação de conta de repasse;
- criação de saque;
- painel ou tela KYC;
- guard de saque;
- alteração de rules para permitir acesso do cliente.

Esses itens permanecem em lotes posteriores do issue #40.

Part of #40