### PR TITLE
feat(media): aplicar audiência a interações e compartilhamentos

### DIFF
--- a/functions/src/chat/direct-chat/application/send-direct-video-reference.handler.ts
+++ b/functions/src/chat/direct-chat/application/send-direct-video-reference.handler.ts
@@ -4,6 +4,12 @@ import { HttpsError, onCall } from 'firebase-functions/v2/https';
 import { FUNCTIONS_REGION } from '../../../config/functions-region';
 import { db, FieldValue } from '../../../firebaseApp';
 import {
+  createVideoAudienceAccessEvaluator,
+  resolveCanonicalVideoAudienceTarget,
+  type PublicVideoAudienceDocument,
+  type VideoPublicationAudienceDocument,
+} from '../../../media/application/video-audience-access.policy';
+import {
   assertMessagingAccountOperational,
 } from '../../shared/messaging-account.policy';
 import type { MessagingUserDoc } from '../../shared/messaging.types';
@@ -96,6 +102,18 @@ export const sendDirectVideoReference = onCall<SendDirectVideoReferenceRequest>(
 
     const messageId = buildMessageId(chatId, actorUid, clientRequestId);
     const chatRef = db.doc(`chats/${chatId}`);
+    const initialChatSnapshot = await chatRef.get();
+    const initialChat = initialChatSnapshot.exists
+      ? initialChatSnapshot.data() as DirectChatDocumentForSend
+      : undefined;
+    const expectedTargetUid = resolveDirectMessageTargetUid(
+      initialChat,
+      actorUid
+    );
+    const [actorAudience, targetAudience] = await Promise.all([
+      createVideoAudienceAccessEvaluator(actorUid),
+      createVideoAudienceAccessEvaluator(expectedTargetUid),
+    ]);
     const messageRef = chatRef.collection('messages').doc(messageId);
 
     return db.runTransaction(async (transaction) => {
@@ -104,6 +122,13 @@ export const sendDirectVideoReference = onCall<SendDirectVideoReferenceRequest>(
         ? chatSnapshot.data() as DirectChatDocumentForSend
         : undefined;
       const targetUid = resolveDirectMessageTargetUid(chat, actorUid);
+
+      if (targetUid !== expectedTargetUid) {
+        throw new HttpsError(
+          'aborted',
+          'A conversa mudou durante o envio. Tente novamente.'
+        );
+      }
 
       const actorRef = db.doc(`users/${actorUid}`);
       const targetRef = db.doc(`users/${targetUid}`);
@@ -164,6 +189,35 @@ export const sendDirectVideoReference = onCall<SendDirectVideoReferenceRequest>(
         actorFriendSnapshot.exists,
         targetFriendSnapshot.exists
       );
+
+      const publicVideo = publicVideoSnapshot.exists
+        ? publicVideoSnapshot.data() as PublicVideoAudienceDocument
+        : undefined;
+      const publication = publicationSnapshot.exists
+        ? publicationSnapshot.data() as VideoPublicationAudienceDocument
+        : undefined;
+      const audienceTarget = resolveCanonicalVideoAudienceTarget({
+        ownerUid: requestedReference.ownerUid,
+        videoId: requestedReference.videoId,
+        action: 'SHARE',
+        publicVideo,
+        publication,
+      });
+
+      if (!publicProfileSnapshot.exists || !audienceTarget) {
+        throw new HttpsError(
+          'failed-precondition',
+          'Este vídeo não está disponível para compartilhamento.'
+        );
+      }
+
+      /**
+       * Compartilhar uma referência não concede acesso. Remetente e
+       * destinatário precisam possuir audiência válida no instante do envio;
+       * o playback revalida tudo novamente ao abrir a mensagem.
+       */
+      await actorAudience.assertInTransaction(transaction, audienceTarget);
+      await targetAudience.assertInTransaction(transaction, audienceTarget);
 
       const storedReference =
         resolveStoredDirectMessagePublicVideoReference({

--- a/functions/src/chat/direct-chat/domain/direct-message-public-video-reference.policy.test.ts
+++ b/functions/src/chat/direct-chat/domain/direct-message-public-video-reference.policy.test.ts
@@ -8,8 +8,10 @@ import {
 
 const REQUESTED = Object.freeze({ ownerUid: 'owner_1', videoId: 'video_1' });
 const PUBLIC_VIDEO = Object.freeze({
+  id: 'video_1',
   ownerUid: 'owner_1',
   mediaType: 'VIDEO',
+  assetAccess: 'SIGNED_URL',
   visibility: 'PUBLIC',
   moderationStatus: 'APPROVED',
   title: '  Vídeo público  ',
@@ -38,7 +40,7 @@ test('normaliza somente identificadores seguros', () => {
   );
 });
 
-test('gera referência mínima para vídeo público e aprovado', () => {
+test('gera referência mínima para vídeo publicado e aprovado', () => {
   const result = resolveStoredDirectMessagePublicVideoReference({
     requested: REQUESTED,
     publicProfileExists: true,
@@ -56,6 +58,17 @@ test('gera referência mínima para vídeo público e aprovado', () => {
   assert.equal('storagePath' in (result ?? {}), false);
 });
 
+test('preserva audiência FRIENDS para validação central posterior', () => {
+  const result = resolveStoredDirectMessagePublicVideoReference({
+    requested: REQUESTED,
+    publicProfileExists: true,
+    publicVideo: { ...PUBLIC_VIDEO, visibility: 'FRIENDS' },
+    publication: { ...PUBLICATION, visibility: 'FRIENDS' },
+  });
+
+  assert.equal(result?.videoId, 'video_1');
+});
+
 test('rejeita vídeo removido, privado ou sem publicação ativa', () => {
   assert.equal(
     resolveStoredDirectMessagePublicVideoReference({
@@ -71,7 +84,7 @@ test('rejeita vídeo removido, privado ou sem publicação ativa', () => {
       requested: REQUESTED,
       publicProfileExists: true,
       publicVideo: { ...PUBLIC_VIDEO, visibility: 'PRIVATE' },
-      publication: PUBLICATION,
+      publication: { ...PUBLICATION, visibility: 'PRIVATE' },
     }),
     null
   );
@@ -93,6 +106,15 @@ test('rejeita divergência entre a referência e os documentos', () => {
       publicProfileExists: true,
       publicVideo: { ...PUBLIC_VIDEO, ownerUid: 'other' },
       publication: PUBLICATION,
+    }),
+    null
+  );
+  assert.equal(
+    resolveStoredDirectMessagePublicVideoReference({
+      requested: REQUESTED,
+      publicProfileExists: true,
+      publicVideo: PUBLIC_VIDEO,
+      publication: { ...PUBLICATION, visibility: 'FRIENDS' },
     }),
     null
   );

--- a/functions/src/chat/direct-chat/domain/direct-message-public-video-reference.policy.ts
+++ b/functions/src/chat/direct-chat/domain/direct-message-public-video-reference.policy.ts
@@ -1,12 +1,21 @@
 // functions/src/chat/direct-chat/domain/direct-message-public-video-reference.policy.ts
 // -----------------------------------------------------------------------------
-// Referência segura de vídeo público em mensagens diretas.
+// Referência segura de vídeo publicado em mensagens diretas.
 //
 // A mensagem persiste somente identidade e metadado público mínimo. URL
 // assinada, caminho de Storage e tokens de acesso nunca pertencem ao chat.
+// A audiência do remetente e do destinatário é validada separadamente pelo
+// VideoAudiencePolicy antes da criação da mensagem.
 // -----------------------------------------------------------------------------
 
 const SAFE_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+const SHAREABLE_VISIBILITIES = new Set([
+  'PUBLIC',
+  'COMPATIBLE',
+  'FRIENDS',
+  'SUBSCRIBERS',
+  'PREMIUM',
+]);
 
 export interface RequestedPublicVideoReference {
   ownerUid: string;
@@ -14,8 +23,10 @@ export interface RequestedPublicVideoReference {
 }
 
 export interface PublicVideoDocumentForDirectShare {
+  id?: unknown;
   ownerUid?: unknown;
   mediaType?: unknown;
+  assetAccess?: unknown;
   visibility?: unknown;
   moderationStatus?: unknown;
   title?: unknown;
@@ -39,6 +50,10 @@ export interface StoredDirectMessagePublicVideoReference {
 function normalizeId(value: unknown): string {
   const normalized = String(value ?? '').trim();
   return SAFE_ID_PATTERN.test(normalized) ? normalized : '';
+}
+
+function normalizeEnum(value: unknown): string {
+  return String(value ?? '').trim().toUpperCase();
 }
 
 function replaceControlCharacters(value: string): string {
@@ -78,15 +93,6 @@ export function normalizeRequestedPublicVideoReference(
   return ownerUid && videoId ? { ownerUid, videoId } : null;
 }
 
-/**
- * MANUTENÇÃO — RESTRIÇÃO FUTURA POR ASSINATURA/AUDIÊNCIA
- *
- * Hoje a referência direta aceita somente vídeo PUBLIC + APPROVED. Quando
- * FRIENDS, SUBSCRIBERS ou PREMIUM forem ativados, esta decisão deverá receber
- * o UID do destinatário e validar amizade/entitlement vigente. O envio da
- * referência jamais concede acesso: o playback deve revalidar a audiência
- * novamente, inclusive após cancelamento ou mudança do plano.
- */
 export function resolveStoredDirectMessagePublicVideoReference(params: {
   requested: RequestedPublicVideoReference;
   publicProfileExists: boolean;
@@ -99,20 +105,27 @@ export function resolveStoredDirectMessagePublicVideoReference(params: {
     return null;
   }
 
+  const videoId = normalizeId(publicVideo.id);
   const videoOwnerUid = normalizeId(publicVideo.ownerUid);
   const publicationOwnerUid = normalizeId(publication.ownerUid);
   const publicationVideoId = normalizeId(publication.videoId);
+  const projectionVisibility = normalizeEnum(publicVideo.visibility);
+  const publicationVisibility = normalizeEnum(publication.visibility);
+  const projectionModeration = normalizeEnum(publicVideo.moderationStatus);
+  const publicationModeration = normalizeEnum(publication.moderationStatus);
 
   if (
+    videoId !== requested.videoId ||
     videoOwnerUid !== requested.ownerUid ||
     publicationOwnerUid !== requested.ownerUid ||
     publicationVideoId !== requested.videoId ||
-    publicVideo.mediaType !== 'VIDEO' ||
-    publicVideo.visibility !== 'PUBLIC' ||
-    publicVideo.moderationStatus !== 'APPROVED' ||
-    publication.isPublished !== true ||
-    publication.visibility !== 'PUBLIC' ||
-    publication.moderationStatus !== 'APPROVED'
+    normalizeEnum(publicVideo.mediaType) !== 'VIDEO' ||
+    normalizeEnum(publicVideo.assetAccess) !== 'SIGNED_URL' ||
+    !SHAREABLE_VISIBILITIES.has(projectionVisibility) ||
+    projectionVisibility !== publicationVisibility ||
+    projectionModeration !== 'APPROVED' ||
+    projectionModeration !== publicationModeration ||
+    publication.isPublished !== true
   ) {
     return null;
   }

--- a/functions/src/media/application/authorize-public-video-share.handler.ts
+++ b/functions/src/media/application/authorize-public-video-share.handler.ts
@@ -1,0 +1,95 @@
+import { HttpsError, onCall } from 'firebase-functions/v2/https';
+
+import { FUNCTIONS_REGION } from '../../config/functions-region';
+import { db } from '../../firebaseApp';
+import {
+  createVideoAudienceAccessEvaluator,
+  resolveCanonicalVideoAudienceTarget,
+  type PublicVideoAudienceDocument,
+  type VideoPublicationAudienceDocument,
+} from './video-audience-access.policy';
+
+interface AuthorizePublicVideoShareRequest {
+  ownerUid?: unknown;
+  videoId?: unknown;
+}
+
+interface AuthorizePublicVideoShareResponse {
+  ownerUid: string;
+  videoId: string;
+  canonicalPath: string;
+}
+
+function cleanId(value: unknown): string {
+  const normalized = String(value ?? '').trim();
+  return /^[A-Za-z0-9_-]{1,128}$/.test(normalized) ? normalized : '';
+}
+
+export const authorizePublicVideoShare =
+  onCall<AuthorizePublicVideoShareRequest>(
+    { region: FUNCTIONS_REGION },
+    async (request): Promise<AuthorizePublicVideoShareResponse> => {
+      const viewerUid = cleanId(request.auth?.uid);
+      const ownerUid = cleanId(request.data?.ownerUid);
+      const videoId = cleanId(request.data?.videoId);
+
+      if (!viewerUid) {
+        throw new HttpsError('unauthenticated', 'Usuário não autenticado.');
+      }
+
+      if (!ownerUid || !videoId) {
+        throw new HttpsError('invalid-argument', 'Vídeo inválido.');
+      }
+
+      const audience = await createVideoAudienceAccessEvaluator(viewerUid);
+      const publicProfileRef = db.doc(`public_profiles/${ownerUid}`);
+      const publicVideoRef = publicProfileRef
+        .collection('public_videos')
+        .doc(videoId);
+      const publicationRef = db.doc(
+        `users/${ownerUid}/video_publications/${videoId}`
+      );
+      const [publicProfileSnapshot, publicVideoSnapshot, publicationSnapshot] =
+        await Promise.all([
+          publicProfileRef.get(),
+          publicVideoRef.get(),
+          publicationRef.get(),
+        ]);
+
+      if (
+        !publicProfileSnapshot.exists ||
+        !publicVideoSnapshot.exists ||
+        !publicationSnapshot.exists
+      ) {
+        throw new HttpsError(
+          'failed-precondition',
+          'Este vídeo não está disponível para compartilhamento.'
+        );
+      }
+
+      const target = resolveCanonicalVideoAudienceTarget({
+        ownerUid,
+        videoId,
+        action: 'SHARE',
+        publicVideo:
+          publicVideoSnapshot.data() as PublicVideoAudienceDocument,
+        publication:
+          publicationSnapshot.data() as VideoPublicationAudienceDocument,
+      });
+
+      if (!target) {
+        throw new HttpsError(
+          'failed-precondition',
+          'Este vídeo não está disponível para compartilhamento.'
+        );
+      }
+
+      await audience.assert(target);
+
+      return {
+        ownerUid,
+        videoId,
+        canonicalPath: `/media/video/${ownerUid}/${videoId}`,
+      };
+    }
+  );

--- a/functions/src/media/application/create-video-comment-orchestrator.handler.ts
+++ b/functions/src/media/application/create-video-comment-orchestrator.handler.ts
@@ -1,22 +1,16 @@
 import { onCall } from 'firebase-functions/v2/https';
 
-import {
-  assertInteractionAccess,
-} from '../../account_lifecycle/interaction-access.policy';
 import { FUNCTIONS_REGION } from '../../config/functions-region';
 import {
   createVideoComment as createVideoCommentCore,
 } from './manage-video-comment.handler';
 
+/**
+ * Mantém o nome público e o ponto de orquestração existentes.
+ * Lifecycle, idade, bloqueio bilateral e audiência são validados
+ * transacionalmente pelo núcleo antes de criar o comentário.
+ */
 export const createVideoComment = onCall(
   { region: FUNCTIONS_REGION },
-  async (request) => {
-    const authorUid = String(request.auth?.uid ?? '').trim();
-
-    if (authorUid) {
-      await assertInteractionAccess(authorUid);
-    }
-
-    return createVideoCommentCore.run(request as any);
-  }
+  async (request) => createVideoCommentCore.run(request)
 );

--- a/functions/src/media/application/manage-video-comment.handler.ts
+++ b/functions/src/media/application/manage-video-comment.handler.ts
@@ -7,14 +7,17 @@ import {
   normalizeMediaCount,
   type MediaScoreBreakdown,
 } from './media-engagement-score';
+import {
+  createVideoAudienceAccessEvaluator,
+  resolveCanonicalVideoAudienceTarget,
+  type PublicVideoAudienceDocument,
+  type VideoPublicationAudienceDocument,
+} from './video-audience-access.policy';
 
 type VideoCommentStatus = 'VISIBLE' | 'HIDDEN' | 'DELETED';
 type VideoCommentModerationAction = 'HIDE' | 'RESTORE' | 'DELETE';
 
-interface PublicVideoDoc {
-  ownerUid?: string;
-  visibility?: string;
-  moderationStatus?: string;
+interface PublicVideoDoc extends PublicVideoAudienceDocument {
   commentsEnabled?: boolean;
   reactionsCount?: number;
   likesCount?: number;
@@ -100,17 +103,6 @@ function resolveNickname(
 }
 
 function assertVideoAllowsComments(video: PublicVideoDoc): void {
-  if (video.visibility !== 'PUBLIC') {
-    throw new HttpsError('failed-precondition', 'Este vídeo não está público.');
-  }
-
-  if (video.moderationStatus !== 'APPROVED') {
-    throw new HttpsError(
-      'failed-precondition',
-      'Este vídeo ainda não está aprovado para comentários.'
-    );
-  }
-
   if (video.commentsEnabled !== true) {
     throw new HttpsError(
       'failed-precondition',
@@ -140,29 +132,54 @@ export const createVideoComment = onCall<CreateVideoCommentRequest>(
       throw new HttpsError('invalid-argument', 'Comentário vazio.');
     }
 
+    if (authorUid === ownerUid && !parentCommentId) {
+      throw new HttpsError(
+        'failed-precondition',
+        'O autor pode responder comentários, mas não comentar o próprio vídeo.'
+      );
+    }
+
+    const audience = await createVideoAudienceAccessEvaluator(authorUid);
     const videoRef = db.doc(
       `public_profiles/${ownerUid}/public_videos/${videoId}`
+    );
+    const publicationRef = db.doc(
+      `users/${ownerUid}/video_publications/${videoId}`
     );
     const authorProfileRef = db.doc(`public_profiles/${authorUid}`);
     const commentsCollection = videoRef.collection('comments');
     const newCommentRef = commentsCollection.doc();
 
     return db.runTransaction(async (transaction) => {
-      const [videoSnap, authorProfileSnap] = await Promise.all([
+      const [videoSnap, publicationSnap, authorProfileSnap] = await Promise.all([
         transaction.get(videoRef),
+        transaction.get(publicationRef),
         transaction.get(authorProfileRef),
       ]);
 
-      if (!videoSnap.exists) {
+      if (!videoSnap.exists || !publicationSnap.exists) {
         throw new HttpsError('not-found', 'Vídeo público não encontrado.');
       }
 
       const video = videoSnap.data() as PublicVideoDoc;
+      const publication =
+        publicationSnap.data() as VideoPublicationAudienceDocument;
+      const target = resolveCanonicalVideoAudienceTarget({
+        ownerUid,
+        videoId,
+        action: 'INTERACT',
+        publicVideo: video,
+        publication,
+      });
 
-      if (video.ownerUid !== ownerUid) {
-        throw new HttpsError('failed-precondition', 'Vídeo inconsistente.');
+      if (!target) {
+        throw new HttpsError(
+          'failed-precondition',
+          'O vídeo possui dados de publicação inconsistentes.'
+        );
       }
 
+      await audience.assertInTransaction(transaction, target);
       assertVideoAllowsComments(video);
 
       const authorNickname = resolveNickname(

--- a/functions/src/media/application/rate-video.handler.ts
+++ b/functions/src/media/application/rate-video.handler.ts
@@ -1,8 +1,5 @@
 import { HttpsError, onCall } from 'firebase-functions/v2/https';
 
-import {
-  assertInteractionAccessInTransaction,
-} from '../../account_lifecycle/interaction-access.policy';
 import { FUNCTIONS_REGION } from '../../config/functions-region';
 import { db } from '../../firebaseApp';
 import {
@@ -10,6 +7,12 @@ import {
   normalizeMediaCount,
   type MediaScoreBreakdown,
 } from './media-engagement-score';
+import {
+  createVideoAudienceAccessEvaluator,
+  resolveCanonicalVideoAudienceTarget,
+  type PublicVideoAudienceDocument,
+  type VideoPublicationAudienceDocument,
+} from './video-audience-access.policy';
 import {
   buildNextVideoRatingAggregate,
   normalizeVideoRating,
@@ -21,10 +24,7 @@ interface RateVideoRequest {
   rating?: number;
 }
 
-interface PublicVideoDoc {
-  ownerUid?: string;
-  visibility?: string;
-  moderationStatus?: string;
+interface PublicVideoDoc extends PublicVideoAudienceDocument {
   ratingsEnabled?: boolean;
   reactionsCount?: number;
   likesCount?: number;
@@ -45,26 +45,6 @@ interface VideoRatingDoc {
 function cleanId(value: unknown): string {
   const normalized = String(value ?? '').trim();
   return /^[A-Za-z0-9_-]{1,128}$/.test(normalized) ? normalized : '';
-}
-
-function assertRateableVideo(video: PublicVideoDoc): void {
-  if (video.visibility !== 'PUBLIC') {
-    throw new HttpsError('failed-precondition', 'Este vídeo não está público.');
-  }
-
-  if (video.moderationStatus !== 'APPROVED') {
-    throw new HttpsError(
-      'failed-precondition',
-      'Este vídeo ainda não está aprovado para avaliações.'
-    );
-  }
-
-  if (video.ratingsEnabled !== true) {
-    throw new HttpsError(
-      'failed-precondition',
-      'Avaliações desabilitadas neste vídeo.'
-    );
-  }
 }
 
 export const rateVideo = onCall<RateVideoRequest>(
@@ -93,30 +73,52 @@ export const rateVideo = onCall<RateVideoRequest>(
       );
     }
 
+    const audience = await createVideoAudienceAccessEvaluator(viewerUid);
     const videoRef = db.doc(
       `public_profiles/${ownerUid}/public_videos/${videoId}`
+    );
+    const publicationRef = db.doc(
+      `users/${ownerUid}/video_publications/${videoId}`
     );
     const ratingRef = videoRef.collection('ratings').doc(viewerUid);
 
     return db.runTransaction(async (transaction) => {
-      await assertInteractionAccessInTransaction(transaction, viewerUid);
-
-      const [videoSnap, ratingSnap] = await Promise.all([
+      const [videoSnap, publicationSnap, ratingSnap] = await Promise.all([
         transaction.get(videoRef),
+        transaction.get(publicationRef),
         transaction.get(ratingRef),
       ]);
 
-      if (!videoSnap.exists) {
+      if (!videoSnap.exists || !publicationSnap.exists) {
         throw new HttpsError('not-found', 'Vídeo público não encontrado.');
       }
 
       const video = videoSnap.data() as PublicVideoDoc;
+      const publication =
+        publicationSnap.data() as VideoPublicationAudienceDocument;
+      const target = resolveCanonicalVideoAudienceTarget({
+        ownerUid,
+        videoId,
+        action: 'INTERACT',
+        publicVideo: video,
+        publication,
+      });
 
-      if (video.ownerUid !== ownerUid) {
-        throw new HttpsError('failed-precondition', 'Vídeo inconsistente.');
+      if (!target) {
+        throw new HttpsError(
+          'failed-precondition',
+          'O vídeo possui dados de publicação inconsistentes.'
+        );
       }
 
-      assertRateableVideo(video);
+      await audience.assertInTransaction(transaction, target);
+
+      if (video.ratingsEnabled !== true) {
+        throw new HttpsError(
+          'failed-precondition',
+          'Avaliações desabilitadas neste vídeo.'
+        );
+      }
 
       const currentRating = ratingSnap.exists
         ? ratingSnap.data() as VideoRatingDoc

--- a/functions/src/media/application/toggle-video-reaction.handler.ts
+++ b/functions/src/media/application/toggle-video-reaction.handler.ts
@@ -1,8 +1,5 @@
 import { HttpsError, onCall } from 'firebase-functions/v2/https';
 
-import {
-  assertInteractionAccessInTransaction,
-} from '../../account_lifecycle/interaction-access.policy';
 import { FUNCTIONS_REGION } from '../../config/functions-region';
 import { db } from '../../firebaseApp';
 import {
@@ -10,16 +7,19 @@ import {
   normalizeMediaCount,
   type MediaScoreBreakdown,
 } from './media-engagement-score';
+import {
+  createVideoAudienceAccessEvaluator,
+  resolveCanonicalVideoAudienceTarget,
+  type PublicVideoAudienceDocument,
+  type VideoPublicationAudienceDocument,
+} from './video-audience-access.policy';
 
 interface ToggleVideoReactionRequest {
   ownerUid?: string;
   videoId?: string;
 }
 
-interface PublicVideoDoc {
-  ownerUid?: string;
-  visibility?: string;
-  moderationStatus?: string;
+interface PublicVideoDoc extends PublicVideoAudienceDocument {
   reactionsEnabled?: boolean;
   reactionsCount?: number;
   likesCount?: number;
@@ -56,45 +56,57 @@ export const toggleVideoReaction = onCall<ToggleVideoReactionRequest>(
       );
     }
 
+    const audience = await createVideoAudienceAccessEvaluator(viewerUid);
     const videoRef = db.doc(
       `public_profiles/${ownerUid}/public_videos/${videoId}`
+    );
+    const publicationRef = db.doc(
+      `users/${ownerUid}/video_publications/${videoId}`
     );
     const likeRef = videoRef.collection('likes').doc(viewerUid);
 
     return db.runTransaction(async (transaction) => {
-      await assertInteractionAccessInTransaction(transaction, viewerUid);
-
-      const [videoSnap, likeSnap] = await Promise.all([
+      const [videoSnap, publicationSnap, likeSnap] = await Promise.all([
         transaction.get(videoRef),
+        transaction.get(publicationRef),
         transaction.get(likeRef),
       ]);
 
-      if (!videoSnap.exists) {
+      if (!videoSnap.exists || !publicationSnap.exists) {
         throw new HttpsError('not-found', 'Vídeo público não encontrado.');
       }
 
       const video = videoSnap.data() as PublicVideoDoc;
+      const publication =
+        publicationSnap.data() as VideoPublicationAudienceDocument;
+      const target = resolveCanonicalVideoAudienceTarget({
+        ownerUid,
+        videoId,
+        action: 'INTERACT',
+        publicVideo: video,
+        publication,
+      });
 
-      if (video.ownerUid !== ownerUid) {
-        throw new HttpsError('failed-precondition', 'Vídeo inconsistente.');
-      }
-
-      if (video.visibility !== 'PUBLIC') {
-        throw new HttpsError('failed-precondition', 'Este vídeo não está público.');
-      }
-
-      if (video.moderationStatus !== 'APPROVED') {
+      if (!target) {
         throw new HttpsError(
           'failed-precondition',
-          'Este vídeo ainda não está aprovado para curtidas.'
+          'O vídeo possui dados de publicação inconsistentes.'
         );
       }
 
-      if (video.reactionsEnabled !== true) {
-        throw new HttpsError(
-          'failed-precondition',
-          'Curtidas desabilitadas neste vídeo.'
-        );
+      /**
+       * Remover a própria reação é limpeza de dado e permanece disponível
+       * mesmo após revogação de audiência. Criar uma reação exige autorização.
+       */
+      if (!likeSnap.exists) {
+        await audience.assertInTransaction(transaction, target);
+
+        if (video.reactionsEnabled !== true) {
+          throw new HttpsError(
+            'failed-precondition',
+            'Curtidas desabilitadas neste vídeo.'
+          );
+        }
       }
 
       const currentCount = normalizeMediaCount(

--- a/functions/src/media/application/video-audience-access.policy.test.ts
+++ b/functions/src/media/application/video-audience-access.policy.test.ts
@@ -2,7 +2,9 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
 import {
+  assertVideoAudienceAccessDecision,
   evaluateVideoAudienceAccess,
+  resolveCanonicalVideoAudienceTarget,
   type VideoAudienceAccessInput,
 } from './video-audience-access.policy';
 
@@ -144,6 +146,82 @@ describe('video-audience-access.policy', () => {
     assert.deepEqual(
       evaluateVideoAudienceAccess(accessInput({ visibility: 'CUSTOM' })),
       { allowed: false, reason: 'unsupported_visibility' }
+    );
+  });
+
+  it('resolve somente projeção e publicação canônicas', () => {
+    const target = resolveCanonicalVideoAudienceTarget({
+      ownerUid: 'owner-uid',
+      videoId: 'video-uid',
+      action: 'INTERACT',
+      publicVideo: {
+        id: 'video-uid',
+        ownerUid: 'owner-uid',
+        mediaType: 'VIDEO',
+        assetAccess: 'SIGNED_URL',
+        visibility: 'PUBLIC',
+        moderationStatus: 'APPROVED',
+      },
+      publication: {
+        ownerUid: 'owner-uid',
+        videoId: 'video-uid',
+        isPublished: true,
+        visibility: 'PUBLIC',
+        moderationStatus: 'APPROVED',
+      },
+    });
+
+    assert.deepEqual(target, {
+      ownerUid: 'owner-uid',
+      action: 'INTERACT',
+      visibility: 'PUBLIC',
+      isPublished: true,
+      moderationStatus: 'APPROVED',
+    });
+
+    assert.equal(
+      resolveCanonicalVideoAudienceTarget({
+        ownerUid: 'owner-uid',
+        videoId: 'video-uid',
+        action: 'SHARE',
+        publicVideo: {
+          id: 'video-uid',
+          ownerUid: 'owner-uid',
+          mediaType: 'VIDEO',
+          assetAccess: 'SIGNED_URL',
+          visibility: 'PUBLIC',
+          moderationStatus: 'APPROVED',
+        },
+        publication: {
+          ownerUid: 'owner-uid',
+          videoId: 'video-uid',
+          isPublished: true,
+          visibility: 'FRIENDS',
+          moderationStatus: 'APPROVED',
+        },
+      }),
+      null
+    );
+  });
+
+  it('converte negação em erro callable sem expor direção do bloqueio', () => {
+    assert.throws(
+      () => assertVideoAudienceAccessDecision(
+        { allowed: false, reason: 'blocked' },
+        'SHARE'
+      ),
+      (error: unknown) => {
+        const candidate = error as {
+          code?: unknown;
+          message?: unknown;
+          details?: { reason?: unknown };
+        };
+
+        assert.equal(candidate.code, 'permission-denied');
+        assert.match(String(candidate.message), /audiência válida/i);
+        assert.equal(candidate.details?.reason, 'blocked');
+        return true;
+      }
     );
   });
 });

--- a/functions/src/media/application/video-audience-access.policy.ts
+++ b/functions/src/media/application/video-audience-access.policy.ts
@@ -1,3 +1,4 @@
+import type { Transaction } from 'firebase-admin/firestore';
 import { HttpsError } from 'firebase-functions/v2/https';
 
 import {
@@ -57,10 +58,32 @@ export interface VideoAudienceAccessTarget {
   moderationStatus: unknown;
 }
 
+export interface PublicVideoAudienceDocument {
+  id?: unknown;
+  ownerUid?: unknown;
+  mediaType?: unknown;
+  assetAccess?: unknown;
+  visibility?: unknown;
+  moderationStatus?: unknown;
+}
+
+export interface VideoPublicationAudienceDocument {
+  ownerUid?: unknown;
+  videoId?: unknown;
+  isPublished?: unknown;
+  visibility?: unknown;
+  moderationStatus?: unknown;
+}
+
 export interface VideoAudienceAccessEvaluator {
   evaluate(
     target: VideoAudienceAccessTarget
   ): Promise<VideoAudienceAccessDecision>;
+  assert(target: VideoAudienceAccessTarget): Promise<void>;
+  assertInTransaction(
+    transaction: Transaction,
+    target: VideoAudienceAccessTarget
+  ): Promise<void>;
 }
 
 interface BlockContext {
@@ -112,8 +135,12 @@ function cleanId(value: unknown): string {
   return normalized;
 }
 
+function normalizeEnum(value: unknown): string {
+  return String(value ?? '').trim().toUpperCase();
+}
+
 function normalizeVisibility(value: unknown): VideoAudienceVisibility | null {
-  const normalized = String(value ?? '').trim().toUpperCase();
+  const normalized = normalizeEnum(value);
 
   return SUPPORTED_VISIBILITIES.has(normalized as VideoAudienceVisibility)
     ? normalized as VideoAudienceVisibility
@@ -121,11 +148,123 @@ function normalizeVisibility(value: unknown): VideoAudienceVisibility | null {
 }
 
 function isApproved(value: unknown): boolean {
-  return String(value ?? '').trim().toUpperCase() === 'APPROVED';
+  return normalizeEnum(value) === 'APPROVED';
 }
 
 function denied(reason: VideoAudienceAccessReason): VideoAudienceAccessDecision {
   return { allowed: false, reason };
+}
+
+function actionLabel(action: VideoAudienceAction): string {
+  switch (action) {
+  case 'LIST':
+    return 'listar';
+  case 'PLAY':
+    return 'reproduzir';
+  case 'INTERACT':
+    return 'interagir com';
+  case 'SHARE':
+    return 'compartilhar';
+  default:
+    return 'acessar';
+  }
+}
+
+export function assertVideoAudienceAccessDecision(
+  decision: VideoAudienceAccessDecision,
+  action: VideoAudienceAction
+): void {
+  if (decision.allowed) {
+    return;
+  }
+
+  const reason = decision.reason ?? 'unsupported_visibility';
+  const details = { action, reason };
+
+  if (reason === 'invalid_target') {
+    throw new HttpsError(
+      'invalid-argument',
+      'A referência do vídeo é inválida.',
+      details
+    );
+  }
+
+  if (reason === 'viewer_restricted') {
+    throw new HttpsError(
+      'failed-precondition',
+      `Sua conta não pode ${actionLabel(action)} este vídeo no momento.`,
+      details
+    );
+  }
+
+  if (
+    reason === 'blocked' ||
+    reason === 'compatibility_required' ||
+    reason === 'friendship_required' ||
+    reason === 'subscriber_entitlement_required' ||
+    reason === 'premium_entitlement_required'
+  ) {
+    throw new HttpsError(
+      'permission-denied',
+      `Você não possui audiência válida para ${actionLabel(action)} este vídeo.`,
+      details
+    );
+  }
+
+  throw new HttpsError(
+    'failed-precondition',
+    `Este vídeo não está disponível para ${actionLabel(action)}.`,
+    details
+  );
+}
+
+export function resolveCanonicalVideoAudienceTarget(params: {
+  ownerUid: unknown;
+  videoId: unknown;
+  action: VideoAudienceAction;
+  publicVideo: PublicVideoAudienceDocument | null | undefined;
+  publication: VideoPublicationAudienceDocument | null | undefined;
+}): VideoAudienceAccessTarget | null {
+  const ownerUid = cleanId(params.ownerUid);
+  const videoId = cleanId(params.videoId);
+  const publicVideo = params.publicVideo;
+  const publication = params.publication;
+
+  if (!ownerUid || !videoId || !publicVideo || !publication) {
+    return null;
+  }
+
+  const projectionId = cleanId(publicVideo.id);
+  const projectionOwnerUid = cleanId(publicVideo.ownerUid);
+  const publicationOwnerUid = cleanId(publication.ownerUid);
+  const publicationVideoId = cleanId(publication.videoId);
+  const projectionVisibility = normalizeVisibility(publicVideo.visibility);
+  const publicationVisibility = normalizeVisibility(publication.visibility);
+  const projectionModeration = normalizeEnum(publicVideo.moderationStatus);
+  const publicationModeration = normalizeEnum(publication.moderationStatus);
+
+  if (
+    projectionId !== videoId ||
+    projectionOwnerUid !== ownerUid ||
+    publicationOwnerUid !== ownerUid ||
+    publicationVideoId !== videoId ||
+    normalizeEnum(publicVideo.mediaType) !== 'VIDEO' ||
+    normalizeEnum(publicVideo.assetAccess) !== 'SIGNED_URL' ||
+    !projectionVisibility ||
+    projectionVisibility !== publicationVisibility ||
+    !projectionModeration ||
+    projectionModeration !== publicationModeration
+  ) {
+    return null;
+  }
+
+  return {
+    ownerUid,
+    action: params.action,
+    visibility: publicationVisibility,
+    isPublished: publication.isPublished === true,
+    moderationStatus: publicationModeration,
+  };
 }
 
 export function evaluateVideoAudienceAccess(
@@ -238,6 +377,22 @@ async function readBlockContext(
   };
 }
 
+async function readBlockContextInTransaction(
+  transaction: Transaction,
+  viewerUid: string,
+  ownerUid: string
+): Promise<BlockContext> {
+  const [viewerBlock, ownerBlock] = await Promise.all([
+    transaction.get(db.doc(`users/${viewerUid}/blocks/${ownerUid}`)),
+    transaction.get(db.doc(`users/${ownerUid}/blocks/${viewerUid}`)),
+  ]);
+
+  return {
+    viewerBlockedOwner: isActiveBlock(viewerBlock),
+    ownerBlockedViewer: isActiveBlock(ownerBlock),
+  };
+}
+
 async function readFriendshipContext(
   viewerUid: string,
   ownerUid: string
@@ -245,6 +400,23 @@ async function readFriendshipContext(
   const [viewerFriend, ownerFriend] = await Promise.all([
     db.doc(`users/${viewerUid}/friends/${ownerUid}`).get(),
     db.doc(`users/${ownerUid}/friends/${viewerUid}`).get(),
+  ]);
+
+  return {
+    bilateralFriendship:
+      isValidFriendEdge(viewerFriend, ownerUid) &&
+      isValidFriendEdge(ownerFriend, viewerUid),
+  };
+}
+
+async function readFriendshipContextInTransaction(
+  transaction: Transaction,
+  viewerUid: string,
+  ownerUid: string
+): Promise<FriendshipContext> {
+  const [viewerFriend, ownerFriend] = await Promise.all([
+    transaction.get(db.doc(`users/${viewerUid}/friends/${ownerUid}`)),
+    transaction.get(db.doc(`users/${ownerUid}/friends/${viewerUid}`)),
   ]);
 
   return {
@@ -276,11 +448,66 @@ function assertViewerAccountAvailable(
   assertInteractionAccessData(viewer);
 }
 
+function buildAccessInput(
+  viewerUid: string,
+  target: VideoAudienceAccessTarget,
+  blocks: BlockContext,
+  bilateralFriendship: boolean
+): VideoAudienceAccessInput {
+  return {
+    viewerUid,
+    ownerUid: target.ownerUid,
+    action: target.action,
+    visibility: target.visibility,
+    isPublished: target.isPublished,
+    moderationStatus: target.moderationStatus,
+    viewerLifecycleAllowed: true,
+    ...blocks,
+    bilateralFriendship,
+
+    /**
+     * COMPATIBLE depende de projeção backend canônica. O cálculo Angular
+     * nunca autoriza mídia por link direto.
+     */
+    mutuallyCompatible: false,
+
+    /**
+     * SUBSCRIBERS/PREMIUM dependem de entitlement bilateral do criador,
+     * com vigência, cancelamento, chargeback e status KYC/AML. A assinatura
+     * da plataforma não concede acesso ao conteúdo de um criador.
+     */
+    hasCreatorSubscriberEntitlement: false,
+    hasCreatorPremiumEntitlement: false,
+  };
+}
+
+function ownerAccessInput(
+  viewerUid: string,
+  target: VideoAudienceAccessTarget
+): VideoAudienceAccessInput {
+  return {
+    viewerUid,
+    ownerUid: target.ownerUid,
+    action: target.action,
+    visibility: target.visibility,
+    isPublished: target.isPublished,
+    moderationStatus: target.moderationStatus,
+    viewerLifecycleAllowed: true,
+    viewerBlockedOwner: false,
+    ownerBlockedViewer: false,
+    bilateralFriendship: true,
+    mutuallyCompatible: true,
+    hasCreatorSubscriberEntitlement: true,
+    hasCreatorPremiumEntitlement: true,
+  };
+}
+
 /**
  * Cria uma sessão de autorização por requisição.
  *
  * - valida Auth, lifecycle e idade uma única vez;
  * - mantém caches separados de bloqueios e amizades por proprietário;
+ * - oferece assert transacional para impedir TOCTOU em interações e envios;
  * - vídeos públicos fazem apenas as duas leituras bilaterais de bloqueio;
  * - amizade só é consultada quando a audiência realmente é FRIENDS;
  * - audiências sem fonte autorizativa no backend permanecem negadas.
@@ -311,101 +538,136 @@ export async function createVideoAudienceAccessEvaluator(
   const blockCache = new Map<string, Promise<BlockContext>>();
   const friendshipCache = new Map<string, Promise<FriendshipContext>>();
 
+  const evaluate = async (
+    target: VideoAudienceAccessTarget
+  ): Promise<VideoAudienceAccessDecision> => {
+    const ownerUid = cleanId(target.ownerUid);
+
+    if (!ownerUid) {
+      return denied('invalid_target');
+    }
+
+    if (viewerUid === ownerUid) {
+      return evaluateVideoAudienceAccess(ownerAccessInput(viewerUid, target));
+    }
+
+    let blockPromise = blockCache.get(ownerUid);
+
+    if (!blockPromise) {
+      blockPromise = readBlockContext(viewerUid, ownerUid);
+      blockCache.set(ownerUid, blockPromise);
+    }
+
+    const blocks = await blockPromise;
+    const visibility = normalizeVisibility(target.visibility);
+    let bilateralFriendship = false;
+
+    if (
+      !blocks.viewerBlockedOwner &&
+      !blocks.ownerBlockedViewer &&
+      visibility === 'FRIENDS'
+    ) {
+      let friendshipPromise = friendshipCache.get(ownerUid);
+
+      if (!friendshipPromise) {
+        friendshipPromise = readFriendshipContext(viewerUid, ownerUid);
+        friendshipCache.set(ownerUid, friendshipPromise);
+      }
+
+      bilateralFriendship = (
+        await friendshipPromise
+      ).bilateralFriendship;
+    }
+
+    return evaluateVideoAudienceAccess(buildAccessInput(
+      viewerUid,
+      { ...target, ownerUid },
+      blocks,
+      bilateralFriendship
+    ));
+  };
+
   return {
-    evaluate: async (
+    evaluate,
+    assert: async (target: VideoAudienceAccessTarget): Promise<void> => {
+      assertVideoAudienceAccessDecision(
+        await evaluate(target),
+        target.action
+      );
+    },
+    assertInTransaction: async (
+      transaction: Transaction,
       target: VideoAudienceAccessTarget
-    ): Promise<VideoAudienceAccessDecision> => {
+    ): Promise<void> => {
       const ownerUid = cleanId(target.ownerUid);
 
       if (!ownerUid) {
-        return denied('invalid_target');
+        assertVideoAudienceAccessDecision(
+          denied('invalid_target'),
+          target.action
+        );
+        return;
       }
+
+      const viewerSnapshot = await transaction.get(
+        db.doc(`users/${viewerUid}`)
+      );
+      const transactionalViewer = viewerSnapshot.exists
+        ? viewerSnapshot.data() as ViewerAccountDocument
+        : null;
+
+      if (!transactionalViewer) {
+        throw new HttpsError('not-found', 'Conta não encontrada.');
+      }
+
+      assertViewerAccountAvailable(
+        transactionalViewer,
+        viewerUid,
+        authUser.disabled
+      );
 
       if (viewerUid === ownerUid) {
-        return evaluateVideoAudienceAccess({
-          viewerUid,
-          ownerUid,
-          action: target.action,
-          visibility: target.visibility,
-          isPublished: target.isPublished,
-          moderationStatus: target.moderationStatus,
-          viewerLifecycleAllowed: true,
-          viewerBlockedOwner: false,
-          ownerBlockedViewer: false,
-          bilateralFriendship: true,
-          mutuallyCompatible: true,
-          hasCreatorSubscriberEntitlement: true,
-          hasCreatorPremiumEntitlement: true,
-        });
+        assertVideoAudienceAccessDecision(
+          evaluateVideoAudienceAccess(ownerAccessInput(
+            viewerUid,
+            { ...target, ownerUid }
+          )),
+          target.action
+        );
+        return;
       }
 
-      let blockPromise = blockCache.get(ownerUid);
-
-      if (!blockPromise) {
-        blockPromise = readBlockContext(viewerUid, ownerUid);
-        blockCache.set(ownerUid, blockPromise);
-      }
-
-      const blocks = await blockPromise;
+      const blocks = await readBlockContextInTransaction(
+        transaction,
+        viewerUid,
+        ownerUid
+      );
       const visibility = normalizeVisibility(target.visibility);
-
-      if (blocks.viewerBlockedOwner || blocks.ownerBlockedViewer) {
-        return evaluateVideoAudienceAccess({
-          viewerUid,
-          ownerUid,
-          action: target.action,
-          visibility: target.visibility,
-          isPublished: target.isPublished,
-          moderationStatus: target.moderationStatus,
-          viewerLifecycleAllowed: true,
-          ...blocks,
-          bilateralFriendship: false,
-          mutuallyCompatible: false,
-          hasCreatorSubscriberEntitlement: false,
-          hasCreatorPremiumEntitlement: false,
-        });
-      }
-
       let bilateralFriendship = false;
 
-      if (visibility === 'FRIENDS') {
-        let friendshipPromise = friendshipCache.get(ownerUid);
-
-        if (!friendshipPromise) {
-          friendshipPromise = readFriendshipContext(viewerUid, ownerUid);
-          friendshipCache.set(ownerUid, friendshipPromise);
-        }
-
+      if (
+        !blocks.viewerBlockedOwner &&
+        !blocks.ownerBlockedViewer &&
+        visibility === 'FRIENDS'
+      ) {
         bilateralFriendship = (
-          await friendshipPromise
+          await readFriendshipContextInTransaction(
+            transaction,
+            viewerUid,
+            ownerUid
+          )
         ).bilateralFriendship;
       }
 
-      return evaluateVideoAudienceAccess({
-        viewerUid,
-        ownerUid,
-        action: target.action,
-        visibility: target.visibility,
-        isPublished: target.isPublished,
-        moderationStatus: target.moderationStatus,
-        viewerLifecycleAllowed: true,
-        ...blocks,
-        bilateralFriendship,
-
-        /**
-         * COMPATIBLE depende de projeção backend canônica. O cálculo Angular
-         * nunca autoriza mídia por link direto.
-         */
-        mutuallyCompatible: false,
-
-        /**
-         * SUBSCRIBERS/PREMIUM dependem de entitlement bilateral do criador,
-         * com vigência, cancelamento, chargeback e status KYC/AML. A assinatura
-         * da plataforma não concede acesso ao conteúdo de um criador.
-         */
-        hasCreatorSubscriberEntitlement: false,
-        hasCreatorPremiumEntitlement: false,
-      });
+      assertVideoAudienceAccessDecision(
+        evaluateVideoAudienceAccess(buildAccessInput(
+          viewerUid,
+          { ...target, ownerUid },
+          blocks,
+          bilateralFriendship
+        )),
+        target.action
+      );
     },
   };
 }

--- a/functions/src/media/index.ts
+++ b/functions/src/media/index.ts
@@ -119,6 +119,9 @@ export {
 export {
   listAuthorizedPublicVideos,
 } from './application/list-authorized-public-videos.handler';
+export {
+  authorizePublicVideoShare,
+} from './application/authorize-public-video-share.handler';
 
 export {
   recordPhotoView,

--- a/src/app/core/services/media/public-video-share-authorization.service.ts
+++ b/src/app/core/services/media/public-video-share-authorization.service.ts
@@ -1,0 +1,93 @@
+import { Injectable, inject } from '@angular/core';
+import { Functions, httpsCallable } from '@angular/fire/functions';
+import { Observable, defer, of, throwError } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+
+import { GlobalErrorHandlerService } from 'src/app/core/services/error-handler/global-error-handler.service';
+
+interface AuthorizePublicVideoShareRequest {
+  ownerUid: string;
+  videoId: string;
+}
+
+interface AuthorizePublicVideoShareResponse {
+  ownerUid: string;
+  videoId: string;
+  canonicalPath: string;
+}
+
+interface ContextualError extends Error {
+  original?: unknown;
+  context?: Record<string, unknown>;
+  skipUserNotification?: boolean;
+}
+
+const SAFE_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+
+function normalizeId(value: unknown): string {
+  const normalized = String(value ?? '').trim();
+  return SAFE_ID_PATTERN.test(normalized) ? normalized : '';
+}
+
+@Injectable({ providedIn: 'root' })
+export class PublicVideoShareAuthorizationService {
+  private readonly functions = inject(Functions);
+  private readonly errorHandler = inject(GlobalErrorHandlerService);
+
+  authorizeShare$(
+    ownerUidValue: unknown,
+    videoIdValue: unknown
+  ): Observable<string | null> {
+    const ownerUid = normalizeId(ownerUidValue);
+    const videoId = normalizeId(videoIdValue);
+
+    if (!ownerUid || !videoId) {
+      return of(null);
+    }
+
+    const expectedPath = `/media/video/${ownerUid}/${videoId}`;
+
+    return defer(async () => {
+      const callable = httpsCallable<
+        AuthorizePublicVideoShareRequest,
+        AuthorizePublicVideoShareResponse
+      >(this.functions, 'authorizePublicVideoShare');
+      const response = await callable({ ownerUid, videoId });
+      return response.data;
+    }).pipe(
+      map((response) =>
+        response?.ownerUid === ownerUid &&
+        response?.videoId === videoId &&
+        response?.canonicalPath === expectedPath
+          ? expectedPath
+          : null
+      ),
+      catchError((error: unknown) => {
+        this.reportError(error, { ownerUid, videoId });
+        return throwError(() => error);
+      })
+    );
+  }
+
+  private reportError(
+    error: unknown,
+    context: Record<string, unknown>
+  ): void {
+    try {
+      const normalizedError: ContextualError = error instanceof Error
+        ? error
+        : new Error('Erro ao autorizar compartilhamento de vídeo.');
+
+      normalizedError.original = error;
+      normalizedError.context = {
+        scope: 'PublicVideoShareAuthorizationService',
+        op: 'authorizeShare$',
+        ...context,
+      };
+      normalizedError.skipUserNotification = true;
+      this.errorHandler.handleError(normalizedError);
+    } catch {
+      // noop
+    }
+  }
+}

--- a/src/app/core/services/media/public-video-share.service.spec.ts
+++ b/src/app/core/services/media/public-video-share.service.spec.ts
@@ -1,8 +1,10 @@
 import { TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ErrorNotificationService } from 'src/app/core/services/error-handler/error-notification.service';
 import { GlobalErrorHandlerService } from 'src/app/core/services/error-handler/global-error-handler.service';
+import { PublicVideoShareAuthorizationService } from './public-video-share-authorization.service';
 import {
   PublicVideoShareService,
   buildPublicVideoCanonicalPath,
@@ -16,6 +18,9 @@ describe('PublicVideoShareService', () => {
     showError: ReturnType<typeof vi.fn>;
   };
   let globalErrorHandler: { handleError: ReturnType<typeof vi.fn> };
+  let shareAuthorization: {
+    authorizeShare$: ReturnType<typeof vi.fn>;
+  };
   const originalShare = Object.getOwnPropertyDescriptor(navigator, 'share');
   const originalCanShare = Object.getOwnPropertyDescriptor(
     navigator,
@@ -33,6 +38,9 @@ describe('PublicVideoShareService', () => {
       showError: vi.fn(),
     };
     globalErrorHandler = { handleError: vi.fn() };
+    shareAuthorization = {
+      authorizeShare$: vi.fn(() => of('/media/video/owner_1/video-1')),
+    };
 
     TestBed.configureTestingModule({
       providers: [
@@ -43,6 +51,10 @@ describe('PublicVideoShareService', () => {
         {
           provide: GlobalErrorHandlerService,
           useValue: globalErrorHandler,
+        },
+        {
+          provide: PublicVideoShareAuthorizationService,
+          useValue: shareAuthorization,
         },
       ],
     });
@@ -64,7 +76,7 @@ describe('PublicVideoShareService', () => {
     expect(buildPublicVideoCanonicalPath('../owner', 'video-1')).toBeNull();
   });
 
-  it('usa o compartilhamento nativo quando o navegador permite', async () => {
+  it('usa o compartilhamento nativo após autorização backend', async () => {
     const nativeShare = vi.fn().mockResolvedValue(undefined);
     setNavigatorProperty('share', nativeShare);
     setNavigatorProperty('canShare', vi.fn(() => true));
@@ -75,6 +87,10 @@ describe('PublicVideoShareService', () => {
     });
 
     expect(outcome).toBe('shared');
+    expect(shareAuthorization.authorizeShare$).toHaveBeenCalledWith(
+      'owner_1',
+      'video-1'
+    );
     expect(nativeShare).toHaveBeenCalledWith(
       expect.objectContaining({
         url: `${document.location.origin}/media/video/owner_1/video-1`,
@@ -102,6 +118,42 @@ describe('PublicVideoShareService', () => {
     );
     expect(errorNotification.showSuccess).toHaveBeenCalledWith(
       'Link do vídeo copiado.'
+    );
+  });
+
+  it('não expõe o link quando o backend nega a audiência', async () => {
+    shareAuthorization.authorizeShare$.mockReturnValue(of(null));
+    const nativeShare = vi.fn().mockResolvedValue(undefined);
+    setNavigatorProperty('share', nativeShare);
+
+    const outcome = await service.sharePublicVideo({
+      ownerUid: 'owner_1',
+      id: 'video-1',
+    });
+
+    expect(outcome).toBe('failed');
+    expect(nativeShare).not.toHaveBeenCalled();
+    expect(errorNotification.showWarning).toHaveBeenCalledWith(
+      'Este vídeo não está disponível para compartilhamento.'
+    );
+  });
+
+  it('informa falha de autorização sem tentar compartilhar', async () => {
+    shareAuthorization.authorizeShare$.mockReturnValue(
+      throwError(() => new Error('permission-denied'))
+    );
+    const nativeShare = vi.fn().mockResolvedValue(undefined);
+    setNavigatorProperty('share', nativeShare);
+
+    const outcome = await service.sharePublicVideo({
+      ownerUid: 'owner_1',
+      id: 'video-1',
+    });
+
+    expect(outcome).toBe('failed');
+    expect(nativeShare).not.toHaveBeenCalled();
+    expect(errorNotification.showError).toHaveBeenCalledWith(
+      'Não foi possível autorizar o compartilhamento deste vídeo.'
     );
   });
 

--- a/src/app/core/services/media/public-video-share.service.spec.ts
+++ b/src/app/core/services/media/public-video-share.service.spec.ts
@@ -10,6 +10,15 @@ import {
   buildPublicVideoCanonicalPath,
 } from './public-video-share.service';
 
+const CANONICAL_PATH = '/media/video/owner_1/video-1';
+
+function expectedCanonicalUrl(): string {
+  const origin = String(document.location?.origin ?? '').trim();
+  return origin && origin !== 'null'
+    ? `${origin}${CANONICAL_PATH}`
+    : CANONICAL_PATH;
+}
+
 describe('PublicVideoShareService', () => {
   let service: PublicVideoShareService;
   let errorNotification: {
@@ -39,7 +48,7 @@ describe('PublicVideoShareService', () => {
     };
     globalErrorHandler = { handleError: vi.fn() };
     shareAuthorization = {
-      authorizeShare$: vi.fn(() => of('/media/video/owner_1/video-1')),
+      authorizeShare$: vi.fn(() => of(CANONICAL_PATH)),
     };
 
     TestBed.configureTestingModule({
@@ -71,7 +80,7 @@ describe('PublicVideoShareService', () => {
 
   it('monta endereço canônico sem incluir URL temporária do Storage', () => {
     expect(buildPublicVideoCanonicalPath('owner_1', 'video-1')).toBe(
-      '/media/video/owner_1/video-1'
+      CANONICAL_PATH
     );
     expect(buildPublicVideoCanonicalPath('../owner', 'video-1')).toBeNull();
   });
@@ -93,7 +102,7 @@ describe('PublicVideoShareService', () => {
     );
     expect(nativeShare).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: `${document.location.origin}/media/video/owner_1/video-1`,
+        url: expectedCanonicalUrl(),
       })
     );
     expect(errorNotification.showSuccess).toHaveBeenCalledWith(
@@ -113,9 +122,7 @@ describe('PublicVideoShareService', () => {
     });
 
     expect(outcome).toBe('copied');
-    expect(writeText).toHaveBeenCalledWith(
-      `${document.location.origin}/media/video/owner_1/video-1`
-    );
+    expect(writeText).toHaveBeenCalledWith(expectedCanonicalUrl());
     expect(errorNotification.showSuccess).toHaveBeenCalledWith(
       'Link do vídeo copiado.'
     );

--- a/src/app/core/services/media/public-video-share.service.ts
+++ b/src/app/core/services/media/public-video-share.service.ts
@@ -1,15 +1,23 @@
 import { DOCUMENT, isPlatformBrowser } from '@angular/common';
 import { Injectable, PLATFORM_ID, inject } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
 
 import { IPublicVideoItem } from 'src/app/core/interfaces/media/i-public-video-item';
 import { ErrorNotificationService } from 'src/app/core/services/error-handler/error-notification.service';
 import { GlobalErrorHandlerService } from 'src/app/core/services/error-handler/global-error-handler.service';
+import { PublicVideoShareAuthorizationService } from './public-video-share-authorization.service';
 
 export type PublicVideoShareOutcome =
   | 'shared'
   | 'copied'
   | 'cancelled'
   | 'failed';
+
+interface ContextualError extends Error {
+  original?: unknown;
+  context?: Record<string, unknown>;
+  skipUserNotification?: boolean;
+}
 
 const SAFE_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
 
@@ -36,18 +44,44 @@ export class PublicVideoShareService {
   private readonly platformId = inject(PLATFORM_ID);
   private readonly errorNotification = inject(ErrorNotificationService);
   private readonly globalErrorHandler = inject(GlobalErrorHandlerService);
+  private readonly shareAuthorization = inject(
+    PublicVideoShareAuthorizationService
+  );
 
   async sharePublicVideo(
     video: Pick<IPublicVideoItem, 'id' | 'ownerUid'>
   ): Promise<PublicVideoShareOutcome> {
-    const canonicalPath = buildPublicVideoCanonicalPath(
+    const localCanonicalPath = buildPublicVideoCanonicalPath(
       video?.ownerUid,
       video?.id
     );
 
-    if (!canonicalPath || !isPlatformBrowser(this.platformId)) {
+    if (!localCanonicalPath || !isPlatformBrowser(this.platformId)) {
       this.errorNotification.showWarning(
         'Este vídeo não possui um link compartilhável.'
+      );
+      return 'failed';
+    }
+
+    let canonicalPath: string | null = null;
+
+    try {
+      canonicalPath = await firstValueFrom(
+        this.shareAuthorization.authorizeShare$(
+          video.ownerUid,
+          video.id
+        )
+      );
+    } catch {
+      this.errorNotification.showError(
+        'Não foi possível autorizar o compartilhamento deste vídeo.'
+      );
+      return 'failed';
+    }
+
+    if (canonicalPath !== localCanonicalPath) {
+      this.errorNotification.showWarning(
+        'Este vídeo não está disponível para compartilhamento.'
       );
       return 'failed';
     }
@@ -155,17 +189,16 @@ export class PublicVideoShareService {
 
   private reportError(error: unknown): void {
     try {
-      const normalized = error instanceof Error
+      const normalized: ContextualError = error instanceof Error
         ? new Error(error.message)
         : new Error('Falha ao compartilhar vídeo público.');
 
-      (normalized as any).original = error;
-      (normalized as any).context = {
+      normalized.original = error;
+      normalized.context = {
         scope: 'PublicVideoShareService',
         op: 'sharePublicVideo',
       };
-      (normalized as any).skipUserNotification = true;
-
+      normalized.skipUserNotification = true;
       this.globalErrorHandler.handleError(normalized);
     } catch {
       // noop

--- a/src/app/media/videos/public-video-viewer/public-video-viewer.component.spec.ts
+++ b/src/app/media/videos/public-video-viewer/public-video-viewer.component.spec.ts
@@ -18,6 +18,7 @@ import { MediaReactionsService } from 'src/app/core/services/media/media-reactio
 import { MediaVideoCommentsService } from 'src/app/core/services/media/media-video-comments.service';
 import { MediaVideoRatingsService } from 'src/app/core/services/media/media-video-ratings.service';
 import { PublicVideoAccessService } from 'src/app/core/services/media/public-video-access.service';
+import { PublicVideoShareService } from 'src/app/core/services/media/public-video-share.service';
 import { VideoViewTrackingService } from 'src/app/core/services/media/video-view-tracking.service';
 import {
   IPublicVideoViewerData,
@@ -133,6 +134,9 @@ describe('PublicVideoViewerComponent', () => {
     refreshPublicVideoUrl$: vi.fn((video: IPublicVideoItem) => of(video)),
     invalidatePublicVideoAccess: vi.fn(),
   };
+  const publicVideoShare = {
+    sharePublicVideo: vi.fn(() => Promise.resolve('shared' as const)),
+  };
   const reactions = {
     getVideoLikesCount$: vi.fn(() => of(12)),
     isVideoLikedByViewer$: vi.fn(() => of(false)),
@@ -201,6 +205,7 @@ describe('PublicVideoViewerComponent', () => {
         },
         { provide: VideoViewTrackingService, useValue: videoViewTracking },
         { provide: PublicVideoAccessService, useValue: publicVideoAccess },
+        { provide: PublicVideoShareService, useValue: publicVideoShare },
         { provide: MediaReactionsService, useValue: reactions },
         { provide: MediaVideoCommentsService, useValue: comments },
         { provide: MediaVideoRatingsService, useValue: ratings },


### PR DESCRIPTION
## Dependência

PR empilhado sobre o #50 (`agent/video-p0-audience-policy`). O diff deste PR contém apenas o fechamento P0 de `INTERACT` e `SHARE`.

## O que mudou

- adiciona `assertInTransaction()` à política central de audiência para evitar autorização fora da transação;
- cria resolvedor canônico compartilhado entre projeção pública e `video_publications`;
- aplica audiência transacional a curtidas, avaliações e criação de comentários;
- permite desfazer a própria curtida mesmo após revogação de audiência, por ser limpeza de dado;
- impede o autor de criar comentário raiz no próprio vídeo e inflar `commentsCount`/score;
- preserva respostas do autor sem incremento de score;
- mantém moderação e exclusão de comentários fora da barreira de audiência para preservar direitos de limpeza e moderação;
- cria a callable `authorizePublicVideoShare`;
- adiciona gateway Angular reativo antes de `navigator.share` ou cópia do link;
- mantém o método público `sharePublicVideo()` e os componentes existentes;
- exige audiência válida para remetente e destinatário antes de enviar referência de vídeo no chat;
- mantém referências de chat sem URL assinada, caminho de Storage ou token;
- revalida publicação, visibilidade e moderação canônicas.

## Supressões e substituições intencionais

### Compartilhamento externo direto

Foi suprimida a geração local do link seguida imediatamente por `navigator.share`/clipboard.

Ela foi substituída pela autorização backend `authorizePublicVideoShare`. O caminho canônico só é exposto ao navegador quando o backend confirma publicação, moderação, lifecycle, idade, bloqueio bilateral e audiência.

### Pré-validação duplicada de comentários

Foi removida do orquestrador a chamada isolada de `assertInteractionAccess` e o cast `any`.

A validação não foi eliminada: foi substituída pela política transacional completa no núcleo de criação do comentário, que inclui lifecycle, idade, publicação canônica, bloqueio e audiência.

## Decisões de segurança

- criar curtida, avaliação ou comentário exige audiência válida;
- remover curtida existente continua permitido como limpeza do próprio dado;
- exclusão de comentário pelo autor e moderação pelo dono do vídeo continuam possíveis sem audiência atual;
- compartilhar externamente autoriza o remetente, mas não concede acesso ao destinatário do link;
- compartilhar no chat exige autorização do remetente e do destinatário;
- abrir ou reproduzir o vídeo continua revalidando a audiência novamente;
- `COMPATIBLE`, `SUBSCRIBERS` e `PREMIUM` continuam fechados enquanto não houver projeções/entitlements backend confiáveis.

## Compatibilidade

- nomes públicos dos métodos foram mantidos;
- fluxo Angular continua reativo por `Observable` no gateway de autorização;
- `sharePublicVideo()` permanece `Promise` apenas na borda, por depender das APIs nativas assíncronas de compartilhamento/clipboard;
- tratamento de falhas continua integrado a `GlobalErrorHandlerService` e `ErrorNotificationService`.

## Correções de teste durante o CI

- a expectativa do compartilhamento foi ajustada para aceitar a origem efetivamente fornecida pelo `DOCUMENT` do ambiente;
- a suíte do visualizador passou a mockar `PublicVideoShareService`, evitando carregar `Functions` em testes que não exercitam compartilhamento;
- essas duas correções foram restritas aos testes e não alteraram o código de produção.

## Validação concluída

- Functions lint/build/testes: aprovado;
- testes Angular: aprovado;
- build Angular seguro: aprovado;
- Firestore Rules: aprovado;
- índices do Firestore: aprovado;
- Quality Gate agregado: aprovado;
- Angular CI Validation e build do Emulator: aprovado.