### PR TITLE
style(login): revisar densidade e acessibilidade dos controles

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -50,7 +50,8 @@
               "src/styles/global-forms.css",
               "src/styles/profile-completion-polish.css",
               "src/styles/global-animations.css",
-              "src/styles.css"
+              "src/styles.css",
+              "src/styles/control-density.css"
             ],
             "scripts": [],
             "browser": "src/main.ts"

--- a/src/app/authentication/login-component/login-component.html
+++ b/src/app/authentication/login-component/login-component.html
@@ -1,30 +1,13 @@
 <!-- src/app/authentication/login-component/login-component.html -->
 <div class="auth-container">
   <section class="auth-intro" aria-labelledby="auth-intro-title">
-    <p class="auth-badge">Pré-lançamento</p>
-
     <h1 id="auth-intro-title">
       Entretenimento com controle, privacidade e segurança.
     </h1>
-
-    <p>
-      Uma experiência social mais clara para cadastro, perfil, preferências,
-      comunicação e moderação.
-    </p>
-
-    <ul class="auth-trust-list" aria-label="Pontos de confiança da plataforma">
-      <li>Perfil e preferências sob seu controle</li>
-      <li>Fluxo de cadastro guiado e seguro</li>
-      <li>Conta preparada para descoberta e moderação</li>
-    </ul>
   </section>
 
   <div class="form-container">
-    <p class="form-kicker">Acesso seguro</p>
     <h2 class="form-header">Entre na sua conta</h2>
-    <p class="form-subtitle">
-      Use e-mail/senha ou continue com Google.
-    </p>
 
     <form
       [formGroup]="loginForm"
@@ -39,41 +22,51 @@
         {{ currentAssistiveStatus }}
       </p>
 
-      <label class="field-label" for="email">E-mail</label>
-      <input
-        formControlName="email"
-        id="email"
-        class="input-field"
-        type="email"
-        name="email"
-        placeholder="seu@email.com"
-        required
-        autocomplete="email"
-        [attr.aria-invalid]="loginForm.controls['email'].touched && loginForm.controls['email'].invalid ? 'true' : 'false'"
-        [attr.aria-describedby]="loginForm.controls['email'].invalid ? 'email-error form-status' : 'form-status'"
-        (focus)="clearError()"
-      />
-      @if (loginForm.controls['email'].touched && loginForm.controls['email'].invalid) {
-        <small id="email-error" class="field-error">Informe um e-mail válido.</small>
-      }
+      <div class="login-field">
+        <label class="field-label" for="email">E-mail</label>
+        <input
+          formControlName="email"
+          id="email"
+          class="input-field control-density-field"
+          type="email"
+          name="email"
+          placeholder="seu@email.com"
+          required
+          autocomplete="email"
+          [attr.aria-invalid]="loginForm.controls['email'].touched && loginForm.controls['email'].invalid ? 'true' : 'false'"
+          aria-describedby="form-status"
+          [attr.aria-errormessage]="loginForm.controls['email'].touched && loginForm.controls['email'].invalid ? 'email-error' : null"
+          (focus)="clearError()"
+        />
+        @if (loginForm.controls['email'].touched && loginForm.controls['email'].invalid) {
+          <small id="email-error" class="field-error" role="alert" aria-live="polite">
+            Informe um e-mail válido.
+          </small>
+        }
+      </div>
 
-      <label class="field-label" for="password">Senha</label>
-      <input
-        formControlName="password"
-        id="password"
-        class="input-field"
-        type="password"
-        name="password"
-        placeholder="Sua senha"
-        required
-        autocomplete="current-password"
-        [attr.aria-invalid]="loginForm.controls['password'].touched && loginForm.controls['password'].invalid ? 'true' : 'false'"
-        [attr.aria-describedby]="loginForm.controls['password'].invalid ? 'password-error form-status' : 'form-status'"
-        (focus)="clearError()"
-      />
-      @if (loginForm.controls['password'].touched && loginForm.controls['password'].invalid) {
-        <small id="password-error" class="field-error">Informe sua senha.</small>
-      }
+      <div class="login-field">
+        <label class="field-label" for="password">Senha</label>
+        <input
+          formControlName="password"
+          id="password"
+          class="input-field control-density-field"
+          type="password"
+          name="password"
+          placeholder="Sua senha"
+          required
+          autocomplete="current-password"
+          [attr.aria-invalid]="loginForm.controls['password'].touched && loginForm.controls['password'].invalid ? 'true' : 'false'"
+          aria-describedby="form-status"
+          [attr.aria-errormessage]="loginForm.controls['password'].touched && loginForm.controls['password'].invalid ? 'password-error' : null"
+          (focus)="clearError()"
+        />
+        @if (loginForm.controls['password'].touched && loginForm.controls['password'].invalid) {
+          <small id="password-error" class="field-error" role="alert" aria-live="polite">
+            Informe sua senha.
+          </small>
+        }
+      </div>
 
       <input
         formControlName="honeypot"
