### PR TITLE
feat(media): proteger ciclo de vida e idempotência

### DIFF
--- a/functions/src/media/application/media-callable-rate-limit.policy.test.ts
+++ b/functions/src/media/application/media-callable-rate-limit.policy.test.ts
@@ -16,6 +16,9 @@ describe('media-callable-rate-limit.policy', () => {
     const publicAccess = resolveMediaCallableRateLimitRule('ACCESS_PUBLIC');
     const privateAccess = resolveMediaCallableRateLimitRule('ACCESS_PRIVATE');
     const listPublic = resolveMediaCallableRateLimitRule('LIST_PUBLIC');
+    const upload = resolveMediaCallableRateLimitRule('UPLOAD_REGISTER');
+    const publish = resolveMediaCallableRateLimitRule('MEDIA_PUBLISH');
+    const deletion = resolveMediaCallableRateLimitRule('MEDIA_DELETE');
 
     assert.ok(reaction.globalMaxPerWindow > reaction.resourceMaxPerWindow);
     assert.ok(report.windowMs > reaction.windowMs);
@@ -28,6 +31,9 @@ describe('media-callable-rate-limit.policy', () => {
     assert.ok(
       listPublic.globalMaxPerWindow > publicAccess.globalMaxPerWindow
     );
+    assert.equal(upload.windowMs, report.windowMs);
+    assert.equal(deletion.windowMs, report.windowMs);
+    assert.ok(upload.globalMaxPerWindow > publish.globalMaxPerWindow);
   });
 
   it('aceita a primeira operação e incrementa o estado', () => {

--- a/functions/src/media/application/media-callable-rate-limit.policy.ts
+++ b/functions/src/media/application/media-callable-rate-limit.policy.ts
@@ -9,7 +9,13 @@ export type MediaCallableRateAction =
   | 'SHARE_MESSAGE'
   | 'ACCESS_PRIVATE'
   | 'ACCESS_PUBLIC'
-  | 'LIST_PUBLIC';
+  | 'LIST_PUBLIC'
+  | 'UPLOAD_REGISTER'
+  | 'MEDIA_PUBLISH'
+  | 'MEDIA_UNPUBLISH'
+  | 'MEDIA_DELETE'
+  | 'MEDIA_SETTINGS'
+  | 'MEDIA_COVER';
 
 export interface MediaCallableRateLimitRule {
   readonly windowMs: number;
@@ -111,6 +117,42 @@ const RULES: Readonly<Record<
     globalMaxPerWindow: 960,
     resourceMaxPerWindow: 640,
     minIntervalMs: 150,
+  },
+  UPLOAD_REGISTER: {
+    windowMs: ONE_HOUR_MS,
+    globalMaxPerWindow: 300,
+    resourceMaxPerWindow: 60,
+    minIntervalMs: 1_000,
+  },
+  MEDIA_PUBLISH: {
+    windowMs: TEN_MINUTES_MS,
+    globalMaxPerWindow: 60,
+    resourceMaxPerWindow: 12,
+    minIntervalMs: 1_000,
+  },
+  MEDIA_UNPUBLISH: {
+    windowMs: TEN_MINUTES_MS,
+    globalMaxPerWindow: 90,
+    resourceMaxPerWindow: 15,
+    minIntervalMs: 500,
+  },
+  MEDIA_DELETE: {
+    windowMs: ONE_HOUR_MS,
+    globalMaxPerWindow: 120,
+    resourceMaxPerWindow: 10,
+    minIntervalMs: 1_000,
+  },
+  MEDIA_SETTINGS: {
+    windowMs: TEN_MINUTES_MS,
+    globalMaxPerWindow: 90,
+    resourceMaxPerWindow: 15,
+    minIntervalMs: 500,
+  },
+  MEDIA_COVER: {
+    windowMs: TEN_MINUTES_MS,
+    globalMaxPerWindow: 60,
+    resourceMaxPerWindow: 15,
+    minIntervalMs: 500,
   },
 };
 

--- a/functions/src/media/application/media-mutation-idempotency.policy.test.ts
+++ b/functions/src/media/application/media-mutation-idempotency.policy.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  hashMediaMutationRequest,
+  resolveUploadMutationCost,
+} from './media-mutation-idempotency.policy';
+
+describe('media-mutation-idempotency.policy', () => {
+  it('gera o mesmo fingerprint independentemente da ordem das chaves', () => {
+    const first = hashMediaMutationRequest({
+      ownerUid: 'owner',
+      videoId: 'video',
+      settings: { title: 'Título', commentsEnabled: true },
+    });
+    const second = hashMediaMutationRequest({
+      settings: { commentsEnabled: true, title: 'Título' },
+      videoId: 'video',
+      ownerUid: 'owner',
+    });
+
+    assert.equal(first, second);
+  });
+
+  it('diferencia operações com conteúdo efetivamente distinto', () => {
+    assert.notEqual(
+      hashMediaMutationRequest({ videoId: 'one' }),
+      hashMediaMutationRequest({ videoId: 'two' })
+    );
+  });
+
+  it('calcula custo de upload por blocos e respeita teto', () => {
+    const unit = 10 * 1024 * 1024;
+
+    assert.equal(resolveUploadMutationCost(1), 1);
+    assert.equal(resolveUploadMutationCost(unit), 1);
+    assert.equal(resolveUploadMutationCost(unit + 1), 2);
+    assert.equal(resolveUploadMutationCost(500 * 1024 * 1024), 50);
+    assert.equal(resolveUploadMutationCost(900 * 1024 * 1024), 50);
+  });
+
+  it('aplica custo conservador quando o tamanho não pode ser validado', () => {
+    assert.equal(resolveUploadMutationCost(null), 5);
+    assert.equal(resolveUploadMutationCost('inválido'), 5);
+  });
+});

--- a/functions/src/media/application/media-mutation-idempotency.policy.ts
+++ b/functions/src/media/application/media-mutation-idempotency.policy.ts
@@ -1,0 +1,83 @@
+import { createHash } from 'node:crypto';
+
+const DEFAULT_UPLOAD_COST_UNIT_BYTES = 10 * 1024 * 1024;
+const DEFAULT_UPLOAD_MAX_COST = 50;
+const DEFAULT_UPLOAD_FALLBACK_COST = 5;
+
+function stableValue(value: unknown): unknown {
+  if (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'boolean'
+  ) {
+    return value;
+  }
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => stableValue(item));
+  }
+
+  if (typeof value === 'object') {
+    const source = value as Record<string, unknown>;
+    const normalized: Record<string, unknown> = {};
+
+    Object.keys(source)
+      .sort()
+      .forEach((key) => {
+        const item = source[key];
+
+        if (item !== undefined && typeof item !== 'function') {
+          normalized[key] = stableValue(item);
+        }
+      });
+
+    return normalized;
+  }
+
+  return String(value ?? '');
+}
+
+export function hashMediaMutationRequest(value: unknown): string {
+  return createHash('sha256')
+    .update(JSON.stringify(stableValue(value)))
+    .digest('hex');
+}
+
+export function resolveUploadMutationCost(
+  sizeBytes: unknown,
+  options: {
+    unitBytes?: number;
+    maxCost?: number;
+    fallbackCost?: number;
+  } = {}
+): number {
+  const unitBytes = Math.max(
+    1,
+    Math.floor(options.unitBytes ?? DEFAULT_UPLOAD_COST_UNIT_BYTES)
+  );
+  const maxCost = Math.max(
+    1,
+    Math.floor(options.maxCost ?? DEFAULT_UPLOAD_MAX_COST)
+  );
+  const fallbackCost = Math.max(
+    1,
+    Math.min(
+      maxCost,
+      Math.floor(options.fallbackCost ?? DEFAULT_UPLOAD_FALLBACK_COST)
+    )
+  );
+  const normalizedSize = Number(sizeBytes ?? 0);
+
+  if (!Number.isFinite(normalizedSize) || normalizedSize <= 0) {
+    return fallbackCost;
+  }
+
+  return Math.max(
+    1,
+    Math.min(maxCost, Math.ceil(normalizedSize / unitBytes))
+  );
+}

