### PR TITLE
feat(media): proteger administração e tipar upload

### DIFF
--- a/functions/src/config/admin-browser-callable-options.ts
+++ b/functions/src/config/admin-browser-callable-options.ts
@@ -1,0 +1,14 @@
+import { FUNCTIONS_REGION } from './functions-region';
+
+/**
+ * Contrato de transporte para callables administrativas acionadas pelo painel
+ * Angular. App Check complementa as claims administrativas validadas pelos
+ * handlers de domínio.
+ *
+ * Triggers, agendadores e executores internos não devem usar estas opções,
+ * porque não representam tráfego originado do navegador.
+ */
+export const ADMIN_BROWSER_CALLABLE_OPTIONS = {
+  region: FUNCTIONS_REGION,
+  enforceAppCheck: process.env.FUNCTIONS_EMULATOR !== 'true',
+} as const;

--- a/functions/src/media/application/media-callable-rate-limit.policy.test.ts
+++ b/functions/src/media/application/media-callable-rate-limit.policy.test.ts
@@ -19,6 +19,14 @@ describe('media-callable-rate-limit.policy', () => {
     const upload = resolveMediaCallableRateLimitRule('UPLOAD_REGISTER');
     const publish = resolveMediaCallableRateLimitRule('MEDIA_PUBLISH');
     const deletion = resolveMediaCallableRateLimitRule('MEDIA_DELETE');
+    const adminStatus = resolveMediaCallableRateLimitRule('ADMIN_STATUS');
+    const adminQueue = resolveMediaCallableRateLimitRule('ADMIN_QUEUE');
+    const adminModeration = resolveMediaCallableRateLimitRule(
+      'ADMIN_MODERATION'
+    );
+    const adminRecovery = resolveMediaCallableRateLimitRule(
+      'ADMIN_PROCESSING_RECOVERY'
+    );
 
     assert.ok(reaction.globalMaxPerWindow > reaction.resourceMaxPerWindow);
     assert.ok(report.windowMs > reaction.windowMs);
@@ -34,6 +42,15 @@ describe('media-callable-rate-limit.policy', () => {
     assert.equal(upload.windowMs, report.windowMs);
     assert.equal(deletion.windowMs, report.windowMs);
     assert.ok(upload.globalMaxPerWindow > publish.globalMaxPerWindow);
+    assert.equal(adminStatus.globalMaxPerWindow, adminStatus.resourceMaxPerWindow);
+    assert.ok(adminStatus.minIntervalMs > adminModeration.minIntervalMs);
+    assert.ok(adminQueue.globalMaxPerWindow > adminQueue.resourceMaxPerWindow);
+    assert.ok(
+      adminModeration.globalMaxPerWindow > adminRecovery.globalMaxPerWindow
+    );
+    assert.ok(
+      adminRecovery.resourceMaxPerWindow < adminModeration.resourceMaxPerWindow
+    );
   });
 
   it('aceita a primeira operação e incrementa o estado', () => {

--- a/functions/src/media/application/media-callable-rate-limit.policy.ts
+++ b/functions/src/media/application/media-callable-rate-limit.policy.ts
@@ -15,7 +15,11 @@ export type MediaCallableRateAction =
   | 'MEDIA_UNPUBLISH'
   | 'MEDIA_DELETE'
   | 'MEDIA_SETTINGS'
-  | 'MEDIA_COVER';
+  | 'MEDIA_COVER'
+  | 'ADMIN_STATUS'
+  | 'ADMIN_QUEUE'
+  | 'ADMIN_MODERATION'
+  | 'ADMIN_PROCESSING_RECOVERY';
 
 export interface MediaCallableRateLimitRule {
   readonly windowMs: number;
@@ -153,6 +157,30 @@ const RULES: Readonly<Record<
     globalMaxPerWindow: 60,
     resourceMaxPerWindow: 15,
     minIntervalMs: 500,
+  },
+  ADMIN_STATUS: {
+    windowMs: TEN_MINUTES_MS,
+    globalMaxPerWindow: 30,
+    resourceMaxPerWindow: 30,
+    minIntervalMs: 3_000,
+  },
+  ADMIN_QUEUE: {
+    windowMs: TEN_MINUTES_MS,
+    globalMaxPerWindow: 600,
+    resourceMaxPerWindow: 240,
+    minIntervalMs: 1_500,
+  },
+  ADMIN_MODERATION: {
+    windowMs: TEN_MINUTES_MS,
+    globalMaxPerWindow: 120,
+    resourceMaxPerWindow: 12,
+    minIntervalMs: 300,
+  },
+  ADMIN_PROCESSING_RECOVERY: {
+    windowMs: TEN_MINUTES_MS,
+    globalMaxPerWindow: 90,
+    resourceMaxPerWindow: 9,
+    minIntervalMs: 1_000,
   },
 };
 

--- a/functions/src/media/application/protected-admin-media-callables.handler.ts
+++ b/functions/src/media/application/protected-admin-media-callables.handler.ts
@@ -1,0 +1,189 @@
+import { onCall } from 'firebase-functions/v2/https';
+
+import {
+  ADMIN_BROWSER_CALLABLE_OPTIONS,
+} from '../../config/admin-browser-callable-options';
+import {
+  listVideoModerationQueue as listVideoModerationQueueCore,
+  reviewVideoModeration as reviewVideoModerationCore,
+} from './admin-video-moderation.handler';
+import {
+  listVideoProcessingRecoveryJobs as listVideoProcessingRecoveryJobsCore,
+  recoverVideoProcessingJob as recoverVideoProcessingJobCore,
+} from './admin-video-processing-recovery.handler';
+import {
+  getVideoProcessingOperationalStatus as getVideoProcessingOperationalStatusCore,
+} from './admin-video-processing-status.handler';
+import {
+  assertMediaCallableRateLimit,
+} from './media-callable-rate-limit.service';
+
+interface ListVideoModerationQueueRequest {
+  limit?: number;
+}
+
+interface ReviewVideoModerationRequest {
+  ownerUid?: string;
+  videoId?: string;
+  decision?: 'APPROVE' | 'REJECT';
+  reason?: string | null;
+}
+
+interface ListVideoProcessingRecoveryJobsRequest {
+  limit?: number;
+}
+
+interface RecoverVideoProcessingJobRequest {
+  ownerUid?: string;
+  videoId?: string;
+  action?: 'RETRY_FAILED' | 'RECHECK_STALE' | 'CANCEL_ACTIVE';
+  reason?: string;
+  operationId?: string;
+}
+
+const DEFAULT_MODERATION_QUEUE_LIMIT = 40;
+const MAX_MODERATION_QUEUE_LIMIT = 80;
+const DEFAULT_RECOVERY_QUEUE_LIMIT = 30;
+const MAX_RECOVERY_QUEUE_LIMIT = 60;
+
+function cleanId(value: unknown): string {
+  const normalized = String(value ?? '').trim();
+  return /^[A-Za-z0-9_-]{1,128}$/.test(normalized) ? normalized : '';
+}
+
+function normalizeLimit(
+  value: unknown,
+  fallback: number,
+  maximum: number
+): number {
+  const numeric = Number(value ?? fallback);
+
+  if (!Number.isFinite(numeric)) {
+    return fallback;
+  }
+
+  return Math.max(1, Math.min(maximum, Math.trunc(numeric)));
+}
+
+function mediaResourceKey(
+  prefix: string,
+  ownerUid: unknown,
+  mediaId: unknown
+): string {
+  return `${prefix}:${cleanId(ownerUid) || 'invalid-owner'}:` +
+    `${cleanId(mediaId) || 'invalid-media'}`;
+}
+
+async function applyAdminRateLimit(input: {
+  actorUid: string;
+  action:
+    | 'ADMIN_STATUS'
+    | 'ADMIN_QUEUE'
+    | 'ADMIN_MODERATION'
+    | 'ADMIN_PROCESSING_RECOVERY';
+  resourceKey: string;
+  cost?: number;
+}): Promise<void> {
+  if (!input.actorUid) {
+    return;
+  }
+
+  await assertMediaCallableRateLimit(input);
+}
+
+export const getVideoProcessingOperationalStatus = onCall<
+  Record<string, never>
+>(
+  ADMIN_BROWSER_CALLABLE_OPTIONS,
+  async (request) => {
+    await applyAdminRateLimit({
+      actorUid: cleanId(request.auth?.uid),
+      action: 'ADMIN_STATUS',
+      resourceKey: 'video-processing-operational-status',
+    });
+
+    return getVideoProcessingOperationalStatusCore.run(request);
+  }
+);
+
+export const listVideoModerationQueue = onCall<
+  ListVideoModerationQueueRequest
+>(
+  ADMIN_BROWSER_CALLABLE_OPTIONS,
+  async (request) => {
+    const limit = normalizeLimit(
+      request.data?.limit,
+      DEFAULT_MODERATION_QUEUE_LIMIT,
+      MAX_MODERATION_QUEUE_LIMIT
+    );
+
+    await applyAdminRateLimit({
+      actorUid: cleanId(request.auth?.uid),
+      action: 'ADMIN_QUEUE',
+      resourceKey: 'video-moderation-queue',
+      cost: limit,
+    });
+
+    return listVideoModerationQueueCore.run(request);
+  }
+);
+
+export const reviewVideoModeration = onCall<ReviewVideoModerationRequest>(
+  ADMIN_BROWSER_CALLABLE_OPTIONS,
+  async (request) => {
+    await applyAdminRateLimit({
+      actorUid: cleanId(request.auth?.uid),
+      action: 'ADMIN_MODERATION',
+      resourceKey: mediaResourceKey(
+        'video-moderation',
+        request.data?.ownerUid,
+        request.data?.videoId
+      ),
+      cost: 2,
+    });
+
+    return reviewVideoModerationCore.run(request);
+  }
+);
+
+export const listVideoProcessingRecoveryJobs = onCall<
+  ListVideoProcessingRecoveryJobsRequest
+>(
+  ADMIN_BROWSER_CALLABLE_OPTIONS,
+  async (request) => {
+    const limit = normalizeLimit(
+      request.data?.limit,
+      DEFAULT_RECOVERY_QUEUE_LIMIT,
+      MAX_RECOVERY_QUEUE_LIMIT
+    );
+
+    await applyAdminRateLimit({
+      actorUid: cleanId(request.auth?.uid),
+      action: 'ADMIN_QUEUE',
+      resourceKey: 'video-processing-recovery-queue',
+      cost: limit,
+    });
+
+    return listVideoProcessingRecoveryJobsCore.run(request);
+  }
+);
+
+export const recoverVideoProcessingJob = onCall<
+  RecoverVideoProcessingJobRequest
+>(
+  ADMIN_BROWSER_CALLABLE_OPTIONS,
+  async (request) => {
+    await applyAdminRateLimit({
+      actorUid: cleanId(request.auth?.uid),
+      action: 'ADMIN_PROCESSING_RECOVERY',
+      resourceKey: mediaResourceKey(
+        'video-processing-recovery',
+        request.data?.ownerUid,
+        request.data?.videoId
+      ),
+      cost: 3,
+    });
+
+    return recoverVideoProcessingJobCore.run(request);
+  }
+);

--- a/functions/src/media/application/register-private-video-upload-orchestrator.handler.ts
+++ b/functions/src/media/application/register-private-video-upload-orchestrator.handler.ts
@@ -10,23 +10,37 @@ import { ensurePrivateVideoProcessingQueued } from './queue-video-processing.han
 import {
   registerPrivateVideoUpload as registerPrivateVideoUploadCore,
 } from './register-private-video-upload.handler';
+import type {
+  VideoPublicationSettingsInput,
+} from './video-publication-settings';
 import {
   extractOwnedPrivateVideoPathForId,
   extractOwnedPrivateVideoPosterPath,
 } from './video-storage-path';
 
-interface RegisterPrivateVideoUploadRequest {
+interface RegisterPrivateVideoUploadRequest
+  extends VideoPublicationSettingsInput {
   ownerUid?: string;
   videoId?: string;
   videoStoragePath?: string;
   posterStoragePath?: string | null;
-  [key: string]: unknown;
+  fileName?: string;
+  mimeType?: string;
+  sizeBytes?: number;
+  durationMs?: number | null;
+  publishWhenReady?: boolean;
 }
 
 interface RegisteredPrivateVideoResponse {
   ownerUid: string;
   videoId: string;
-  [key: string]: unknown;
+  status: 'uploaded' | 'ready';
+  mimeType: string;
+  sizeBytes: number;
+  durationMs: number | null;
+  videoStoragePath: string;
+  posterStoragePath: string | null;
+  createdAt: number;
 }
 
 interface PrivateMediaUploadAuthSnapshot {
@@ -338,7 +352,7 @@ export const registerPrivateVideoUpload = onCall<
   RegisterPrivateVideoUploadRequest
 >(
   { region: FUNCTIONS_REGION },
-  async (request) => {
+  async (request): Promise<RegisteredPrivateVideoResponse> => {
     const requesterUid = cleanId(request.auth?.uid);
     const ownerUid = cleanId(request.data?.ownerUid);
     const videoId = cleanId(request.data?.videoId);
@@ -355,9 +369,7 @@ export const registerPrivateVideoUpload = onCall<
       }
     }
 
-    const response = (
-      await registerPrivateVideoUploadCore.run(request as any)
-    ) as RegisteredPrivateVideoResponse;
+    const response = await registerPrivateVideoUploadCore.run(request);
 
     await ensurePrivateVideoProcessingQueued(
       response.ownerUid,

--- a/functions/src/media/index.ts
+++ b/functions/src/media/index.ts
@@ -32,6 +32,14 @@ export {
 } from './application/protected-media-lifecycle-callables.handler';
 
 export {
+  getVideoProcessingOperationalStatus,
+  listVideoModerationQueue,
+  listVideoProcessingRecoveryJobs,
+  recoverVideoProcessingJob,
+  reviewVideoModeration,
+} from './application/protected-admin-media-callables.handler';
+
+export {
   cleanupMediaCallableRateLimits,
 } from './application/media-callable-rate-limit.service';
 export {
@@ -69,19 +77,8 @@ export {
 } from './application/video-processing.handler';
 
 export {
-  getVideoProcessingOperationalStatus,
-} from './application/admin-video-processing-status.handler';
-
-export {
   cleanupRetriedVideoProcessingOutputs,
-  listVideoProcessingRecoveryJobs,
-  recoverVideoProcessingJob,
 } from './application/admin-video-processing-recovery.handler';
-
-export {
-  listVideoModerationQueue,
-  reviewVideoModeration,
-} from './application/admin-video-moderation.handler';
 
 export {
   cleanupPendingPhotoDeletions,


### PR DESCRIPTION
## Dependência

PR empilhado sobre o #56 (`agent/media-p0-lifecycle-app-check-idempotency`). Nenhum merge é realizado por este pacote.

## Escopo

Este diff protege as callables administrativas de mídia acionadas pelo painel Angular e remove o último cast `as any` do orquestrador de registro de upload.

## Callables administrativas protegidas

A raiz passa a exportar versões com App Check de:

- `getVideoProcessingOperationalStatus`;
- `listVideoModerationQueue`;
- `reviewVideoModeration`;
- `listVideoProcessingRecoveryJobs`;
- `recoverVideoProcessingJob`.

Os handlers administrativos originais continuam validando autenticação e claims de administrador, executando transações, registrando `admin_logs` e aplicando suas idempotências de domínio.

Triggers, agendadores e executores internos não usam o contrato de navegador.

## Contrato administrativo de navegador

Foi criado `admin-browser-callable-options.ts` para separar semanticamente:

- tráfego originado do painel Angular, que exige App Check na nuvem;
- triggers, schedulers e executores internos, que não devem depender de token de navegador.

O Emulator Suite preserva a exceção controlada já adotada pelas demais callables protegidas.

## Rate limiting administrativo

Foram adicionadas quatro categorias centrais:

- `ADMIN_STATUS`;
- `ADMIN_QUEUE`;
- `ADMIN_MODERATION`;
- `ADMIN_PROCESSING_RECOVERY`.

### Regras

- status operacional: 30 consultas por 10 minutos, com intervalo mínimo de 3 segundos;
- filas administrativas: 600 itens por 10 minutos no total e 240 por fila, cobrados pelo limite solicitado;
- moderação: 120 unidades por 10 minutos e 12 por vídeo, custo 2 por revisão;
- recuperação de processamento: 90 unidades por 10 minutos e 9 por vídeo, custo 3 por comando.

As filas de moderação e recuperação compartilham o limite global, mas mantêm limites por recurso separados.

## Upload tipado

O contrato do orquestrador de upload agora corresponde integralmente ao callable interno, incluindo:

- metadados do arquivo;
- duração;
- configurações de publicação;
- `publishWhenReady`;
- resposta registrada completa.

Foi suprimido `request as any` e a delegação passou a usar `registerPrivateVideoUploadCore.run(request)` com tipagem estrutural.

A lógica existente de elegibilidade, limpeza recuperável, idempotência por `ownerUid + videoId + storagePath` e enfileiramento único foi preservada.

## Supressões e substituições intencionais

### Exportações diretas administrativas

Foram suprimidas da raiz as exportações diretas dos cinco handlers administrativos. Elas foram substituídas por `protected-admin-media-callables.handler.ts`.

Os handlers originais não foram removidos; continuam sendo os responsáveis pelas regras de domínio.

### Cast inseguro do upload

Foi suprimido o cast `as any` do orquestrador. Nenhuma validação ou etapa de limpeza foi removida.

## Compatibilidade

- nomes públicos das Functions preservados;
- payloads e respostas preservados;
- Angular continua usando as mesmas strings de callable;
- tratamento de erro do frontend permanece centralizado;
- nenhuma alteração em componentes, rotas ou Firestore Rules;
- nenhuma rotina interna recebeu App Check indevidamente.

## Testes

A política de rate limiting agora valida também:

- cadência mais restritiva para status;
- cobrança proporcional das filas;
- diferença entre moderação e recuperação;
- teto por recurso mais conservador para recuperação.

## Validação concluída

- lint das Functions: aprovado;
- build TypeScript das Functions: aprovado;
- testes das Functions: aprovados;
- compilação dos cinco wrappers administrativos: aprovada;
- delegação tipada do upload sem `as any`: aprovada;
- testes Angular: aprovados;
- build Angular seguro: aprovado;
- Firestore Rules: aprovado;
- índices do Firestore: aprovado;
- Quality Gate agregado: aprovado.

Todos os jobs passaram no primeiro head, sem commit corretivo.