### PR TITLE
feat(media): proteger emissão de URLs e listagens

### DIFF
--- a/functions/src/media/application/get-private-video-access-urls.handler.ts
+++ b/functions/src/media/application/get-private-video-access-urls.handler.ts
@@ -1,6 +1,9 @@
 import * as logger from 'firebase-functions/logger';
 import { HttpsError, onCall } from 'firebase-functions/v2/https';
 
+import {
+  assertInteractionAccess,
+} from '../../account_lifecycle/interaction-access.policy';
 import { FUNCTIONS_REGION } from '../../config/functions-region';
 import { db, storage } from '../../firebaseApp';
 import { createTemporaryStorageReadUrl } from './temporary-storage-read-url.service';
@@ -147,6 +150,12 @@ export const getPrivateVideoAccessUrls = onCall<PrivateVideoAccessRequest>(
         'Você só pode acessar os vídeos do próprio perfil.'
       );
     }
+
+    /**
+     * Conteúdo adulto privado continua sujeito a lifecycle e revalidação de
+     * idade. Restrições não impedem exclusão ou suporte, apenas o playback.
+     */
+    await assertInteractionAccess(requesterUid);
 
     const rawVideoIds = Array.isArray(request.data?.videoIds)
       ? request.data.videoIds

--- a/functions/src/media/application/get-public-photo-access-urls.handler.ts
+++ b/functions/src/media/application/get-public-photo-access-urls.handler.ts
@@ -8,6 +8,10 @@ import {
   normalizeOwnedPublishedPhotoPath,
 } from './photo-storage-path';
 import { createTemporaryStorageReadUrl } from './temporary-storage-read-url.service';