--- a/functions/src/media/application/media-mutation-idempotency.service.ts
+++ b/functions/src/media/application/media-mutation-idempotency.service.ts
@@ -1,0 +1,191 @@
+import { logger } from 'firebase-functions';
+import { HttpsError } from 'firebase-functions/v2/https';
+import { onSchedule } from 'firebase-functions/v2/scheduler';
+
+import { FUNCTIONS_REGION } from '../../config/functions-region';
+import { db } from '../../firebaseApp';
+import { hashMediaMutationRequest } from './media-mutation-idempotency.policy';
+
+const IDEMPOTENCY_COLLECTION = 'media_mutation_idempotency';
+const OPERATION_LEASE_MS = 2 * 60 * 1000;
+const SUCCESS_CACHE_MS = 15 * 1000;
+const CLEANUP_BATCH_LIMIT = 450;
+
+export type MediaMutationAction =
+  | 'UPLOAD_REGISTER'
+  | 'PHOTO_PUBLISH'
+  | 'PHOTO_UNPUBLISH'
+  | 'PHOTO_SET_COVER'
+  | 'VIDEO_PUBLISH'
+  | 'VIDEO_UNPUBLISH'
+  | 'PHOTO_DELETE'
+  | 'VIDEO_DELETE'
+  | 'VIDEO_SETTINGS';
+
+interface MediaMutationIdempotencyInput<T> {
+  actorUid: string;
+  action: MediaMutationAction;
+  resourceKey: string;
+  requestData: unknown;
+  execute: () => Promise<T>;
+}
+
+interface IdempotencyDocument<T> {
+  status?: 'RUNNING' | 'SUCCEEDED';
+  leaseUntil?: number;
+  expiresAt?: number;
+  response?: T;
+}
+
+function cleanId(value: unknown): string {
+  const normalized = String(value ?? '').trim();
+  return /^[A-Za-z0-9_-]{1,128}$/.test(normalized) ? normalized : '';
+}
+
+function cleanResourceKey(value: unknown): string {
+  const normalized = String(value ?? '').trim();
+  return normalized && normalized.length <= 512 ? normalized : '';
+}
+
+function cloneResponse<T>(response: T): T {
+  return JSON.parse(JSON.stringify(response)) as T;
+}
+
+export async function executeMediaMutationIdempotently<T>(
+  input: MediaMutationIdempotencyInput<T>
+): Promise<T> {
+  const actorUid = cleanId(input.actorUid);
+  const resourceKey = cleanResourceKey(input.resourceKey);
+
+  if (!actorUid || !resourceKey) {
+    throw new HttpsError(
+      'invalid-argument',
+      'Não foi possível identificar esta operação de mídia.'
+    );
+  }
+
+  const requestHash = hashMediaMutationRequest(input.requestData);
+  const documentId = hashMediaMutationRequest({
+    actorUid,
+    action: input.action,
+    resourceKey,
+    requestHash,
+  });
+  const documentRef = db
+    .collection(IDEMPOTENCY_COLLECTION)
+    .doc(documentId);
+  const now = Date.now();
+  const acquisition = await db.runTransaction(async (transaction) => {
+    const snapshot = await transaction.get(documentRef);
+    const existing = snapshot.exists
+      ? snapshot.data() as IdempotencyDocument<T>
+      : null;
+
+    if (
+      existing?.status === 'SUCCEEDED' &&
+      Number(existing.expiresAt ?? 0) > now &&
+      existing.response !== undefined
+    ) {
+      return {
+        cached: true as const,
+        response: existing.response,
+      };
+    }
+
+    if (
+      existing?.status === 'RUNNING' &&
+      Number(existing.leaseUntil ?? 0) > now
+    ) {
+      throw new HttpsError(
+        'aborted',
+        'Esta ação já está sendo concluída.',
+        {
+          action: input.action,
+          retryAfterMs: Math.max(
+            1_000,
+            Number(existing.leaseUntil ?? now) - now
+          ),
+        }
+      );
+    }
+
+    transaction.set(documentRef, {
+      actorUid,
+      action: input.action,
+      resourceHash: hashMediaMutationRequest(resourceKey),
+      requestHash,
+      status: 'RUNNING',
+      leaseUntil: now + OPERATION_LEASE_MS,
+      expiresAt: now + OPERATION_LEASE_MS,
+      createdAt: snapshot.exists
+        ? snapshot.get('createdAt') ?? now
+        : now,
+      updatedAt: now,
+    });
+
+    return { cached: false as const };
+  });
+
+  if (acquisition.cached) {
+    return cloneResponse(acquisition.response);
+  }
+
+  try {
+    const response = await input.execute();
+    const safeResponse = cloneResponse(response);
+    const completedAt = Date.now();
+
+    await documentRef.set(
+      {
+        status: 'SUCCEEDED',
+        response: safeResponse,
+        leaseUntil: null,
+        expiresAt: completedAt + SUCCESS_CACHE_MS,
+        updatedAt: completedAt,
+      },
+      { merge: true }
+    );
+
+    return response;
+  } catch (error) {
+    try {
+      await documentRef.delete();
+    } catch (cleanupError) {
+      logger.warn('[mediaMutationIdempotency] Falha ao liberar operação.', {
+        action: input.action,
+        error: cleanupError instanceof Error
+          ? cleanupError.message
+          : String(cleanupError ?? ''),
+      });
+    }
+
+    throw error;
+  }
+}
+
+export const cleanupMediaMutationIdempotency = onSchedule(
+  {
+    schedule: 'every 6 hours',
+    timeZone: 'America/Sao_Paulo',
+    region: FUNCTIONS_REGION,
+  },
+  async () => {
+    const snapshot = await db
+      .collection(IDEMPOTENCY_COLLECTION)
+      .where('expiresAt', '<=', Date.now())
+      .limit(CLEANUP_BATCH_LIMIT)
+      .get();
+
+    if (snapshot.empty) {
+      return;
+    }
+
+    const batch = db.batch();
+    snapshot.docs.forEach((document) => batch.delete(document.ref));
+    await batch.commit();
+
+    logger.info('[cleanupMediaMutationIdempotency] Operações removidas.', {
+      removed: snapshot.size,
+    });
+  }
+);

