### PR TITLE
feat(media): unificar ranking, retenção e recência de vídeos

### DIFF
--- a/functions/src/media/application/media-engagement-score.test.ts
+++ b/functions/src/media/application/media-engagement-score.test.ts
@@ -2,7 +2,11 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
 import {
+  MEDIA_FRESHNESS_HALF_LIFE_MS,
   buildMediaEngagementScore,
+  calculateMediaFreshnessScore,
+  calculateMediaRetentionScore,
+  calculateMediaViewScore,
   normalizeMediaCount,
   normalizeMediaRatingAverage,
   normalizeMediaScore,
@@ -50,12 +54,73 @@ describe('media-engagement-score', () => {
     assert.ok(withRatings.engagementScore > withoutRatings.engagementScore);
   });
 
-  it('preserva qualidade e segurança do breakdown atual', () => {
+  it('normaliza visualizações sem saturar na primeira reprodução', () => {
+    const firstView = calculateMediaViewScore({
+      viewsCount: 1,
+      uniqueViewersCount: 1,
+    });
+    const establishedVideo = calculateMediaViewScore({
+      viewsCount: 1_000,
+      uniqueViewersCount: 700,
+    });
+
+    assert.ok(firstView > 0);
+    assert.ok(firstView < 20);
+    assert.ok(establishedVideo > firstView);
+    assert.ok(establishedVideo <= 100);
+  });
+
+  it('pondera retenção pela quantidade de visualizações qualificadas', () => {
+    const oneView = calculateMediaRetentionScore({
+      qualifiedViewsCount: 1,
+      totalQualifiedPlaybackMs: 8_000,
+      totalQualifiedDurationMs: 10_000,
+    });
+    const established = calculateMediaRetentionScore({
+      qualifiedViewsCount: 30,
+      totalQualifiedPlaybackMs: 240_000,
+      totalQualifiedDurationMs: 300_000,
+    });
+
+    assert.ok(oneView > 0);
+    assert.ok(oneView < established);
+    assert.ok(established <= 80);
+  });
+
+  it('reduz a recência conforme o vídeo envelhece', () => {
+    const now = 2_000_000_000_000;
+    const fresh = calculateMediaFreshnessScore({
+      publishedAt: now,
+      now,
+    });
+    const halfLife = calculateMediaFreshnessScore({
+      publishedAt: now - MEDIA_FRESHNESS_HALF_LIFE_MS,
+      now,
+    });
+    const old = calculateMediaFreshnessScore({
+      publishedAt: now - MEDIA_FRESHNESS_HALF_LIFE_MS * 4,
+      now,
+    });
+
+    assert.equal(fresh, 100);
+    assert.equal(halfLife, 50);
+    assert.ok(old < halfLife);
+  });
+
+  it('preserva qualidade e segurança e integra views, retenção e recência', () => {
+    const now = 2_000_000_000_000;
     const result = buildMediaEngagementScore({
-      reactionsCount: 1,
-      commentsCount: 1,
-      ratingsCount: 1,
-      ratingAverage: 5,
+      reactionsCount: 4,
+      commentsCount: 2,
+      ratingsCount: 3,
+      ratingAverage: 4.5,
+      viewsCount: 100,
+      uniqueViewersCount: 80,
+      qualifiedViewsCount: 30,
+      totalQualifiedPlaybackMs: 240_000,
+      totalQualifiedDurationMs: 300_000,
+      publishedAt: now - 24 * 60 * 60 * 1000,
+      now,
       currentBreakdown: {
         qualityScore: 72,
         safetyScore: 84,
@@ -64,6 +129,23 @@ describe('media-engagement-score', () => {
 
     assert.equal(result.scoreBreakdown.qualityScore, 72);
     assert.equal(result.scoreBreakdown.safetyScore, 84);
+    assert.equal(result.viewScore, result.scoreBreakdown.viewScore);
+    assert.equal(result.retentionScore, result.scoreBreakdown.retentionScore);
+    assert.equal(result.freshnessScore, result.scoreBreakdown.freshnessScore);
     assert.ok(result.score > 0);
+  });
+
+  it('não entrega bônus de segurança sem evidência de qualidade ou consumo', () => {
+    const result = buildMediaEngagementScore({
+      reactionsCount: 0,
+      commentsCount: 0,
+      publishedAt: 1_999_999_000_000,
+      now: 2_000_000_000_000,
+      currentBreakdown: {
+        safetyScore: 100,
+      },
+    });
+
+    assert.equal(result.score, result.freshnessScore * 0.1);
   });
 });

--- a/functions/src/media/application/media-engagement-score.ts
+++ b/functions/src/media/application/media-engagement-score.ts
@@ -1,7 +1,17 @@
+export const MEDIA_RANKING_VERSION = 2;
+export const MEDIA_FRESHNESS_HALF_LIFE_MS = 7 * 24 * 60 * 60 * 1000;
+
+const MEDIA_VIEW_VOLUME_REFERENCE = 10_000;
+const MEDIA_VIEW_UNIQUENESS_CONFIDENCE_VIEWS = 20;
+const MEDIA_RETENTION_CONFIDENCE_VIEWS = 10;
+
 export interface MediaScoreBreakdown {
   rankingScore: number;
   qualityScore: number;
   engagementScore: number;
+  viewScore: number;
+  retentionScore: number;
+  freshnessScore: number;
   safetyScore: number;
 }
 
@@ -10,12 +20,22 @@ export interface MediaEngagementInput {
   commentsCount: number;
   ratingsCount?: number;
   ratingAverage?: number;
+  viewsCount?: number;
+  uniqueViewersCount?: number;
+  qualifiedViewsCount?: number;
+  totalQualifiedPlaybackMs?: number;
+  totalQualifiedDurationMs?: number;
+  publishedAt?: number;
+  now?: number;
   currentBreakdown?: Partial<MediaScoreBreakdown> | null;
 }
 
 export interface MediaEngagementResult {
   score: number;
   engagementScore: number;
+  viewScore: number;
+  retentionScore: number;
+  freshnessScore: number;
   scoreBreakdown: MediaScoreBreakdown;
 }
 
@@ -27,6 +47,16 @@ export function normalizeMediaCount(value: unknown): number {
   }
 
   return Math.floor(count);
+}
+
+export function normalizeMediaTotal(value: unknown): number {
+  const total = Number(value ?? 0);
+
+  if (!Number.isFinite(total) || total < 0) {
+    return 0;
+  }
+
+  return Math.floor(total);
 }
 
 export function normalizeMediaScore(value: unknown): number {
@@ -49,6 +79,118 @@ export function normalizeMediaRatingAverage(value: unknown): number {
   return Math.max(0, Math.min(5, rating));
 }
 
+export function normalizeMediaTimestamp(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+    return Math.floor(value);
+  }
+
+  const timestamp = value as {
+    toMillis?: () => number;
+    toDate?: () => Date;
+    seconds?: number;
+  } | null | undefined;
+
+  if (typeof timestamp?.toMillis === 'function') {
+    try {
+      return normalizeMediaTimestamp(timestamp.toMillis());
+    } catch {
+      return 0;
+    }
+  }
+
+  if (typeof timestamp?.toDate === 'function') {
+    try {
+      return normalizeMediaTimestamp(timestamp.toDate().getTime());
+    } catch {
+      return 0;
+    }
+  }
+
+  if (typeof timestamp?.seconds === 'number') {
+    return normalizeMediaTimestamp(timestamp.seconds * 1000);
+  }
+
+  return 0;
+}
+
+export function calculateMediaViewScore(input: {
+  viewsCount: unknown;
+  uniqueViewersCount: unknown;
+}): number {
+  const viewsCount = normalizeMediaCount(input.viewsCount);
+  const uniqueViewersCount = Math.min(
+    viewsCount,
+    normalizeMediaCount(input.uniqueViewersCount)
+  );
+
+  if (viewsCount === 0) {
+    return 0;
+  }
+
+  const volumeScore = Math.min(
+    100,
+    Math.log1p(viewsCount) / Math.log1p(MEDIA_VIEW_VOLUME_REFERENCE) * 100
+  );
+  const uniqueRatio = uniqueViewersCount / viewsCount;
+  const uniquenessConfidence =
+    1 - Math.exp(-viewsCount / MEDIA_VIEW_UNIQUENESS_CONFIDENCE_VIEWS);
+  const uniqueQualityScore = uniqueRatio * uniquenessConfidence * 100;
+
+  return normalizeMediaScore(
+    volumeScore * 0.65 + uniqueQualityScore * 0.35
+  );
+}
+
+export function calculateMediaRetentionScore(input: {
+  qualifiedViewsCount: unknown;
+  totalQualifiedPlaybackMs: unknown;
+  totalQualifiedDurationMs: unknown;
+}): number {
+  const qualifiedViewsCount = normalizeMediaCount(input.qualifiedViewsCount);
+  const totalQualifiedPlaybackMs = normalizeMediaTotal(
+    input.totalQualifiedPlaybackMs
+  );
+  const totalQualifiedDurationMs = normalizeMediaTotal(
+    input.totalQualifiedDurationMs
+  );
+
+  if (
+    qualifiedViewsCount === 0 ||
+    totalQualifiedDurationMs === 0
+  ) {
+    return 0;
+  }
+
+  const retentionRatio = Math.min(
+    1,
+    totalQualifiedPlaybackMs / totalQualifiedDurationMs
+  );
+  const confidence =
+    1 - Math.exp(-qualifiedViewsCount / MEDIA_RETENTION_CONFIDENCE_VIEWS);
+
+  return normalizeMediaScore(retentionRatio * confidence * 100);
+}
+
+export function calculateMediaFreshnessScore(input: {
+  publishedAt: unknown;
+  now?: unknown;
+}): number {
+  const publishedAt = normalizeMediaTimestamp(input.publishedAt);
+  const normalizedNow = normalizeMediaTimestamp(input.now) || Date.now();
+
+  if (!publishedAt) {
+    return 0;
+  }
+
+  const ageMs = Math.max(0, normalizedNow - publishedAt);
+  const freshness = 100 * Math.pow(
+    0.5,
+    ageMs / MEDIA_FRESHNESS_HALF_LIFE_MS
+  );
+
+  return normalizeMediaScore(freshness);
+}
+
 export function buildMediaEngagementScore(
   input: MediaEngagementInput
 ): MediaEngagementResult {
@@ -63,24 +205,65 @@ export function buildMediaEngagementScore(
     Math.round(Math.log1p(weightedEngagement) * 18)
   );
   const currentBreakdown = input.currentBreakdown ?? {};
+  const hasViewMetrics =
+    input.viewsCount !== undefined || input.uniqueViewersCount !== undefined;
+  const hasRetentionMetrics =
+    input.qualifiedViewsCount !== undefined ||
+    input.totalQualifiedPlaybackMs !== undefined ||
+    input.totalQualifiedDurationMs !== undefined;
+  const hasFreshnessMetrics = input.publishedAt !== undefined;
+  const viewScore = hasViewMetrics
+    ? calculateMediaViewScore({
+      viewsCount: input.viewsCount,
+      uniqueViewersCount: input.uniqueViewersCount,
+    })
+    : normalizeMediaScore(currentBreakdown.viewScore);
+  const retentionScore = hasRetentionMetrics
+    ? calculateMediaRetentionScore({
+      qualifiedViewsCount: input.qualifiedViewsCount,
+      totalQualifiedPlaybackMs: input.totalQualifiedPlaybackMs,
+      totalQualifiedDurationMs: input.totalQualifiedDurationMs,
+    })
+    : normalizeMediaScore(currentBreakdown.retentionScore);
+  const freshnessScore = hasFreshnessMetrics
+    ? calculateMediaFreshnessScore({
+      publishedAt: input.publishedAt,
+      now: input.now,
+    })
+    : normalizeMediaScore(currentBreakdown.freshnessScore);
   const scoreBreakdown: MediaScoreBreakdown = {
     qualityScore: normalizeMediaScore(currentBreakdown.qualityScore ?? 0),
     safetyScore: normalizeMediaScore(currentBreakdown.safetyScore ?? 100),
     engagementScore,
+    viewScore,
+    retentionScore,
+    freshnessScore,
     rankingScore: 0,
   };
+  const evidenceConfidence = Math.max(
+    scoreBreakdown.qualityScore,
+    scoreBreakdown.engagementScore,
+    scoreBreakdown.viewScore,
+    scoreBreakdown.retentionScore
+  ) / 100;
 
   scoreBreakdown.rankingScore = normalizeMediaScore(
     Math.round(
-      scoreBreakdown.qualityScore * 0.25 +
-      scoreBreakdown.engagementScore * 0.45 +
-      scoreBreakdown.safetyScore * 0.30
+      scoreBreakdown.qualityScore * 0.15 +
+      scoreBreakdown.engagementScore * 0.25 +
+      scoreBreakdown.viewScore * 0.20 +
+      scoreBreakdown.retentionScore * 0.20 +
+      scoreBreakdown.freshnessScore * 0.10 +
+      scoreBreakdown.safetyScore * 0.10 * evidenceConfidence
     )
   );
 
   return {
     score: scoreBreakdown.rankingScore,
     engagementScore,
+    viewScore,
+    retentionScore,
+    freshnessScore,
     scoreBreakdown,
   };
 }

--- a/functions/src/media/application/record-video-view.handler.ts
+++ b/functions/src/media/application/record-video-view.handler.ts
@@ -5,6 +5,14 @@ import { HttpsError, onCall } from 'firebase-functions/v2/https';
 import { FUNCTIONS_REGION } from '../../config/functions-region';
 import { db, FieldValue } from '../../firebaseApp';
 import {
+  MEDIA_RANKING_VERSION,
+  buildMediaEngagementScore,
+  normalizeMediaCount,
+  normalizeMediaScore,
+  normalizeMediaTotal,
+  type MediaScoreBreakdown,
+} from './media-engagement-score';
+import {
   PROFILE_VIEWER_INDEX_VERSION,
   PROFILE_VIEWERS_COLLECTION,
   calculatePublicProfileEngagementScore,
@@ -79,22 +87,6 @@ function assertPublicApprovedVideo(
       'Vídeo indisponível para visualização pública.'
     );
   }
-}
-
-function calculateViewScore(input: {
-  viewsCount: number;
-  uniqueViewersCount: number;
-  lastViewedAt: number;
-  publishedAt: number;
-}): number {
-  const recencyBoost =
-    Math.max(0, input.lastViewedAt - input.publishedAt) / 1_000_000_000;
-
-  return Math.round(
-    input.viewsCount * 4 +
-      input.uniqueViewersCount * 6 +
-      recencyBoost
-  );
 }
 
 function hashPlaybackSession(input: {
@@ -229,26 +221,64 @@ export const recordVideoView = onCall<RecordVideoViewRequest>(
       });
       const canCountView = countDecision.canCount;
 
-      const currentVideoViewsCount = safeNumber(publicVideo.viewsCount);
-      const currentVideoUniqueViewersCount = safeNumber(
+      const currentVideoViewsCount = normalizeMediaCount(
+        publicVideo.viewsCount
+      );
+      const currentVideoUniqueViewersCount = normalizeMediaCount(
         publicVideo.uniqueViewersCount
       );
-      const currentVideoViewScore = safeNumber(publicVideo.viewScore);
+      const currentVideoViewScore = normalizeMediaScore(
+        publicVideo.viewScore
+      );
+      const currentQualifiedViewsCount = normalizeMediaCount(
+        publicVideo.qualifiedViewsCount
+      );
+      const currentTotalQualifiedPlaybackMs = normalizeMediaTotal(
+        publicVideo.totalQualifiedPlaybackMs
+      );
+      const currentTotalQualifiedDurationMs = normalizeMediaTotal(
+        publicVideo.totalQualifiedDurationMs
+      );
       const nextVideoViewsCount = canCountView
         ? currentVideoViewsCount + 1
         : currentVideoViewsCount;
       const nextVideoUniqueViewersCount = isUniqueVideoViewer
         ? currentVideoUniqueViewersCount + 1
         : currentVideoUniqueViewersCount;
+      const nextQualifiedViewsCount = canCountView
+        ? currentQualifiedViewsCount + 1
+        : currentQualifiedViewsCount;
+      const nextTotalQualifiedPlaybackMs = canCountView
+        ? currentTotalQualifiedPlaybackMs + Math.min(
+          evidence.playbackMs,
+          evidence.durationMs
+        )
+        : currentTotalQualifiedPlaybackMs;
+      const nextTotalQualifiedDurationMs = canCountView
+        ? currentTotalQualifiedDurationMs + evidence.durationMs
+        : currentTotalQualifiedDurationMs;
       const publishedAt = safeNumber(publicVideo.publishedAt) || now;
-      const nextVideoViewScore = canCountView
-        ? calculateViewScore({
+      const nextVideoRanking = canCountView
+        ? buildMediaEngagementScore({
+          reactionsCount: normalizeMediaCount(
+            publicVideo.reactionsCount ?? publicVideo.likesCount
+          ),
+          commentsCount: normalizeMediaCount(publicVideo.commentsCount),
+          ratingsCount: normalizeMediaCount(publicVideo.ratingsCount),
+          ratingAverage: publicVideo.ratingAverage,
           viewsCount: nextVideoViewsCount,
           uniqueViewersCount: nextVideoUniqueViewersCount,
-          lastViewedAt: now,
+          qualifiedViewsCount: nextQualifiedViewsCount,
+          totalQualifiedPlaybackMs: nextTotalQualifiedPlaybackMs,
+          totalQualifiedDurationMs: nextTotalQualifiedDurationMs,
           publishedAt,
+          now,
+          currentBreakdown: publicVideo.scoreBreakdown as
+            Partial<MediaScoreBreakdown> | undefined,
         })
-        : currentVideoViewScore;
+        : null;
+      const nextVideoViewScore = nextVideoRanking?.viewScore ??
+        currentVideoViewScore;
 
       const currentProfileViewsCount = safeNumber(
         publicProfile.profileViewsCount ?? publicProfile.viewsCount
@@ -362,14 +392,24 @@ export const recordVideoView = onCall<RecordVideoViewRequest>(
         );
       }
 
-      if (canCountView) {
+      if (canCountView && nextVideoRanking) {
         transaction.set(
           publicVideoRef,
           {
             viewsCount: nextVideoViewsCount,
             uniqueViewersCount: nextVideoUniqueViewersCount,
+            qualifiedViewsCount: nextQualifiedViewsCount,
+            totalQualifiedPlaybackMs: nextTotalQualifiedPlaybackMs,
+            totalQualifiedDurationMs: nextTotalQualifiedDurationMs,
             lastViewedAt: now,
-            viewScore: nextVideoViewScore,
+            viewScore: nextVideoRanking.viewScore,
+            retentionScore: nextVideoRanking.retentionScore,
+            freshnessScore: nextVideoRanking.freshnessScore,
+            engagementScore: nextVideoRanking.engagementScore,
+            score: nextVideoRanking.score,
+            scoreBreakdown: nextVideoRanking.scoreBreakdown,
+            rankingVersion: MEDIA_RANKING_VERSION,
+            rankingUpdatedAt: now,
           },
           { merge: true }
         );

--- a/functions/src/media/application/video-ranking-score-maintenance.handler.ts
+++ b/functions/src/media/application/video-ranking-score-maintenance.handler.ts
@@ -8,7 +8,10 @@ import {
   MEDIA_RANKING_VERSION,
   buildMediaEngagementScore,
   normalizeMediaCount,
+  normalizeMediaRatingAverage,
   normalizeMediaScore,
+  normalizeMediaTimestamp,
+  normalizeMediaTotal,
   type MediaScoreBreakdown,
 } from './media-engagement-score';
 
@@ -37,6 +40,17 @@ interface PublicVideoRankingDocument extends FirebaseFirestore.DocumentData {
   scoreBreakdown?: Partial<MediaScoreBreakdown> | null;
 }
 
+interface VideoRankingUpdate {
+  score: number;
+  engagementScore: number;
+  viewScore: number;
+  retentionScore: number;
+  freshnessScore: number;
+  scoreBreakdown: MediaScoreBreakdown;
+  rankingVersion: number;
+  rankingUpdatedAt: number;
+}
+
 function normalizeEnum(value: unknown): string {
   return String(value ?? '').trim().toUpperCase();
 }
@@ -49,20 +63,24 @@ function isRankableVideo(data: PublicVideoRankingDocument): boolean {
 function buildRankingUpdate(
   data: PublicVideoRankingDocument,
   now: number
-): Record<string, unknown> {
+): VideoRankingUpdate {
   const ranking = buildMediaEngagementScore({
     reactionsCount: normalizeMediaCount(
       data.reactionsCount ?? data.likesCount
     ),
     commentsCount: normalizeMediaCount(data.commentsCount),
     ratingsCount: normalizeMediaCount(data.ratingsCount),
-    ratingAverage: data.ratingAverage,
+    ratingAverage: normalizeMediaRatingAverage(data.ratingAverage),
     viewsCount: normalizeMediaCount(data.viewsCount),
     uniqueViewersCount: normalizeMediaCount(data.uniqueViewersCount),
     qualifiedViewsCount: normalizeMediaCount(data.qualifiedViewsCount),
-    totalQualifiedPlaybackMs: data.totalQualifiedPlaybackMs as number,
-    totalQualifiedDurationMs: data.totalQualifiedDurationMs as number,
-    publishedAt: data.publishedAt as number,
+    totalQualifiedPlaybackMs: normalizeMediaTotal(
+      data.totalQualifiedPlaybackMs
+    ),
+    totalQualifiedDurationMs: normalizeMediaTotal(
+      data.totalQualifiedDurationMs
+    ),
+    publishedAt: normalizeMediaTimestamp(data.publishedAt),
     now,
     currentBreakdown: data.scoreBreakdown,
   });
@@ -81,17 +99,17 @@ function buildRankingUpdate(
 
 function hasEquivalentRanking(
   data: PublicVideoRankingDocument,
-  update: Record<string, unknown>
+  update: VideoRankingUpdate
 ): boolean {
   const currentBreakdown = data.scoreBreakdown ?? {};
-  const nextBreakdown = update['scoreBreakdown'] as MediaScoreBreakdown;
+  const nextBreakdown = update.scoreBreakdown;
 
   return normalizeMediaCount(data.rankingVersion) === MEDIA_RANKING_VERSION &&
-    normalizeMediaScore(data.score) === update['score'] &&
-    normalizeMediaScore(data.engagementScore) === update['engagementScore'] &&
-    normalizeMediaScore(data.viewScore) === update['viewScore'] &&
-    normalizeMediaScore(data.retentionScore) === update['retentionScore'] &&
-    normalizeMediaScore(data.freshnessScore) === update['freshnessScore'] &&
+    normalizeMediaScore(data.score) === update.score &&
+    normalizeMediaScore(data.engagementScore) === update.engagementScore &&
+    normalizeMediaScore(data.viewScore) === update.viewScore &&
+    normalizeMediaScore(data.retentionScore) === update.retentionScore &&
+    normalizeMediaScore(data.freshnessScore) === update.freshnessScore &&
     normalizeMediaScore(currentBreakdown.rankingScore) ===
       nextBreakdown.rankingScore &&
     normalizeMediaScore(currentBreakdown.qualityScore) ===

--- a/functions/src/media/application/video-ranking-score-maintenance.handler.ts
+++ b/functions/src/media/application/video-ranking-score-maintenance.handler.ts
@@ -1,0 +1,201 @@
+import { logger } from 'firebase-functions';
+import { onDocumentWritten } from 'firebase-functions/v2/firestore';
+import { onSchedule } from 'firebase-functions/v2/scheduler';
+
+import { FUNCTIONS_REGION } from '../../config/functions-region';
+import { db } from '../../firebaseApp';
+import {
+  MEDIA_RANKING_VERSION,
+  buildMediaEngagementScore,
+  normalizeMediaCount,
+  normalizeMediaScore,
+  type MediaScoreBreakdown,
+} from './media-engagement-score';
+
+const RANKING_REFRESH_LIMIT_PER_QUERY = 240;
+
+interface PublicVideoRankingDocument extends FirebaseFirestore.DocumentData {
+  visibility?: unknown;
+  moderationStatus?: unknown;
+  reactionsCount?: unknown;
+  likesCount?: unknown;
+  commentsCount?: unknown;
+  ratingsCount?: unknown;
+  ratingAverage?: unknown;
+  viewsCount?: unknown;
+  uniqueViewersCount?: unknown;
+  qualifiedViewsCount?: unknown;
+  totalQualifiedPlaybackMs?: unknown;
+  totalQualifiedDurationMs?: unknown;
+  publishedAt?: unknown;
+  score?: unknown;
+  viewScore?: unknown;
+  retentionScore?: unknown;
+  freshnessScore?: unknown;
+  engagementScore?: unknown;
+  rankingVersion?: unknown;
+  scoreBreakdown?: Partial<MediaScoreBreakdown> | null;
+}
+
+function normalizeEnum(value: unknown): string {
+  return String(value ?? '').trim().toUpperCase();
+}
+
+function isRankableVideo(data: PublicVideoRankingDocument): boolean {
+  return normalizeEnum(data.visibility) === 'PUBLIC' &&
+    normalizeEnum(data.moderationStatus) === 'APPROVED';
+}
+
+function buildRankingUpdate(
+  data: PublicVideoRankingDocument,
+  now: number
+): Record<string, unknown> {
+  const ranking = buildMediaEngagementScore({
+    reactionsCount: normalizeMediaCount(
+      data.reactionsCount ?? data.likesCount
+    ),
+    commentsCount: normalizeMediaCount(data.commentsCount),
+    ratingsCount: normalizeMediaCount(data.ratingsCount),
+    ratingAverage: data.ratingAverage,
+    viewsCount: normalizeMediaCount(data.viewsCount),
+    uniqueViewersCount: normalizeMediaCount(data.uniqueViewersCount),
+    qualifiedViewsCount: normalizeMediaCount(data.qualifiedViewsCount),
+    totalQualifiedPlaybackMs: data.totalQualifiedPlaybackMs as number,
+    totalQualifiedDurationMs: data.totalQualifiedDurationMs as number,
+    publishedAt: data.publishedAt as number,
+    now,
+    currentBreakdown: data.scoreBreakdown,
+  });
+
+  return {
+    score: ranking.score,
+    engagementScore: ranking.engagementScore,
+    viewScore: ranking.viewScore,
+    retentionScore: ranking.retentionScore,
+    freshnessScore: ranking.freshnessScore,
+    scoreBreakdown: ranking.scoreBreakdown,
+    rankingVersion: MEDIA_RANKING_VERSION,
+    rankingUpdatedAt: now,
+  };
+}
+
+function hasEquivalentRanking(
+  data: PublicVideoRankingDocument,
+  update: Record<string, unknown>
+): boolean {
+  const currentBreakdown = data.scoreBreakdown ?? {};
+  const nextBreakdown = update['scoreBreakdown'] as MediaScoreBreakdown;
+
+  return normalizeMediaCount(data.rankingVersion) === MEDIA_RANKING_VERSION &&
+    normalizeMediaScore(data.score) === update['score'] &&
+    normalizeMediaScore(data.engagementScore) === update['engagementScore'] &&
+    normalizeMediaScore(data.viewScore) === update['viewScore'] &&
+    normalizeMediaScore(data.retentionScore) === update['retentionScore'] &&
+    normalizeMediaScore(data.freshnessScore) === update['freshnessScore'] &&
+    normalizeMediaScore(currentBreakdown.rankingScore) ===
+      nextBreakdown.rankingScore &&
+    normalizeMediaScore(currentBreakdown.qualityScore) ===
+      nextBreakdown.qualityScore &&
+    normalizeMediaScore(currentBreakdown.engagementScore) ===
+      nextBreakdown.engagementScore &&
+    normalizeMediaScore(currentBreakdown.viewScore) ===
+      nextBreakdown.viewScore &&
+    normalizeMediaScore(currentBreakdown.retentionScore) ===
+      nextBreakdown.retentionScore &&
+    normalizeMediaScore(currentBreakdown.freshnessScore) ===
+      nextBreakdown.freshnessScore &&
+    normalizeMediaScore(currentBreakdown.safetyScore) ===
+      nextBreakdown.safetyScore;
+}
+
+export const recalculateVideoRankingOnWrite = onDocumentWritten(
+  {
+    document: 'public_profiles/{ownerUid}/public_videos/{videoId}',
+    region: FUNCTIONS_REGION,
+    maxInstances: 20,
+  },
+  async (event) => {
+    const after = event.data?.after;
+
+    if (!after?.exists) {
+      return;
+    }
+
+    const data = after.data() as PublicVideoRankingDocument;
+
+    if (!isRankableVideo(data)) {
+      return;
+    }
+
+    const update = buildRankingUpdate(data, Date.now());
+
+    if (hasEquivalentRanking(data, update)) {
+      return;
+    }
+
+    await after.ref.set(update, { merge: true });
+  }
+);
+
+export const refreshPublicVideoRankingScores = onSchedule(
+  {
+    schedule: 'every 6 hours',
+    timeZone: 'America/Sao_Paulo',
+    region: FUNCTIONS_REGION,
+  },
+  async () => {
+    const rankableVideos = db
+      .collectionGroup('public_videos')
+      .where('visibility', '==', 'PUBLIC')
+      .where('moderationStatus', '==', 'APPROVED');
+    const [topSnapshot, latestSnapshot] = await Promise.all([
+      rankableVideos
+        .orderBy('score', 'desc')
+        .limit(RANKING_REFRESH_LIMIT_PER_QUERY)
+        .get(),
+      rankableVideos
+        .orderBy('publishedAt', 'desc')
+        .limit(RANKING_REFRESH_LIMIT_PER_QUERY)
+        .get(),
+    ]);
+    const candidates = new Map<
+      string,
+      FirebaseFirestore.QueryDocumentSnapshot
+    >();
+
+    for (const document of [...topSnapshot.docs, ...latestSnapshot.docs]) {
+      candidates.set(document.ref.path, document);
+    }
+
+    const now = Date.now();
+    const batch = db.batch();
+    let updatedVideos = 0;
+
+    for (const document of candidates.values()) {
+      const data = document.data() as PublicVideoRankingDocument;
+
+      if (!isRankableVideo(data)) {
+        continue;
+      }
+
+      const update = buildRankingUpdate(data, now);
+
+      if (hasEquivalentRanking(data, update)) {
+        continue;
+      }
+
+      batch.set(document.ref, update, { merge: true });
+      updatedVideos += 1;
+    }
+
+    if (updatedVideos > 0) {
+      await batch.commit();
+    }
+
+    logger.info('[refreshPublicVideoRankingScores] Ranking atualizado.', {
+      scannedVideos: candidates.size,
+      updatedVideos,
+      rankingVersion: MEDIA_RANKING_VERSION,
+    });
+  }
+);

--- a/functions/src/media/index.ts
+++ b/functions/src/media/index.ts
@@ -129,3 +129,8 @@ export {
 export {
   recordVideoView,
 } from './application/record-video-view-orchestrator.handler';
+
+export {
+  recalculateVideoRankingOnWrite,
+  refreshPublicVideoRankingScores,
+} from './application/video-ranking-score-maintenance.handler';


### PR DESCRIPTION
## Dependência

PR empilhado sobre o #51 (`agent/video-p0-interaction-share-policy`). O diff contém apenas o pacote P0 de ranking, visualização qualificada, retenção e recência.

## O que mudou

- eleva o contrato de ranking para a versão 2;
- normaliza `viewScore` para a mesma faixa de 0 a 100 usada pelo restante do ranking;
- substitui o crescimento linear ilimitado por volume logarítmico e confiança progressiva de audiência única;
- agrega `qualifiedViewsCount`, `totalQualifiedPlaybackMs` e `totalQualifiedDurationMs` nas visualizações efetivamente contabilizadas;
- calcula `retentionScore` pela proporção de reprodução, ponderada pela quantidade de amostras qualificadas;
- corrige a recência com decaimento exponencial e meia-vida de sete dias;
- integra qualidade, engajamento, visualizações, retenção, recência e segurança no `score` principal;
- impede que segurança padrão gere bônus integral sem evidência de qualidade, consumo ou engajamento;
- recalcula o ranking imediatamente quando uma visualização qualificada é contabilizada;
- adiciona trigger central para recalcular o ranking após qualquer escrita no vídeo público;
- adiciona rotina agendada a cada seis horas para atualizar a perda natural de recência dos candidatos `top` e dos vídeos mais recentes;
- reutiliza as consultas e índices já empregados pelo ranking `top` e `latest`;
- adiciona testes unitários para normalização, retenção, recência e composição do ranking.

## Causa raiz

O `viewScore` anterior era calculado por uma soma linear de visualizações e audiência única, sem limite no backend. O cliente normalizava esse valor para 100, causando saturação silenciosa e divergência entre persistência e leitura.

A recência anterior era derivada de `lastViewedAt - publishedAt`, portanto aumentava conforme o conteúdo envelhecia. Além disso, visualizações atualizavam `viewScore`, mas o ranking `top` ordenava pelo campo `score`, que não incorporava consumo ou retenção.

## Fórmula e sinais

### Visualizações

- volume com escala logarítmica;
- proporção de audiência única;
- confiança progressiva para impedir que uma única reprodução produza nota alta.

### Retenção

- soma somente reproduções qualificadas e contabilizadas;
- limita playback ao tempo real do vídeo;
- calcula retenção agregada;
- aplica confiança progressiva conforme cresce a quantidade de amostras.

### Recência

- 100 no momento da publicação;
- 50 após sete dias;
- segue decaimento exponencial;
- nunca aumenta com a idade.

### Ranking principal

Combina:

- qualidade: 15%;
- engajamento: 25%;
- visualizações: 20%;
- retenção: 20%;
- recência: 10%;
- segurança: até 10%, proporcional à confiança dos demais sinais.

## Supressões e substituições intencionais

### Fórmula linear de `viewScore`

Foi suprimida a fórmula `views * 4 + uniqueViewers * 6 + recencyBoost`.

Ela foi substituída por um score normalizado com volume logarítmico, qualidade da audiência única e confiança por amostragem. O motivo é impedir crescimento ilimitado, saturação no cliente e vantagem permanente baseada apenas em volume bruto.

### Recência crescente

Foi suprimido o cálculo baseado em `lastViewedAt - publishedAt`.

Ele foi substituído por decaimento exponencial calculado a partir da idade do vídeo. O motivo é garantir que recência diminua com o tempo e não premie conteúdo antigo.

## Migração e compatibilidade

- nomes públicos existentes foram mantidos;
- handlers de curtida, comentário, avaliação e moderação continuam usando `buildMediaEngagementScore`;
- o contrato foi ampliado internamente, sem exigir alteração dos consumidores Angular;
- campos legados ausentes são normalizados para zero;
- vídeos são migrados automaticamente quando recebem escrita;
- a rotina agendada converge os candidatos de ranking antigos para a versão 2;
- não houve supressão de componentes ou fluxos visuais.

## Segurança e antifraude

- somente reproduções que passam pela qualificação existente entram nos agregados;
- sessões repetidas, intervalo mínimo e limite diário continuam válidos;
- playback agregado é limitado à duração confirmada do vídeo;
- visualizações do próprio autor continuam não contabilizadas;
- o pacote não remove a necessidade futura de App Check, sessão de reprodução emitida pelo backend e rate limiting adicional.

## Correção durante o CI

A primeira execução identificou que `ratingAverage` entrava no serviço de ranking como `unknown` vindo do Firestore. A fronteira foi corrigida com normalização explícita de média, contadores, totais e timestamps antes da composição do score.

A correção fortaleceu a tipagem e não alterou os pesos ou a fórmula definida neste PR.

## Validação concluída

- lint das Functions: aprovado;
- build das Functions: aprovado;
- testes das Functions, incluindo ranking, retenção e recência: aprovado;
- testes Angular: aprovado;
- build Angular seguro: aprovado;
- testes das Firestore Rules: aprovado;
- validação dos índices do Firestore: aprovado;
- Quality Gate agregado: aprovado.

A execução separada `Angular CI Validation` não foi acionada neste head, que altera somente arquivos de Functions. A validação Angular obrigatória permaneceu coberta pelos jobs de testes e build seguro do Quality Gate.