+import {
+  createVideoAudienceAccessEvaluator,
+  type VideoAudienceAccessEvaluator,
+} from './video-audience-access.policy';
 
 interface PublicPhotoAccessRequestItem {
   ownerUid?: string;
@@ -52,11 +56,16 @@ function cleanId(value: unknown): string {
   return normalized;
 }
 
+function normalizeEnum(value: unknown): string {
+  return String(value ?? '').trim().toUpperCase();
+}
+
 function buildRequestKey(ownerUid: string, photoId: string): string {
   return `${ownerUid}:${photoId}`;
 }
 
 async function resolveAccessItem(
+  audience: VideoAudienceAccessEvaluator,
   ownerUid: string,
   photoId: string,
   expiresAt: number
@@ -85,12 +94,40 @@ async function resolveAccessItem(
 
   const publicPhoto = publicPhotoSnap.data();
   const publication = publicationSnap.data();
+  const projectionVisibility = normalizeEnum(publicPhoto?.visibility);
+  const publicationVisibility = normalizeEnum(publication?.visibility);
+  const projectionModeration = normalizeEnum(publicPhoto?.moderationStatus);
+  const publicationModeration = normalizeEnum(publication?.moderationStatus);
 
+  /**
+   * A projeção pública não autoriza acesso isoladamente. Identidade, tipo,
+   * estratégia de ativo, visibilidade e moderação precisam coincidir com a
+   * publicação canônica antes da avaliação de audiência.
+   */
   if (
-    publicPhoto?.visibility !== 'PUBLIC' ||
-    publicPhoto?.moderationStatus !== 'APPROVED' ||
-    publication?.isPublished !== true
+    cleanId(publicPhoto?.id) !== photoId ||
+    cleanId(publicPhoto?.ownerUid) !== ownerUid ||
+    cleanId(publication?.photoId) !== photoId ||
+    cleanId(publication?.ownerUid) !== ownerUid ||
+    normalizeEnum(publicPhoto?.mediaType) !== 'PHOTO' ||
+    normalizeEnum(publicPhoto?.assetAccess) !== 'SIGNED_URL' ||
+    !projectionVisibility ||
+    projectionVisibility !== publicationVisibility ||
+    !projectionModeration ||
+    projectionModeration !== publicationModeration
   ) {
+    return null;
+  }
+
+  const audienceDecision = await audience.evaluate({
+    ownerUid,
+    action: 'PLAY',
+    visibility: publicationVisibility,
+    isPublished: publication?.isPublished === true,
+    moderationStatus: publicationModeration,
+  });
+
+  if (!audienceDecision.allowed) {
     return null;
   }
 
@@ -122,7 +159,9 @@ async function resolveAccessItem(
 export const getPublicPhotoAccessUrls = onCall<PublicPhotoAccessRequest>(
   { region: FUNCTIONS_REGION },
   async (request): Promise<PublicPhotoAccessResponse> => {
-    if (!request.auth?.uid) {
+    const viewerUid = cleanId(request.auth?.uid);
+
+    if (!viewerUid) {
       throw new HttpsError('unauthenticated', 'Usuário não autenticado.');
     }
 
@@ -163,13 +202,19 @@ export const getPublicPhotoAccessUrls = onCall<PublicPhotoAccessRequest>(
       );
     }
 
+    const audience = await createVideoAudienceAccessEvaluator(viewerUid);
     const expiresAt = Date.now() + SIGNED_URL_TTL_MS;
     const resolutions = await Promise.all(
       [...uniqueItems.values()].map(
         async ({ ownerUid, photoId }): Promise<PublicPhotoAccessResolution> => {
           try {
             return {
-              item: await resolveAccessItem(ownerUid, photoId, expiresAt),
+              item: await resolveAccessItem(
+                audience,
+                ownerUid,
+                photoId,
+                expiresAt
+              ),
               technicalFailure: false,
             };
           } catch (error) {

--- a/functions/src/media/application/get-public-photo-access-urls.handler.ts
+++ b/functions/src/media/application/get-public-photo-access-urls.handler.ts
@@ -4,6 +4,11 @@ import { HttpsError, onCall } from 'firebase-functions/v2/https';
 import { FUNCTIONS_REGION } from '../../config/functions-region';
 import { db, storage } from '../../firebaseApp';
 import {
+  resolveCanonicalPhotoAudienceTarget,
+  type PhotoPublicationAudienceDocument,
+  type PublicPhotoAudienceDocument,
+} from './photo-audience-access.policy';
+import {
   containsControlCharacter,
   normalizeOwnedPublishedPhotoPath,
 } from './photo-storage-path';
@@ -56,10 +61,6 @@ function cleanId(value: unknown): string {
   return normalized;
 }
 
-function normalizeEnum(value: unknown): string {
-  return String(value ?? '').trim().toUpperCase();
-}
-
 function buildRequestKey(ownerUid: string, photoId: string): string {
   return `${ownerUid}:${photoId}`;
 }
@@ -92,40 +93,24 @@ async function resolveAccessItem(
     return null;
   }
 
-  const publicPhoto = publicPhotoSnap.data();
-  const publication = publicationSnap.data();
-  const projectionVisibility = normalizeEnum(publicPhoto?.visibility);
-  const publicationVisibility = normalizeEnum(publication?.visibility);
-  const projectionModeration = normalizeEnum(publicPhoto?.moderationStatus);
-  const publicationModeration = normalizeEnum(publication?.moderationStatus);
+  const publicPhoto =
+    publicPhotoSnap.data() as PublicPhotoAudienceDocument;
+  const publication =
+    publicationSnap.data() as PhotoPublicationAudienceDocument & {
+      publishedStoragePath?: unknown;
+    };
+  const target = resolveCanonicalPhotoAudienceTarget({
+    ownerUid,
+    photoId,
+    publicPhoto,
+    publication,
+  });
 
-  /**
-   * A projeção pública não autoriza acesso isoladamente. Identidade, tipo,
-   * estratégia de ativo, visibilidade e moderação precisam coincidir com a
-   * publicação canônica antes da avaliação de audiência.
-   */
-  if (
-    cleanId(publicPhoto?.id) !== photoId ||
-    cleanId(publicPhoto?.ownerUid) !== ownerUid ||
-    cleanId(publication?.photoId) !== photoId ||
-    cleanId(publication?.ownerUid) !== ownerUid ||
-    normalizeEnum(publicPhoto?.mediaType) !== 'PHOTO' ||
-    normalizeEnum(publicPhoto?.assetAccess) !== 'SIGNED_URL' ||
-    !projectionVisibility ||
-    projectionVisibility !== publicationVisibility ||
-    !projectionModeration ||
-    projectionModeration !== publicationModeration
-  ) {
+  if (!target) {
     return null;
   }
 
-  const audienceDecision = await audience.evaluate({
-    ownerUid,
-    action: 'PLAY',
-    visibility: publicationVisibility,
-    isPublished: publication?.isPublished === true,
-    moderationStatus: publicationModeration,
-  });
+  const audienceDecision = await audience.evaluate(target);
 
   if (!audienceDecision.allowed) {
     return null;
@@ -134,7 +119,7 @@ async function resolveAccessItem(
   const storagePath = normalizeOwnedPublishedPhotoPath(
     ownerUid,
     photoId,
-    publication?.publishedStoragePath
+    publication.publishedStoragePath
   );
 
   if (!storagePath) {

--- a/functions/src/media/application/media-callable-rate-limit.policy.test.ts
+++ b/functions/src/media/application/media-callable-rate-limit.policy.test.ts
@@ -13,11 +13,20 @@ describe('media-callable-rate-limit.policy', () => {
     const moderation = resolveMediaCallableRateLimitRule(
       'COMMENT_MODERATE'
     );
+    const publicAccess = resolveMediaCallableRateLimitRule('ACCESS_PUBLIC');
+    const privateAccess = resolveMediaCallableRateLimitRule('ACCESS_PRIVATE');
+    const listPublic = resolveMediaCallableRateLimitRule('LIST_PUBLIC');
 
     assert.ok(reaction.globalMaxPerWindow > reaction.resourceMaxPerWindow);
     assert.ok(report.windowMs > reaction.windowMs);
     assert.ok(
       moderation.globalMaxPerWindow > reaction.globalMaxPerWindow
+    );
+    assert.ok(
+      privateAccess.globalMaxPerWindow > publicAccess.globalMaxPerWindow
+    );
+    assert.ok(
+      listPublic.globalMaxPerWindow > publicAccess.globalMaxPerWindow
     );
   });
 
@@ -36,6 +45,39 @@ describe('media-callable-rate-limit.policy', () => {
       count: 1,
       lastAcceptedAt: 10_000,
     });
+  });
+
+  it('cobra operações em lote pelo número de itens', () => {
+    const decision = buildMediaCallableRateDecision({
+      now: 10_000,
+      state: null,
+      maxPerWindow: 100,
+      windowMs: 60_000,
+      minIntervalMs: 0,
+      cost: 32,
+    });
+
+    assert.equal(decision.allowed, true);
+    assert.equal(decision.nextState.count, 32);
+  });
+
+  it('bloqueia um lote que ultrapassaria o saldo da janela', () => {
+    const decision = buildMediaCallableRateDecision({
+      now: 20_000,
+      state: {
+        windowStartedAt: 10_000,
+        count: 90,
+        lastAcceptedAt: 10_000,
+      },
+      maxPerWindow: 100,
+      windowMs: 60_000,
+      minIntervalMs: 0,
+      cost: 16,
+    });
+
+    assert.equal(decision.allowed, false);
+    assert.equal(decision.retryAfterMs, 50_000);
+    assert.equal(decision.nextState.count, 90);
   });
 
   it('bloqueia rajadas até cumprir o intervalo mínimo', () => {
@@ -73,7 +115,7 @@ describe('media-callable-rate-limit.policy', () => {
     assert.equal(decision.retryAfterMs, 40_000);
   });
 
-  it('reinicia a janela expirada', () => {
+  it('reinicia a janela expirada e aplica o custo atual', () => {
     const decision = buildMediaCallableRateDecision({
       now: 80_000,
       state: {
@@ -81,15 +123,16 @@ describe('media-callable-rate-limit.policy', () => {
         count: 99,
         lastAcceptedAt: 20_000,
       },
-      maxPerWindow: 3,
+      maxPerWindow: 20,
       windowMs: 60_000,
       minIntervalMs: 1_000,
+      cost: 12,
     });
 
     assert.equal(decision.allowed, true);
     assert.deepEqual(decision.nextState, {
       windowStartedAt: 80_000,
-      count: 1,
+      count: 12,
       lastAcceptedAt: 80_000,
     });
   });

--- a/functions/src/media/application/media-callable-rate-limit.policy.ts
+++ b/functions/src/media/application/media-callable-rate-limit.policy.ts
@@ -6,7 +6,10 @@ export type MediaCallableRateAction =
   | 'REPORT'
   | 'REPORT_MODERATE'
   | 'SHARE_AUTHORIZE'
-  | 'SHARE_MESSAGE';
+  | 'SHARE_MESSAGE'
+  | 'ACCESS_PRIVATE'
+  | 'ACCESS_PUBLIC'
+  | 'LIST_PUBLIC';
 
 export interface MediaCallableRateLimitRule {
   readonly windowMs: number;
@@ -27,6 +30,7 @@ export interface MediaCallableRateDecisionInput {
   readonly maxPerWindow: number;
   readonly windowMs: number;
   readonly minIntervalMs: number;
+  readonly cost?: number;
 }
 
 export interface MediaCallableRateDecision {
@@ -90,6 +94,24 @@ const RULES: Readonly<Record<
     resourceMaxPerWindow: 12,
     minIntervalMs: 500,
   },
+  ACCESS_PRIVATE: {
+    windowMs: TEN_MINUTES_MS,
+    globalMaxPerWindow: 600,
+    resourceMaxPerWindow: 120,
+    minIntervalMs: 150,
+  },
+  ACCESS_PUBLIC: {
+    windowMs: TEN_MINUTES_MS,
+    globalMaxPerWindow: 480,
+    resourceMaxPerWindow: 96,
+    minIntervalMs: 100,
+  },
+  LIST_PUBLIC: {
+    windowMs: TEN_MINUTES_MS,
+    globalMaxPerWindow: 960,
+    resourceMaxPerWindow: 640,
+    minIntervalMs: 150,
+  },
 };
 
 function normalizeNonNegativeInteger(value: unknown): number {
@@ -119,6 +141,7 @@ export function buildMediaCallableRateDecision(
     normalizeNonNegativeInteger(input.windowMs)
   );
   const minIntervalMs = normalizeNonNegativeInteger(input.minIntervalMs);
+  const cost = Math.max(1, normalizeNonNegativeInteger(input.cost));
   const previousWindowStartedAt = normalizeNonNegativeInteger(
     input.state?.windowStartedAt
   );
@@ -139,13 +162,13 @@ export function buildMediaCallableRateDecision(
     1_000,
     windowMs - Math.max(0, now - windowStartedAt)
   );
-  const reachedWindowLimit = count >= maxPerWindow;
-  const allowed = !reachedWindowLimit && intervalRemainingMs === 0;
+  const exceedsWindowLimit = count + cost > maxPerWindow;
+  const allowed = !exceedsWindowLimit && intervalRemainingMs === 0;
 
   if (!allowed) {
     return {
       allowed: false,
-      retryAfterMs: reachedWindowLimit
+      retryAfterMs: exceedsWindowLimit
         ? windowRemainingMs
         : Math.max(1_000, intervalRemainingMs),
       nextState: {
@@ -161,7 +184,7 @@ export function buildMediaCallableRateDecision(
     retryAfterMs: minIntervalMs,
     nextState: {
       windowStartedAt,
-      count: count + 1,
+      count: count + cost,
       lastAcceptedAt: now,
     },
   };

--- a/functions/src/media/application/media-callable-rate-limit.service.ts
+++ b/functions/src/media/application/media-callable-rate-limit.service.ts
@@ -17,11 +17,13 @@ import {
 const RATE_LIMIT_COLLECTION = 'media_callable_rate_limits';
 const RATE_LIMIT_RETENTION_MS = 24 * 60 * 60 * 1000;
 const CLEANUP_BATCH_LIMIT = 450;
+const MAX_RATE_LIMIT_COST = 1_000;
 
 export interface MediaCallableRateLimitInput {
   readonly actorUid: string;
   readonly action: MediaCallableRateAction;
   readonly resourceKey: string;
+  readonly cost?: number;
   readonly now?: number;
 }
 
@@ -33,6 +35,16 @@ function cleanActorUid(value: unknown): string {
 function cleanResourceKey(value: unknown): string {
   const normalized = String(value ?? '').trim();
   return normalized && normalized.length <= 512 ? normalized : '';
+}
+
+function normalizeCost(value: unknown): number {
+  const numeric = Number(value ?? 1);
+
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return 1;
+  }
+
+  return Math.min(MAX_RATE_LIMIT_COST, Math.max(1, Math.floor(numeric)));
 }
 
 function hashKey(value: string): string {
@@ -79,9 +91,9 @@ function throwRateLimit(
 /**
  * Consome limites global e por recurso em uma transação Firestore.
  *
- * Casos de uso podem chamar esta função dentro da própria transação, depois
- * das demais leituras, ou utilizar `assertMediaCallableRateLimit` como barreira
- * prévia para proteger consultas e validações mais caras.
+ * `cost` permite que operações em lote sejam cobradas pela quantidade de itens
+ * processados, impedindo que lotes máximos tenham o mesmo peso de uma ação
+ * unitária. Chamadores sem custo explícito preservam o comportamento anterior.
  */
 export async function assertMediaCallableRateLimitInTransaction(
   transaction: Transaction,
@@ -101,6 +113,7 @@ export async function assertMediaCallableRateLimitInTransaction(
   const now = Number.isFinite(requestedNow) && requestedNow > 0
     ? Math.floor(requestedNow)
     : Date.now();
+  const cost = normalizeCost(input.cost);
   const rule = resolveMediaCallableRateLimitRule(input.action);
   const globalRef = rateLimitRef(
     'global',
@@ -124,6 +137,7 @@ export async function assertMediaCallableRateLimitInTransaction(
     maxPerWindow: rule.globalMaxPerWindow,
     windowMs: rule.windowMs,
     minIntervalMs: rule.minIntervalMs,
+    cost,
   });
   const resourceDecision = buildMediaCallableRateDecision({
     now,
@@ -131,6 +145,7 @@ export async function assertMediaCallableRateLimitInTransaction(
     maxPerWindow: rule.resourceMaxPerWindow,
     windowMs: rule.windowMs,
     minIntervalMs: rule.minIntervalMs,
+    cost,
   });
 
   if (!globalDecision.allowed || !resourceDecision.allowed) {
@@ -147,6 +162,7 @@ export async function assertMediaCallableRateLimitInTransaction(
     scope: 'global',
     actorUid,
     action: input.action,
+    lastCost: cost,
     ...globalDecision.nextState,
     updatedAt: now,
   });
@@ -155,6 +171,7 @@ export async function assertMediaCallableRateLimitInTransaction(
     actorUid,
     action: input.action,
     resourceHash: hashKey(resourceKey),
+    lastCost: cost,
     ...resourceDecision.nextState,
     updatedAt: now,
   });

--- a/functions/src/media/application/photo-audience-access.policy.test.ts
+++ b/functions/src/media/application/photo-audience-access.policy.test.ts
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  resolveCanonicalPhotoAudienceTarget,
+} from './photo-audience-access.policy';
+
+function canonicalInput() {
+  return {
+    ownerUid: 'owner-1',
+    photoId: 'photo-1',
+    publicPhoto: {
+      id: 'photo-1',
+      ownerUid: 'owner-1',
+      mediaType: 'PHOTO',
+      assetAccess: 'SIGNED_URL',
+      visibility: 'FRIENDS',
+      moderationStatus: 'APPROVED',
+    },
+    publication: {
+      ownerUid: 'owner-1',
+      photoId: 'photo-1',
+      isPublished: true,
+      visibility: 'FRIENDS',
+      moderationStatus: 'APPROVED',
+    },
+  };
+}
+
+describe('photo-audience-access.policy', () => {
+  it('resolve publicação canônica sem reduzir a visibilidade a PUBLIC', () => {
+    assert.deepEqual(
+      resolveCanonicalPhotoAudienceTarget(canonicalInput()),
+      {
+        ownerUid: 'owner-1',
+        action: 'PLAY',
+        visibility: 'FRIENDS',
+        isPublished: true,
+        moderationStatus: 'APPROVED',
+      }
+    );
+  });
+
+  it('fecha o acesso quando projeção e publicação divergem', () => {
+    const input = canonicalInput();
+    input.publication.visibility = 'PUBLIC';
+
+    assert.equal(resolveCanonicalPhotoAudienceTarget(input), null);
+  });
+
+  it('fecha o acesso para identidade, tipo ou estratégia de ativo inválidos', () => {
+    const wrongOwner = canonicalInput();
+    wrongOwner.publicPhoto.ownerUid = 'other-owner';
+    assert.equal(resolveCanonicalPhotoAudienceTarget(wrongOwner), null);
+
+    const wrongType = canonicalInput();
+    wrongType.publicPhoto.mediaType = 'VIDEO';
+    assert.equal(resolveCanonicalPhotoAudienceTarget(wrongType), null);
+
+    const permanentUrl = canonicalInput();
+    permanentUrl.publicPhoto.assetAccess = 'PUBLIC_URL';
+    assert.equal(resolveCanonicalPhotoAudienceTarget(permanentUrl), null);
+  });
+
+  it('mantém isPublished no alvo para a política de audiência negar', () => {
+    const input = canonicalInput();
+    input.publication.isPublished = false;
+
+    assert.equal(
+      resolveCanonicalPhotoAudienceTarget(input)?.isPublished,
+      false
+    );
+  });
+});

--- a/functions/src/media/application/photo-audience-access.policy.ts
+++ b/functions/src/media/application/photo-audience-access.policy.ts
@@ -1,0 +1,82 @@
+import type {
+  VideoAudienceAccessTarget,
+} from './video-audience-access.policy';
+
+export interface PublicPhotoAudienceDocument {
+  id?: unknown;
+  ownerUid?: unknown;
+  mediaType?: unknown;
+  assetAccess?: unknown;
+  visibility?: unknown;
+  moderationStatus?: unknown;
+}
+
+export interface PhotoPublicationAudienceDocument {
+  ownerUid?: unknown;
+  photoId?: unknown;
+  isPublished?: unknown;
+  visibility?: unknown;
+  moderationStatus?: unknown;
+}
+
+function cleanId(value: unknown): string {
+  const normalized = String(value ?? '').trim();
+
+  return normalized &&
+    normalized.length <= 128 &&
+    !normalized.includes('/')
+    ? normalized
+    : '';
+}
+
+function normalizeEnum(value: unknown): string {
+  return String(value ?? '').trim().toUpperCase();
+}
+
+/**
+ * Resolve a projeção pública e a publicação privada como um único alvo.
+ * Qualquer divergência fecha o acesso antes de consultar relações ou emitir URL.
+ */
+export function resolveCanonicalPhotoAudienceTarget(params: {
+  ownerUid: unknown;
+  photoId: unknown;
+  publicPhoto: PublicPhotoAudienceDocument | null | undefined;
+  publication: PhotoPublicationAudienceDocument | null | undefined;
+}): VideoAudienceAccessTarget | null {
+  const ownerUid = cleanId(params.ownerUid);
+  const photoId = cleanId(params.photoId);
+  const publicPhoto = params.publicPhoto;
+  const publication = params.publication;
+
+  if (!ownerUid || !photoId || !publicPhoto || !publication) {
+    return null;
+  }
+
+  const projectionVisibility = normalizeEnum(publicPhoto.visibility);
+  const publicationVisibility = normalizeEnum(publication.visibility);
+  const projectionModeration = normalizeEnum(publicPhoto.moderationStatus);
+  const publicationModeration = normalizeEnum(publication.moderationStatus);
+
+  if (
+    cleanId(publicPhoto.id) !== photoId ||
+    cleanId(publicPhoto.ownerUid) !== ownerUid ||
+    cleanId(publication.photoId) !== photoId ||
+    cleanId(publication.ownerUid) !== ownerUid ||
+    normalizeEnum(publicPhoto.mediaType) !== 'PHOTO' ||
+    normalizeEnum(publicPhoto.assetAccess) !== 'SIGNED_URL' ||
+    !projectionVisibility ||
+    projectionVisibility !== publicationVisibility ||
+    !projectionModeration ||
+    projectionModeration !== publicationModeration
+  ) {
+    return null;
+  }
+
+  return {
+    ownerUid,
+    action: 'PLAY',
+    visibility: publicationVisibility,
+    isPublished: publication.isPublished === true,
+    moderationStatus: publicationModeration,
+  };
+}

--- a/functions/src/media/application/protected-media-access-callables.handler.ts
+++ b/functions/src/media/application/protected-media-access-callables.handler.ts
@@ -1,0 +1,209 @@
+import { createHash } from 'node:crypto';
+
+import { onCall } from 'firebase-functions/v2/https';
+
+import { PROTECTED_CALLABLE_OPTIONS } from '../../config/protected-callable-options';
+import {
+  getPrivateVideoAccessUrls as getPrivateVideoAccessUrlsCore,
+} from './get-private-video-access-urls.handler';
+import {
+  getPublicPhotoAccessUrls as getPublicPhotoAccessUrlsCore,
+} from './get-public-photo-access-urls.handler';
+import {
+  getPublicVideoAccessUrls as getPublicVideoAccessUrlsCore,
+} from './get-public-video-access-urls.handler';
+import {
+  listAuthorizedPublicVideos as listAuthorizedPublicVideosCore,
+} from './list-authorized-public-videos.handler';
+import {
+  assertMediaCallableRateLimit,
+} from './media-callable-rate-limit.service';
+
+interface PrivateVideoAccessRequest {
+  ownerUid?: string;
+  videoIds?: string[];
+}
+
+interface PublicPhotoAccessRequestItem {
+  ownerUid?: string;
+  photoId?: string;
+}
+
+interface PublicPhotoAccessRequest {
+  items?: PublicPhotoAccessRequestItem[];
+}
+
+interface PublicVideoAccessRequestItem {
+  ownerUid?: string;
+  videoId?: string;
+}
+
+interface PublicVideoAccessRequest {
+  items?: PublicVideoAccessRequestItem[];
+}
+
+interface RankingCursor {
+  mode: 'top' | 'latest';
+  score: number;
+  uniqueViewersCount: number;
+  viewsCount: number;
+  publishedAt: number;
+  documentPath: string;
+}
+
+interface RankingRequest {
+  mode?: unknown;
+  pageSize?: unknown;
+  cursor?: Partial<RankingCursor> | null;
+}
+
+const MAX_PRIVATE_VIDEO_ITEMS = 60;
+const MAX_PUBLIC_PHOTO_ITEMS = 32;
+const MAX_PUBLIC_VIDEO_ITEMS = 16;
+const DEFAULT_PAGE_SIZE = 12;
+const MAX_PAGE_SIZE = 16;
+
+function cleanId(value: unknown): string {
+  const normalized = String(value ?? '').trim();
+  return /^[A-Za-z0-9_-]{1,128}$/.test(normalized) ? normalized : '';
+}
+
+function fingerprint(parts: string[]): string {
+  const normalized = parts.filter(Boolean).sort();
+  const payload = normalized.length ? normalized.join('|') : 'invalid';
+  return createHash('sha256').update(payload).digest('hex');
+}
+
+function boundedRawCost(value: unknown, max: number): number {
+  return Array.isArray(value)
+    ? Math.max(1, Math.min(max, value.length))
+    : 1;
+}
+
+function privateVideoFingerprint(request: PrivateVideoAccessRequest): string {
+  const ownerUid = cleanId(request.ownerUid) || 'invalid-owner';
+  const videoIds = Array.isArray(request.videoIds)
+    ? [...new Set(request.videoIds.map(cleanId).filter(Boolean))]
+    : [];
+
+  return `private-video:${ownerUid}:${fingerprint(videoIds)}`;
+}
+
+function publicPhotoFingerprint(request: PublicPhotoAccessRequest): string {
+  const items = Array.isArray(request.items) ? request.items : [];
+  const keys = items.flatMap((item) => {
+    const ownerUid = cleanId(item?.ownerUid);
+    const photoId = cleanId(item?.photoId);
+    return ownerUid && photoId ? [`${ownerUid}:${photoId}`] : [];
+  });
+
+  return `public-photo:${fingerprint([...new Set(keys)])}`;
+}
+
+function publicVideoFingerprint(request: PublicVideoAccessRequest): string {
+  const items = Array.isArray(request.items) ? request.items : [];
+  const keys = items.flatMap((item) => {
+    const ownerUid = cleanId(item?.ownerUid);
+    const videoId = cleanId(item?.videoId);
+    return ownerUid && videoId ? [`${ownerUid}:${videoId}`] : [];
+  });
+
+  return `public-video:${fingerprint([...new Set(keys)])}`;
+}
+
+function normalizePageSize(value: unknown): number {
+  const numeric = Number(value ?? DEFAULT_PAGE_SIZE);
+
+  return Number.isFinite(numeric)
+    ? Math.max(1, Math.min(MAX_PAGE_SIZE, Math.trunc(numeric)))
+    : DEFAULT_PAGE_SIZE;
+}
+
+function normalizeMode(value: unknown): 'top' | 'latest' {
+  return String(value ?? '').trim().toLowerCase() === 'top'
+    ? 'top'
+    : 'latest';
+}
+
+export const getPrivateVideoAccessUrls = onCall<PrivateVideoAccessRequest>(
+  PROTECTED_CALLABLE_OPTIONS,
+  async (request) => {
+    const actorUid = cleanId(request.auth?.uid);
+
+    if (actorUid) {
+      await assertMediaCallableRateLimit({
+        actorUid,
+        action: 'ACCESS_PRIVATE',
+        resourceKey: privateVideoFingerprint(request.data ?? {}),
+        cost: boundedRawCost(
+          request.data?.videoIds,
+          MAX_PRIVATE_VIDEO_ITEMS
+        ),
+      });
+    }
+
+    return getPrivateVideoAccessUrlsCore.run(request);
+  }
+);
+
+export const getPublicPhotoAccessUrls = onCall<PublicPhotoAccessRequest>(
+  PROTECTED_CALLABLE_OPTIONS,
+  async (request) => {
+    const actorUid = cleanId(request.auth?.uid);
+
+    if (actorUid) {
+      await assertMediaCallableRateLimit({
+        actorUid,
+        action: 'ACCESS_PUBLIC',
+        resourceKey: publicPhotoFingerprint(request.data ?? {}),
+        cost: boundedRawCost(
+          request.data?.items,
+          MAX_PUBLIC_PHOTO_ITEMS
+        ),
+      });
+    }
+
+    return getPublicPhotoAccessUrlsCore.run(request);
+  }
+);
+
+export const getPublicVideoAccessUrls = onCall<PublicVideoAccessRequest>(
+  PROTECTED_CALLABLE_OPTIONS,
+  async (request) => {
+    const actorUid = cleanId(request.auth?.uid);
+
+    if (actorUid) {
+      await assertMediaCallableRateLimit({
+        actorUid,
+        action: 'ACCESS_PUBLIC',
+        resourceKey: publicVideoFingerprint(request.data ?? {}),
+        cost: boundedRawCost(
+          request.data?.items,
+          MAX_PUBLIC_VIDEO_ITEMS
+        ),
+      });
+    }
+
+    return getPublicVideoAccessUrlsCore.run(request);
+  }
+);
+
+export const listAuthorizedPublicVideos = onCall<RankingRequest>(
+  PROTECTED_CALLABLE_OPTIONS,
+  async (request) => {
+    const actorUid = cleanId(request.auth?.uid);
+    const mode = normalizeMode(request.data?.mode);
+    const pageSize = normalizePageSize(request.data?.pageSize);
+
+    if (actorUid) {
+      await assertMediaCallableRateLimit({
+        actorUid,
+        action: 'LIST_PUBLIC',
+        resourceKey: `public-video-feed:${mode}`,
+        cost: pageSize,
+      });
+    }
+
+    return listAuthorizedPublicVideosCore.run(request);
+  }
+);

--- a/functions/src/media/application/video-view-session.policy.test.ts
+++ b/functions/src/media/application/video-view-session.policy.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
 import './media-callable-rate-limit.policy.test';
+import './photo-audience-access.policy.test';
 import {
   VIDEO_VIEW_SESSION_MIN_INTERVAL_MS,
   VIDEO_VIEW_SESSION_RATE_WINDOW_MS,

--- a/functions/src/media/index.ts
+++ b/functions/src/media/index.ts
@@ -13,6 +13,13 @@ export {
 } from './application/protected-media-callables.handler';
 
 export {
+  getPrivateVideoAccessUrls,
+  getPublicPhotoAccessUrls,
+  getPublicVideoAccessUrls,
+  listAuthorizedPublicVideos,
+} from './application/protected-media-access-callables.handler';
+
+export {
   cleanupMediaCallableRateLimits,
 } from './application/media-callable-rate-limit.service';
 
@@ -99,21 +106,6 @@ export {
 export {
   cleanupPendingPublishedVideoAssets,
 } from './application/cleanup-published-video-assets.handler';
-
-export {
-  getPrivateVideoAccessUrls,
-} from './application/get-private-video-access-urls.handler';
-
-export {
-  getPublicPhotoAccessUrls,
-} from './application/get-public-photo-access-urls.handler';
-
-export {
-  getPublicVideoAccessUrls,
-} from './application/get-public-video-access-urls.handler';
-export {
-  listAuthorizedPublicVideos,
-} from './application/list-authorized-public-videos.handler';
 
 export {
   issueVideoViewSession,


### PR DESCRIPTION
## Dependência

PR empilhado sobre o #54 (`agent/media-p0-mutation-app-check-rate-limit`). O diff contém somente o pacote P0 de proteção da emissão de URLs temporárias e listagens públicas.

## Callables protegidas

A raiz passa a exportar versões com App Check de:

- `getPrivateVideoAccessUrls`;
- `getPublicPhotoAccessUrls`;
- `getPublicVideoAccessUrls`;
- `listAuthorizedPublicVideos`.

Os nomes públicos e os contratos de request/response foram preservados. O Emulator Suite mantém a exceção controlada definida no #53.

## Rate limiting ponderado

O limitador central agora aceita `cost`, mantendo custo padrão 1 para todas as callables já protegidas.

Operações em lote passam a consumir unidades pela quantidade solicitada:

- vídeos privados: até 60 unidades por chamada;
- fotos publicadas: até 32 unidades por chamada;
- vídeos publicados: até 16 unidades por chamada;
- listagem de vídeos: custo igual ao `pageSize`, entre 1 e 16.

Isso impede que um lote máximo tenha o mesmo peso de uma consulta unitária.

### Limites adicionados

- `ACCESS_PRIVATE`: 600 itens por 10 minutos no total, 120 por fingerprint de lote, intervalo mínimo de 150 ms;
- `ACCESS_PUBLIC`: 480 itens por 10 minutos no total, 96 por fingerprint de lote, intervalo mínimo de 100 ms;
- `LIST_PUBLIC`: 960 itens por 10 minutos no total, 640 por modo de ranking, intervalo mínimo de 150 ms.

Fotos e vídeos publicados compartilham `ACCESS_PUBLIC`, impedindo contorno ao alternar o tipo de mídia.

## Fingerprints e minimização de dados

- fingerprints de lotes são derivados por SHA-256;
- documentos de rate limit continuam usando IDs SHA-256;
- a chave bruta do lote não é persistida;
- somente o hash do recurso, custo e estado da janela são armazenados;
- retenção continua limitada a 24 horas de inatividade.

## Audiência de fotos

Foi criada `photo-audience-access.policy.ts` para resolver projeção pública e publicação canônica antes de emitir URL.

A política fecha o acesso quando houver divergência de proprietário, identificador, tipo de mídia, estratégia de ativo, visibilidade ou moderação.

Após resolver o alvo canônico, a política central revalida lifecycle, idade, publicação, moderação, bloqueio bilateral, amizade, compatibilidade e entitlement de assinante ou premium.

A correção também permite fotos `FRIENDS`, `SUBSCRIBERS` e `PREMIUM` quando o visitante possui audiência válida; o comportamento anterior aceitava somente `PUBLIC` e não verificava relações.

## Playback privado

`getPrivateVideoAccessUrls` agora exige lifecycle operacional antes de assinar vídeos privados do próprio usuário.

Uma conta suspensa, bloqueada para interação ou aguardando revalidação de idade não recebe URL de playback. Isso não altera exclusão, retenção ou suporte; a restrição se aplica apenas ao acesso ao conteúdo adulto.

## Supressões e substituições intencionais

### Exportações diretas dos handlers de acesso

Foram suprimidas na raiz as exportações diretas de:

- `get-private-video-access-urls.handler.ts`;
- `get-public-photo-access-urls.handler.ts`;
- `get-public-video-access-urls.handler.ts`;
- `list-authorized-public-videos.handler.ts`.

Elas foram substituídas por `protected-media-access-callables.handler.ts`, que aplica App Check e rate limiting antes de delegar aos mesmos handlers de domínio. Nenhum handler de domínio foi removido.

### Validação inline das fotos

Foi suprimida a validação canônica embutida diretamente em `get-public-photo-access-urls.handler.ts`.

Ela foi substituída pela política pura e testável `resolveCanonicalPhotoAudienceTarget`.

## Compatibilidade

- nenhum componente ou serviço Angular foi alterado;
- nomes públicos e respostas foram mantidos;
- URLs públicas continuam com TTL de 5 minutos;
- URLs privadas continuam com TTL de 10 minutos;
- nenhuma URL permanente foi introduzida;
- tratamento de erros continua centralizado no frontend.

## Validação concluída

- lint das Functions: aprovado;
- build das Functions: aprovado;
- testes das Functions: aprovado;
- política ponderada de rate limiting: aprovada;
- política canônica de audiência de fotos: aprovada;
- testes Angular: aprovado;
- build Angular seguro: aprovado;
- Firestore Rules: aprovado;
- índices do Firestore: aprovado;
- Quality Gate agregado: aprovado.

O primeiro head passou integralmente sem correções de CI. A execução separada `Angular CI Validation` não foi acionada porque o diff final altera somente Functions; Angular permaneceu coberto pelo Quality Gate obrigatório.