--- a/functions/src/media/application/protected-media-lifecycle-callables.handler.ts
+++ b/functions/src/media/application/protected-media-lifecycle-callables.handler.ts
@@ -1,0 +1,331 @@
+import { onCall } from 'firebase-functions/v2/https';
+
+import { PROTECTED_CALLABLE_OPTIONS } from '../../config/protected-callable-options';
+import { storage } from '../../firebaseApp';
+import {
+  deleteProfilePhoto as deleteProfilePhotoCore,
+} from './delete-profile-photo.handler';
+import {
+  deleteProfileVideo as deleteProfileVideoCore,
+} from './delete-profile-video.handler';
+import {
+  setCoverPhoto as setCoverPhotoCore,
+  unpublishPhoto as unpublishPhotoCore,
+} from './manage-photo-publication.handler';
+import {
+  unpublishVideo as unpublishVideoCore,
+} from './manage-video-publication.handler';
+import {
+  assertMediaCallableRateLimit,
+} from './media-callable-rate-limit.service';
+import {
+  executeMediaMutationIdempotently,
+  type MediaMutationAction,
+} from './media-mutation-idempotency.service';
+import {
+  resolveUploadMutationCost,
+} from './media-mutation-idempotency.policy';
+import {
+  publishPhoto as publishPhotoCore,
+} from './publish-photo-orchestrator.handler';
+import {
+  publishVideo as publishVideoCore,
+} from './publish-video-orchestrator.handler';
+import {
+  registerPrivateVideoUpload as registerPrivateVideoUploadCore,
+} from './register-private-video-upload-orchestrator.handler';
+import {
+  updateVideoPublicationSettings as updateVideoPublicationSettingsCore,
+} from './update-video-publication-settings.handler';
+import {
+  extractOwnedPrivateVideoPathForId,
+} from './video-storage-path';
+import type {
+  MediaCallableRateAction,
+} from './media-callable-rate-limit.policy';
+
+interface PublishPhotoRequest {
+  ownerUid?: string;
+  photoId?: string;
+  visibility?: 'FRIENDS' | 'SUBSCRIBERS' | 'PREMIUM' | 'PUBLIC';
+  caption?: string | null;
+  isCover?: boolean;
+  orderIndex?: number;
+  commentsEnabled?: boolean;
+  commentsPolicy?: 'OFF' | 'FRIENDS' | 'SUBSCRIBERS' | 'EVERYONE';
+  reactionsEnabled?: boolean;
+}
+
+interface PhotoTargetRequest {
+  ownerUid?: string;
+  photoId?: string;
+}
+
+interface PublishVideoRequest {
+  ownerUid?: string;
+  videoId?: string;
+  visibility?: 'FRIENDS' | 'SUBSCRIBERS' | 'PREMIUM' | 'PUBLIC';
+  orderIndex?: number;
+}
+
+interface VideoTargetRequest {
+  ownerUid?: string;
+  videoId?: string;
+}
+
+interface UpdateVideoPublicationSettingsRequest extends VideoTargetRequest {
+  title?: unknown;
+  description?: unknown;
+  reactionsEnabled?: unknown;
+  commentsEnabled?: unknown;
+  ratingsEnabled?: unknown;
+}
+
+interface RegisterPrivateVideoUploadRequest extends UpdateVideoPublicationSettingsRequest {
+  videoStoragePath?: string;
+  posterStoragePath?: string | null;
+  fileName?: string;
+  mimeType?: string;
+  sizeBytes?: number;
+  durationMs?: number | null;
+  publishWhenReady?: boolean;
+  [key: string]: unknown;
+}
+
+function cleanId(value: unknown): string {
+  const normalized = String(value ?? '').trim();
+  return /^[A-Za-z0-9_-]{1,128}$/.test(normalized) ? normalized : '';
+}
+
+function resourceKey(
+  mediaType: 'photo' | 'video',
+  ownerUid: unknown,
+  mediaId: unknown
+): string {
+  return [
+    mediaType,
+    cleanId(ownerUid) || 'invalid-owner',
+    cleanId(mediaId) || 'invalid-media',
+  ].join(':');
+}
+
+async function executeProtectedMutation<T>(input: {
+  actorUid: string;
+  idempotencyAction: MediaMutationAction;
+  rateAction: MediaCallableRateAction;
+  resourceKey: string;
+  requestData: unknown;
+  cost: number;
+  execute: () => Promise<T>;
+}): Promise<T> {
+  if (!input.actorUid) {
+    return input.execute();
+  }
+
+  return executeMediaMutationIdempotently({
+    actorUid: input.actorUid,
+    action: input.idempotencyAction,
+    resourceKey: input.resourceKey,
+    requestData: input.requestData,
+    execute: async () => {
+      await assertMediaCallableRateLimit({
+        actorUid: input.actorUid,
+        action: input.rateAction,
+        resourceKey: input.resourceKey,
+        cost: input.cost,
+      });
+
+      return input.execute();
+    },
+  });
+}
+
+async function resolveUploadCost(
+  actorUid: string,
+  data: RegisterPrivateVideoUploadRequest | undefined
+): Promise<number> {
+  const ownerUid = cleanId(data?.ownerUid);
+  const videoId = cleanId(data?.videoId);
+
+  if (!actorUid || actorUid !== ownerUid || !videoId) {
+    return resolveUploadMutationCost(null);
+  }
+
+  const storagePath = extractOwnedPrivateVideoPathForId(
+    ownerUid,
+    videoId,
+    data?.videoStoragePath
+  );
+
+  if (!storagePath) {
+    return resolveUploadMutationCost(null);
+  }
+
+  try {
+    const [metadata] = await storage.bucket().file(storagePath).getMetadata();
+    return resolveUploadMutationCost(metadata.size);
+  } catch {
+    return resolveUploadMutationCost(null);
+  }
+}
+
+export const registerPrivateVideoUpload = onCall<RegisterPrivateVideoUploadRequest>(
+  PROTECTED_CALLABLE_OPTIONS,
+  async (request) => {
+    const actorUid = cleanId(request.auth?.uid);
+    const key = resourceKey(
+      'video',
+      request.data?.ownerUid,
+      request.data?.videoId
+    );
+
+    if (actorUid) {
+      await assertMediaCallableRateLimit({
+        actorUid,
+        action: 'UPLOAD_REGISTER',
+        resourceKey: key,
+        cost: await resolveUploadCost(actorUid, request.data),
+      });
+    }
+
+    return registerPrivateVideoUploadCore.run(request);
+  }
+);
+
+export const publishPhoto = onCall<PublishPhotoRequest>(
+  PROTECTED_CALLABLE_OPTIONS,
+  async (request) => executeProtectedMutation({
+    actorUid: cleanId(request.auth?.uid),
+    idempotencyAction: 'PHOTO_PUBLISH',
+    rateAction: 'MEDIA_PUBLISH',
+    resourceKey: resourceKey(
+      'photo',
+      request.data?.ownerUid,
+      request.data?.photoId
+    ),
+    requestData: request.data,
+    cost: 2,
+    execute: () => publishPhotoCore.run(request),
+  })
+);
+
+export const unpublishPhoto = onCall<PhotoTargetRequest>(
+  PROTECTED_CALLABLE_OPTIONS,
+  async (request) => executeProtectedMutation({
+    actorUid: cleanId(request.auth?.uid),
+    idempotencyAction: 'PHOTO_UNPUBLISH',
+    rateAction: 'MEDIA_UNPUBLISH',
+    resourceKey: resourceKey(
+      'photo',
+      request.data?.ownerUid,
+      request.data?.photoId
+    ),
+    requestData: request.data,
+    cost: 1,
+    execute: () => unpublishPhotoCore.run(request),
+  })
+);
+
+export const setCoverPhoto = onCall<PhotoTargetRequest>(
+  PROTECTED_CALLABLE_OPTIONS,
+  async (request) => executeProtectedMutation({
+    actorUid: cleanId(request.auth?.uid),
+    idempotencyAction: 'PHOTO_SET_COVER',
+    rateAction: 'MEDIA_COVER',
+    resourceKey: resourceKey(
+      'photo',
+      request.data?.ownerUid,
+      request.data?.photoId
+    ),
+    requestData: request.data,
+    cost: 1,
+    execute: () => setCoverPhotoCore.run(request),
+  })
+);
+
+export const publishVideo = onCall<PublishVideoRequest>(
+  PROTECTED_CALLABLE_OPTIONS,
+  async (request) => executeProtectedMutation({
+    actorUid: cleanId(request.auth?.uid),
+    idempotencyAction: 'VIDEO_PUBLISH',
+    rateAction: 'MEDIA_PUBLISH',
+    resourceKey: resourceKey(
+      'video',
+      request.data?.ownerUid,
+      request.data?.videoId
+    ),
+    requestData: request.data,
+    cost: 5,
+    execute: () => publishVideoCore.run(request),
+  })
+);
+
+export const unpublishVideo = onCall<VideoTargetRequest>(
+  PROTECTED_CALLABLE_OPTIONS,
+  async (request) => executeProtectedMutation({
+    actorUid: cleanId(request.auth?.uid),
+    idempotencyAction: 'VIDEO_UNPUBLISH',
+    rateAction: 'MEDIA_UNPUBLISH',
+    resourceKey: resourceKey(
+      'video',
+      request.data?.ownerUid,
+      request.data?.videoId
+    ),
+    requestData: request.data,
+    cost: 2,
+    execute: () => unpublishVideoCore.run(request),
+  })
+);
+
+export const deleteProfilePhoto = onCall<PhotoTargetRequest>(
+  PROTECTED_CALLABLE_OPTIONS,
+  async (request) => executeProtectedMutation({
+    actorUid: cleanId(request.auth?.uid),
+    idempotencyAction: 'PHOTO_DELETE',
+    rateAction: 'MEDIA_DELETE',
+    resourceKey: resourceKey(
+      'photo',
+      request.data?.ownerUid,
+      request.data?.photoId
+    ),
+    requestData: request.data,
+    cost: 2,
+    execute: () => deleteProfilePhotoCore.run(request),
+  })
+);
+
+export const deleteProfileVideo = onCall<VideoTargetRequest>(
+  PROTECTED_CALLABLE_OPTIONS,
+  async (request) => executeProtectedMutation({
+    actorUid: cleanId(request.auth?.uid),
+    idempotencyAction: 'VIDEO_DELETE',
+    rateAction: 'MEDIA_DELETE',
+    resourceKey: resourceKey(
+      'video',
+      request.data?.ownerUid,
+      request.data?.videoId
+    ),
+    requestData: request.data,
+    cost: 5,
+    execute: () => deleteProfileVideoCore.run(request),
+  })
+);
+
+export const updateVideoPublicationSettings = onCall<
+  UpdateVideoPublicationSettingsRequest
+>(
+  PROTECTED_CALLABLE_OPTIONS,
+  async (request) => executeProtectedMutation({
+    actorUid: cleanId(request.auth?.uid),
+    idempotencyAction: 'VIDEO_SETTINGS',
+    rateAction: 'MEDIA_SETTINGS',
+    resourceKey: resourceKey(
+      'video',
+      request.data?.ownerUid,
+      request.data?.videoId
+    ),
+    requestData: request.data,
+    cost: 1,
+    execute: () => updateVideoPublicationSettingsCore.run(request),
+  })
+);