@@ -104,7 +97,7 @@
 
       <div class="button-container">
         <button
-          class="btn btn-primary"
+          class="btn btn-primary control-density-button control-density-button--primary"
           type="submit"
           [disabled]="isLoading || !(hasRequiredFields$ | async)"
           [attr.aria-disabled]="(isLoading || !(hasRequiredFields$ | async)) ? 'true' : 'false'"
@@ -118,7 +111,7 @@
       </div>
 
       <button
-        class="btn-google"
+        class="btn-google control-density-button control-density-button--primary"
         type="button"
         (click)="loginWithGoogle()"
         [disabled]="isLoading"
@@ -127,11 +120,6 @@
         <span class="google-mark" aria-hidden="true">G</span>
         <span>{{ googleButtonLabel }}</span>
       </button>
-
-      <p class="auth-note">
-        Ao continuar, você mantém o fluxo seguro da plataforma. O Google autentica
-        sua identidade; a plataforma continua controlando perfil, preferências e descoberta.
-      </p>
 
       @if (isLoading) {
         <div class="loading-overlay" role="status" aria-live="polite">
@@ -176,7 +164,7 @@
 
         <div class="modal-actions">
           <button
-            class="btn btn-primary"
+            class="btn btn-primary control-density-button control-density-button--primary"
             type="button"
             (click)="resendVerificationEmail()"
             [disabled]="isLoading"
@@ -186,7 +174,7 @@
           </button>
 
           <button
-            class="btn btn-primary"
+            class="btn btn-primary control-density-button control-density-button--primary"
             type="button"
             [routerLink]="['/register/welcome']"
             [queryParams]="{ autocheck: '1' }"
@@ -196,7 +184,7 @@
           </button>
 
           <button
-            class="btn btn-danger"
+            class="btn btn-danger control-density-button control-density-button--primary"
             type="button"
             (click)="logout()"
             [disabled]="isLoading"

--- a/src/styles/control-density.css
+++ b/src/styles/control-density.css
@@ -1,0 +1,174 @@
+/* src/styles/control-density.css
+ *
+ * Fundação opt-in para densidade de controles.
+ *
+ * Decisões:
+ * - 40px em dispositivos com ponteiro preciso;
+ * - 44px em dispositivos de toque, reutilizando o token --tap-target;
+ * - nenhum seletor global genérico para todo <button>;
+ * - controles especiais continuam com a geometria própria;
+ * - a migração das demais telas deve usar as classes utilitárias abaixo.
+ */
+
+:root {
+  --control-height: 40px;
+  --control-height-touch: var(--tap-target, 44px);
+  --control-height-active: var(--control-height);
+  --control-radius: var(--radius-md, 8px);
+  --control-padding-inline: 12px;
+}
+
+@media (pointer: coarse) {
+  :root {
+    --control-height-active: var(--control-height-touch);
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Utilitários opt-in                                                         */
+/* -------------------------------------------------------------------------- */
+.control-density-field {
+  box-sizing: border-box;
+  block-size: var(--control-height-active);
+  min-block-size: var(--control-height-active);
+  padding-block: 0;
+  padding-inline: var(--control-padding-inline);
+  border-radius: var(--control-radius);
+  line-height: 1.2;
+}
+
+.control-density-button {
+  box-sizing: border-box;
+  min-block-size: var(--control-height-active);
+  padding-block: 0;
+  padding-inline: var(--control-padding-inline);
+  border-radius: var(--control-radius);
+  line-height: 1.2;
+  white-space: normal;
+  text-align: center;
+}
+
+.control-density-button--primary {
+  min-block-size: var(--tap-target, 44px);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Login: aplicação explícita dos tokens                                      */
+/* -------------------------------------------------------------------------- */
+app-login-component .input-field.control-density-field {
+  height: var(--control-height-active) !important;
+  min-height: var(--control-height-active) !important;
+  padding-block: 0 !important;
+  padding-inline: var(--control-padding-inline) !important;
+  border-radius: var(--control-radius) !important;
+}
+
+app-login-component .button-container .btn.control-density-button,
+app-login-component .btn-google.control-density-button,
+app-login-component .modal-actions .btn.control-density-button {
+  min-height: var(--tap-target, 44px) !important;
+  padding-block: 0 !important;
+  padding-inline: var(--control-padding-inline) !important;
+  border-radius: var(--control-radius) !important;
+}
+
+app-login-component .login-field {
+  position: relative;
+  display: grid;
+  gap: 0.5rem;
+}
+
+app-login-component .login-field .field-label {
+  min-width: 0;
+  padding-inline-end: min(58%, 240px);
+}
+
+app-login-component .login-field .field-error {
+  position: absolute;
+  inset-block-start: 0;
+  inset-inline-end: 0;
+  z-index: 4;
+  max-inline-size: min(58%, 240px);
+  margin: 0;
+  padding: 3px 7px;
+  border-radius: 6px;
+  background: var(--danger-color, #c62828);
+  box-shadow: 0 4px 12px rgb(0 0 0 / 18%);
+  color: #fff;
+  font-size: 0.72rem;
+  font-weight: 700;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+  pointer-events: none;
+  white-space: normal;
+}
+
+app-login-component .login-field .field-error::after {
+  content: '';
+  position: absolute;
+  inset-inline-end: 10px;
+  inset-block-end: -4px;
+  width: 8px;
+  height: 8px;
+  background: inherit;
+  transform: rotate(45deg);
+}
+
+app-login-component .remember-me,
+app-login-component .forgot-password {
+  min-block-size: var(--tap-target, 44px);
+}
+
+app-login-component .forgot-password {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding-inline: 0.25rem;
+}
+
+/* No mobile, o formulário aparece antes do texto institucional. */
+@media (max-width: 900px) {
+  app-login-component .form-container {
+    order: 1;
+  }
+
+  app-login-component .auth-intro {
+    order: 2;
+  }
+}
+
+/* Mensagens deixam de flutuar em telas estreitas para não cobrir o label. */
+@media (max-width: 520px) {
+  app-login-component .login-field .field-label {
+    padding-inline-end: 0;
+  }
+
+  app-login-component .login-field .field-error {
+    position: static;
+    max-inline-size: 100%;
+    margin-block-start: -0.2rem;
+    box-shadow: none;
+  }
+
+  app-login-component .login-field .field-error::after {
+    display: none;
+  }
+
+  app-login-component .auth-intro h1 {
+    margin-block: 0.35rem;
+    font-size: clamp(1.75rem, 9vw, 2.35rem);
+    line-height: 1.05;
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Alto contraste                                                             */
+/* -------------------------------------------------------------------------- */
+html.high-contrast app-login-component .login-field .field-error {
+  border: 2px solid currentColor;
+  box-shadow: none;
+}
+
+html.high-contrast :is(.control-density-field, .control-density-button) {
+  border-width: 2px;
+}


### PR DESCRIPTION
## Objetivo

Substituir a proposta visual antiga da PR #42 por uma implementação atualizada sobre a `main`, com densidade opt-in, área de toque acessível e validação de formulário semanticamente correta.

## Revisão da padronização

A auditoria encontrou três alturas recorrentes no código existente: 36px, 40px e 44/48px. Este lote não força todos os componentes com seletores genéricos. Em vez disso:

- define 40px para ponteiro preciso;
- reutiliza `--tap-target: 44px` em dispositivos de toque;
- cria utilitários `control-density-field` e `control-density-button` para migração gradual;
- mantém botões primários com mínimo de 44px;
- não aplica regras globais a todo elemento `button`;
- preserva controles especiais, ícones, FABs, navegação de mídia e textareas.

## Login

- remove textos redundantes da proposta anterior;
- mantém título institucional e formulário;
- coloca o formulário antes do título institucional em telas menores;
- torna mensagens de campo estáticas no mobile para evitar sobreposição;
- usa `aria-errormessage`, `role="alert"` e `aria-live="polite"`;
- mantém foco, loading, alto contraste, recuperação de senha e modal de verificação.

## Correções sobre a PR #42

- remove o seletor global amplo para todo `button`;
- troca 40px de toque pelo token existente de 44px;
- evita `role="tooltip"` em mensagens de erro;
- evita `white-space: nowrap` em erros que poderiam escapar da tela;
- carrega a camada opt-in após os estilos existentes;
- não depende de `:has()`, ampliando compatibilidade entre navegadores modernos.

## Supressões explícitas

Foram removidos do HTML do login:

- selo `Pré-lançamento`;
- parágrafo promocional lateral;
- lista de promessas;
- selo `Acesso seguro`;
- subtítulo que repetia os métodos de login;
- nota extensa abaixo do botão Google.

Motivo: reduzir ruído visual e priorizar a ação principal.

Os seletores antigos correspondentes permanecem temporariamente no CSS encapsulado do componente, embora sem elementos correspondentes no HTML. Eles não afetam a renderização e serão removidos somente após a aprovação visual, evitando misturar limpeza extensa com a etapa de conferência.

## Limites

- nenhuma mudança de lógica de autenticação;
- nenhuma dependência alterada;
- nenhuma mudança em KYC/AML, cache, NgRx, Rules ou Functions;
- nenhum merge antes da conferência visual.

Substitui #42.