--- a/functions/src/media/application/publish-photo-orchestrator.handler.ts
+++ b/functions/src/media/application/publish-photo-orchestrator.handler.ts
@@ -8,18 +8,28 @@ import {
   publishPhoto as publishPhotoCore,
 } from './manage-photo-publication.handler';
 
-export const publishPhoto = onCall(
+interface PublishPhotoRequest {
+  ownerUid?: string;
+  photoId?: string;
+  visibility?: 'FRIENDS' | 'SUBSCRIBERS' | 'PREMIUM' | 'PUBLIC';
+  caption?: string | null;
+  isCover?: boolean;
+  orderIndex?: number;
+  commentsEnabled?: boolean;
+  commentsPolicy?: 'OFF' | 'FRIENDS' | 'SUBSCRIBERS' | 'EVERYONE';
+  reactionsEnabled?: boolean;
+}
+
+export const publishPhoto = onCall<PublishPhotoRequest>(
   { region: FUNCTIONS_REGION },
   async (request) => {
-    const ownerUid = String(
-      (request.data as { ownerUid?: unknown } | null | undefined)?.ownerUid ?? ''
-    ).trim();
+    const ownerUid = String(request.data?.ownerUid ?? '').trim();
     const requesterUid = String(request.auth?.uid ?? '').trim();
 
     if (ownerUid && requesterUid === ownerUid) {
       await assertInteractionAccess(ownerUid);
     }
 
-    return publishPhotoCore.run(request as any);
+    return publishPhotoCore.run(request);
   }
 );

--- a/functions/src/media/application/publish-video-orchestrator.handler.ts
+++ b/functions/src/media/application/publish-video-orchestrator.handler.ts
@@ -11,16 +11,21 @@ import {
   synchronizePublishedVideoSettings,
 } from './sync-published-video-settings.handler';
 
+interface PublishVideoRequest {
+  ownerUid?: string;
+  videoId?: string;
+  visibility?: 'FRIENDS' | 'SUBSCRIBERS' | 'PREMIUM' | 'PUBLIC';
+  orderIndex?: number;
+}
+
 interface PublishVideoResponse {
   videoId: string;
   moderationStatus: string;
   [key: string]: unknown;
 }
 
-function ownerUidFromRequestData(data: unknown): string {
-  const ownerUid = String(
-    (data as { ownerUid?: unknown } | null | undefined)?.ownerUid ?? ''
-  ).trim();
+function ownerUidFromRequestData(data: PublishVideoRequest | undefined): string {
+  const ownerUid = String(data?.ownerUid ?? '').trim();
 
   return /^[A-Za-z0-9_-]{1,128}$/.test(ownerUid) ? ownerUid : '';
 }
@@ -29,7 +34,7 @@ function ownerUidFromRequestData(data: unknown): string {
  * Publica o vídeo e só responde depois que a projeção pública recebeu os
  * metadados e preferências canônicos já salvos na publicação privada.
  */
-export const publishVideo = onCall(
+export const publishVideo = onCall<PublishVideoRequest>(
   { region: FUNCTIONS_REGION },
   async (request) => {
     const ownerUid = ownerUidFromRequestData(request.data);
@@ -40,7 +45,7 @@ export const publishVideo = onCall(
     }
 
     const response = (
-      await publishVideoCore.run(request as any)
+      await publishVideoCore.run(request)
     ) as PublishVideoResponse;
 
     await synchronizePublishedVideoSettings(ownerUid, response.videoId);

--- a/functions/src/media/application/video-view-session.policy.test.ts
+++ b/functions/src/media/application/video-view-session.policy.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
 import './media-callable-rate-limit.policy.test';
+import './media-mutation-idempotency.policy.test';
 import './photo-audience-access.policy.test';
 import {
   VIDEO_VIEW_SESSION_MIN_INTERVAL_MS,
@@ -35,35 +36,31 @@ describe('video-view-session.policy', () => {
     });
   });
 
-  it('aplica intervalo mínimo entre emissões', () => {
+  it('bloqueia emissões rápidas para o mesmo escopo', () => {
     const now = 1_800_000_000_000;
     const decision = buildVideoViewSessionRateDecision({
-      now,
+      now: now + VIDEO_VIEW_SESSION_MIN_INTERVAL_MS - 1,
       state: {
-        windowStartedAt: now - 1_000,
+        windowStartedAt: now,
         count: 1,
-        lastIssuedAt: now - 500,
+        lastIssuedAt: now,
       },
       maxPerWindow: 6,
     });
 
     assert.equal(decision.allowed, false);
-    assert.equal(
-      decision.retryAfterMs,
-      VIDEO_VIEW_SESSION_MIN_INTERVAL_MS - 500
-    );
+    assert.equal(decision.retryAfterMs, 1_000);
     assert.equal(decision.nextState.count, 1);
   });
 
-  it('bloqueia a janela cheia e informa quando pode tentar novamente', () => {
+  it('bloqueia ao atingir o máximo da janela', () => {
     const now = 1_800_000_000_000;
-    const windowStartedAt = now - 60_000;
     const decision = buildVideoViewSessionRateDecision({
-      now,
+      now: now + 30_000,
       state: {
-        windowStartedAt,
+        windowStartedAt: now,
         count: 6,
-        lastIssuedAt: now - VIDEO_VIEW_SESSION_MIN_INTERVAL_MS,
+        lastIssuedAt: now,
       },
       maxPerWindow: 6,
     });
@@ -71,27 +68,28 @@ describe('video-view-session.policy', () => {
     assert.equal(decision.allowed, false);
     assert.equal(
       decision.retryAfterMs,
-      VIDEO_VIEW_SESSION_RATE_WINDOW_MS - 60_000
+      VIDEO_VIEW_SESSION_RATE_WINDOW_MS - 30_000
     );
   });
 
-  it('reinicia a contagem quando a janela expira', () => {
+  it('reinicia a janela expirada', () => {
     const now = 1_800_000_000_000;
+    const nextWindow = now + VIDEO_VIEW_SESSION_RATE_WINDOW_MS;
     const decision = buildVideoViewSessionRateDecision({
-      now,
+      now: nextWindow,
       state: {
-        windowStartedAt: now - VIDEO_VIEW_SESSION_RATE_WINDOW_MS,
+        windowStartedAt: now,
         count: 99,
-        lastIssuedAt: now - VIDEO_VIEW_SESSION_MIN_INTERVAL_MS,
+        lastIssuedAt: now,
       },
       maxPerWindow: 6,
     });
 
     assert.equal(decision.allowed, true);
     assert.deepEqual(decision.nextState, {
-      windowStartedAt: now,
+      windowStartedAt: nextWindow,
       count: 1,
-      lastIssuedAt: now,
+      lastIssuedAt: nextWindow,
     });
   });
 });

--- a/functions/src/media/application/video-view-session.policy.test.ts
+++ b/functions/src/media/application/video-view-session.policy.test.ts
@@ -49,7 +49,7 @@ describe('video-view-session.policy', () => {
     });
 
     assert.equal(decision.allowed, false);
-    assert.equal(decision.retryAfterMs, 1_000);
+    assert.equal(decision.retryAfterMs, 1);
     assert.equal(decision.nextState.count, 1);
   });
 

--- a/functions/src/media/index.ts
+++ b/functions/src/media/index.ts
@@ -20,34 +20,31 @@ export {
 } from './application/protected-media-access-callables.handler';
 
 export {
-  cleanupMediaCallableRateLimits,
-} from './application/media-callable-rate-limit.service';
+  deleteProfilePhoto,
+  deleteProfileVideo,
+  publishPhoto,
+  publishVideo,
+  registerPrivateVideoUpload,
+  setCoverPhoto,
+  unpublishPhoto,
+  unpublishVideo,
+  updateVideoPublicationSettings,
+} from './application/protected-media-lifecycle-callables.handler';
 
 export {
-  publishPhoto,
-} from './application/publish-photo-orchestrator.handler';
+  cleanupMediaCallableRateLimits,
+} from './application/media-callable-rate-limit.service';
 export {
-  unpublishPhoto,
-  setCoverPhoto,
-} from './application/manage-photo-publication.handler';
+  cleanupMediaMutationIdempotency,
+} from './application/media-mutation-idempotency.service';
 
 export {
   syncPublishedPhotoOnPrivateUpdate,
 } from './application/sync-published-photo-on-private-update.handler';
 
 export {
-  unpublishVideo,
-} from './application/manage-video-publication.handler';
-export {
-  publishVideo,
-} from './application/publish-video-orchestrator.handler';
-export {
   publishVideoWhenReady,
 } from './application/publish-video-when-ready.handler';
-
-export {
-  updateVideoPublicationSettings,
-} from './application/update-video-publication-settings.handler';
 
 export {
   syncPublishedVideoSettings,
@@ -60,9 +57,6 @@ export {
 export {
   cleanupPendingPrivateVideoUploadAssets,
 } from './application/register-private-video-upload.handler';
-export {
-  registerPrivateVideoUpload,
-} from './application/register-private-video-upload-orchestrator.handler';
 
 export {
   queuePrivateVideoProcessing,
@@ -91,12 +85,10 @@ export {
 
 export {
   cleanupPendingPhotoDeletions,
-  deleteProfilePhoto,
 } from './application/delete-profile-photo.handler';
 
 export {
   cleanupPendingVideoDeletions,
-  deleteProfileVideo,
 } from './application/delete-profile-video.handler';
 
 export {


### PR DESCRIPTION
## Dependência

PR empilhado sobre o #55 (`agent/media-p0-access-url-protection`). O diff contém somente o pacote P0 de proteção do ciclo de vida de mídia.

## Callables protegidas

A raiz passa a exportar versões com App Check de:

- `registerPrivateVideoUpload`;
- `publishPhoto`;
- `unpublishPhoto`;
- `setCoverPhoto`;
- `publishVideo`;
- `unpublishVideo`;
- `deleteProfilePhoto`;
- `deleteProfileVideo`;
- `updateVideoPublicationSettings`.

Os nomes públicos e os contratos de request/response foram preservados. Triggers Firestore, agendadores e rotinas administrativas internas não foram submetidos a App Check de navegador.

## Rate limiting por custo

Foram adicionadas categorias centrais:

- `UPLOAD_REGISTER`;
- `MEDIA_PUBLISH`;
- `MEDIA_UNPUBLISH`;
- `MEDIA_DELETE`;
- `MEDIA_SETTINGS`;
- `MEDIA_COVER`.

### Custos aplicados

- upload: custo calculado pelo tamanho real no Storage, em blocos de 10 MiB, limitado a 50 unidades;
- tamanho indisponível ou inválido: custo conservador de 5 unidades;
- publicação de foto: 2 unidades;
- publicação de vídeo: 5 unidades;
- despublicação de foto: 1 unidade;
- despublicação de vídeo: 2 unidades;
- exclusão de foto: 2 unidades;
- exclusão de vídeo: 5 unidades;
- edição de configurações e definição de capa: 1 unidade.

O custo maior de vídeo representa cópia de ativos, limpeza de outputs processados e cancelamento de jobs.

### Janelas

- upload: 300 unidades por hora no total e 60 por vídeo;
- publicação: 60 unidades por 10 minutos e 12 por mídia;
- despublicação: 90 unidades por 10 minutos e 15 por mídia;
- exclusão: 120 unidades por hora e 10 por mídia;
- configurações: 90 unidades por 10 minutos e 15 por vídeo;
- capa: 60 unidades por 10 minutos e 15 por foto.

## Idempotência transacional

Foi criada uma barreira Firestore curta para publicação, despublicação, exclusão, capa e configurações.

A chave é derivada por SHA-256 de:

- usuário autenticado;
- operação;
- recurso;
- fingerprint canônico do request.

Comportamento:

- uma operação em andamento mantém lease de até dois minutos;
- retry concorrente recebe `aborted` com `retryAfterMs`;
- resposta concluída é reutilizada por 15 segundos para absorver duplo clique e retry de rede;
- falhas liberam a chave para nova tentativa;
- documentos expirados são removidos a cada seis horas, até 450 por execução;
- somente hashes do recurso e request são persistidos.

O registro de upload não usa a cache genérica porque já possui idempotência canônica mais forte por `ownerUid + videoId + storagePath`, incluindo tratamento de concorrência e limpeza recuperável.

## Upload e processamento

Antes do registro, a borda protegida:

- valida identidade e namespace do caminho;
- lê o tamanho real do objeto no Storage;
- calcula o custo ponderado;
- aplica o limite antes da elegibilidade, registro e enfileiramento.

O fluxo existente continua respondendo somente depois que `ensurePrivateVideoProcessingQueued` garante um único job idempotente. O trigger Firestore permanece como reconciliação.

## Supressões e substituições intencionais

### Exportações diretas

Foram suprimidas na raiz as exportações diretas dos handlers de upload, publicação, despublicação, capa, exclusão e configurações.

Elas foram substituídas por `protected-media-lifecycle-callables.handler.ts`, que aplica App Check, custo, rate limiting e idempotência antes de delegar aos mesmos handlers de domínio.

Nenhum handler de domínio, agendador ou trigger foi removido.

### Tipagem dos orquestradores

Foram suprimidos os casts `as any` dos orquestradores de publicação de foto e vídeo. Os requests agora são tipados e delegados diretamente aos handlers compatíveis.

O cast interno preexistente do orquestrador de registro de upload não foi removido neste diff, porque esse arquivo concentra elegibilidade, limpeza física recuperável e fila síncrona. A borda pública nova é tipada; a remoção interna deve ocorrer por extração de um core tipado próprio, sem duplicar esse fluxo crítico.

## Compatibilidade

- nenhum componente ou serviço Angular foi alterado;
- nomes públicos das Functions foram mantidos;
- tratamento de erros continua centralizado no frontend;
- Emulator Suite mantém a exceção de App Check já existente;
- rotinas de exclusão continuam duráveis e retomáveis;
- publicação e processamento continuam usando os mesmos documentos canônicos.

## Testes adicionados

- fingerprint estável independentemente da ordem das chaves;
- diferenciação de requests distintos;
- custo por blocos de 10 MiB;
- teto de custo de upload;
- fallback conservador quando o tamanho não é validável;
- regras específicas para upload, publicação e exclusão.

## Validação concluída

- lint das Functions: aprovado;
- build TypeScript das Functions: aprovado;
- 246 testes das Functions: aprovados;
- testes de fingerprint e custo: aprovados;
- testes Angular: aprovados;
- build Angular seguro: aprovado;
- Firestore Rules: aprovado;
- índices do Firestore: aprovado;
- Quality Gate agregado: aprovado.

O primeiro head compilou e todos os testes novos passaram, mas uma expectativa preexistente de sessão foi alterada acidentalmente de `1` ms para `1.000` ms durante o carregamento das novas suítes. O segundo head restaurou somente essa asserção; nenhum código de produção foi alterado após a primeira execução.