### PR TITLE
feat(media): centralizar claims e cooldown administrativo

### DIFF
--- a/functions/src/media/application/admin-authorization.policy.test.ts
+++ b/functions/src/media/application/admin-authorization.policy.test.ts
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  assertAdminAuthorization,
+  resolveAdminAuthorization,
+} from './admin-authorization.policy';
+
+describe('admin-authorization.policy', () => {
+  it('aceita a claim booleana admin', () => {
+    assert.deepEqual(
+      resolveAdminAuthorization({
+        uid: 'admin_1',
+        token: { admin: true },
+      }),
+      {
+        adminUid: 'admin_1',
+        allowed: true,
+        source: 'admin',
+      }
+    );
+  });
+
+  it('aceita role e roles com normalização textual', () => {
+    assert.equal(
+      resolveAdminAuthorization({
+        uid: 'admin_2',
+        token: { role: ' ADMIN ' },
+      }).source,
+      'role'
+    );
+    assert.equal(
+      resolveAdminAuthorization({
+        uid: 'admin_3',
+        token: { roles: ['moderator', 'Admin'] },
+      }).source,
+      'roles'
+    );
+  });
+
+  it('não aceita coerção booleana nem roles não textuais', () => {
+    assert.equal(
+      resolveAdminAuthorization({
+        uid: 'user_1',
+        token: { admin: 'true', role: true, roles: [true, 1] },
+      }).allowed,
+      false
+    );
+  });
+
+  it('rejeita identidade administrativa inválida como não autenticada', () => {
+    assert.throws(
+      () => assertAdminAuthorization(
+        { uid: '../admin', token: { admin: true } },
+        'Operação restrita.'
+      ),
+      (error: unknown) => {
+        const candidate = error as { code?: unknown; message?: unknown };
+        return candidate.code === 'unauthenticated' &&
+          candidate.message === 'Administrador não autenticado.';
+      }
+    );
+  });
+
+  it('preserva a mensagem de permissão do domínio', () => {
+    assert.throws(
+      () => assertAdminAuthorization(
+        { uid: 'user_2', token: {} },
+        'Apenas administradores podem revisar esta fila.'
+      ),
+      (error: unknown) => {
+        const candidate = error as { code?: unknown; message?: unknown };
+        return candidate.code === 'permission-denied' &&
+          candidate.message ===
+            'Apenas administradores podem revisar esta fila.';
+      }
+    );
+  });
+});

--- a/functions/src/media/application/admin-authorization.policy.ts
+++ b/functions/src/media/application/admin-authorization.policy.ts
@@ -1,0 +1,87 @@
+import { HttpsError } from 'firebase-functions/v2/https';
+
+export type AdminClaimSource = 'admin' | 'role' | 'roles';
+
+export interface AdminAuthorizationSnapshot {
+  readonly adminUid: string;
+  readonly allowed: boolean;
+  readonly source: AdminClaimSource | null;
+}
+
+interface CallableAuthLike {
+  readonly uid?: unknown;
+  readonly token?: unknown;
+}
+
+function cleanAdminUid(value: unknown): string {
+  const normalized = String(value ?? '').trim();
+  return /^[A-Za-z0-9_-]{1,128}$/.test(normalized) ? normalized : '';
+}
+
+function normalizeRole(value: unknown): string {
+  return typeof value === 'string'
+    ? value.trim().toLowerCase()
+    : '';
+}
+
+function authToken(value: unknown): Readonly<Record<string, unknown>> {
+  return typeof value === 'object' && value !== null
+    ? value as Readonly<Record<string, unknown>>
+    : {};
+}
+
+/**
+ * Resolve claims administrativas sem confiar em coerção booleana ou valores
+ * não textuais. A plataforma aceita exclusivamente os formatos já usados:
+ * `admin: true`, `role: 'admin'` ou `roles: ['admin']`.
+ */
+export function resolveAdminAuthorization(
+  requestAuth: unknown
+): AdminAuthorizationSnapshot {
+  const auth = requestAuth as CallableAuthLike | null | undefined;
+  const adminUid = cleanAdminUid(auth?.uid);
+  const token = authToken(auth?.token);
+
+  if (token['admin'] === true) {
+    return { adminUid, allowed: true, source: 'admin' };
+  }
+
+  if (normalizeRole(token['role']) === 'admin') {
+    return { adminUid, allowed: true, source: 'role' };
+  }
+
+  const roles = Array.isArray(token['roles'])
+    ? token['roles'].map(normalizeRole)
+    : [];
+
+  if (roles.includes('admin')) {
+    return { adminUid, allowed: true, source: 'roles' };
+  }
+
+  return { adminUid, allowed: false, source: null };
+}
+
+/**
+ * Autoriza uma operação administrativa e devolve o UID já normalizado.
+ * A mensagem de permissão permanece específica do domínio chamador.
+ */
+export function assertAdminAuthorization(
+  requestAuth: unknown,
+  permissionMessage: string
+): string {
+  const authorization = resolveAdminAuthorization(requestAuth);
+
+  if (!authorization.adminUid) {
+    throw new HttpsError('unauthenticated', 'Administrador não autenticado.');
+  }
+
+  if (!authorization.allowed) {
+    throw new HttpsError(
+      'permission-denied',
+      String(permissionMessage ?? '').trim() ||
+        'Apenas administradores podem concluir esta ação.'
+    );
+  }
+
+  return authorization.adminUid;
+}

--- a/functions/src/media/application/protected-admin-media-callables.handler.ts
+++ b/functions/src/media/application/protected-admin-media-callables.handler.ts
@@ -4,6 +4,9 @@ import {
   ADMIN_BROWSER_CALLABLE_OPTIONS,
 } from '../../config/admin-browser-callable-options';
 import {
+  assertAdminAuthorization,
+} from './admin-authorization.policy';
+import {
   listVideoModerationQueue as listVideoModerationQueueCore,
   reviewVideoModeration as reviewVideoModerationCore,
 } from './admin-video-moderation.handler';
@@ -84,10 +87,6 @@ async function applyAdminRateLimit(input: {
   resourceKey: string;
   cost?: number;
 }): Promise<void> {
-  if (!input.actorUid) {
-    return;
-  }
-
   await assertMediaCallableRateLimit(input);
 }
 
@@ -96,8 +95,13 @@ export const getVideoProcessingOperationalStatus = onCall<
 >(
   ADMIN_BROWSER_CALLABLE_OPTIONS,
   async (request) => {
+    const adminUid = assertAdminAuthorization(
+      request.auth,
+      'Apenas administradores podem consultar o processamento de vídeos.'
+    );
+
     await applyAdminRateLimit({
-      actorUid: cleanId(request.auth?.uid),
+      actorUid: adminUid,
       action: 'ADMIN_STATUS',
       resourceKey: 'video-processing-operational-status',
     });
@@ -111,6 +115,10 @@ export const listVideoModerationQueue = onCall<
 >(
   ADMIN_BROWSER_CALLABLE_OPTIONS,
   async (request) => {
+    const adminUid = assertAdminAuthorization(
+      request.auth,
+      'Apenas administradores podem moderar vídeos.'
+    );
     const limit = normalizeLimit(
       request.data?.limit,
       DEFAULT_MODERATION_QUEUE_LIMIT,
@@ -118,7 +126,7 @@ export const listVideoModerationQueue = onCall<
     );
 
     await applyAdminRateLimit({
-      actorUid: cleanId(request.auth?.uid),
+      actorUid: adminUid,
       action: 'ADMIN_QUEUE',
       resourceKey: 'video-moderation-queue',
       cost: limit,
@@ -131,8 +139,13 @@ export const listVideoModerationQueue = onCall<
 export const reviewVideoModeration = onCall<ReviewVideoModerationRequest>(
   ADMIN_BROWSER_CALLABLE_OPTIONS,
   async (request) => {
+    const adminUid = assertAdminAuthorization(
+      request.auth,
+      'Apenas administradores podem moderar vídeos.'
+    );
+
     await applyAdminRateLimit({
-      actorUid: cleanId(request.auth?.uid),
+      actorUid: adminUid,
       action: 'ADMIN_MODERATION',
       resourceKey: mediaResourceKey(
         'video-moderation',
@@ -151,6 +164,10 @@ export const listVideoProcessingRecoveryJobs = onCall<
 >(
   ADMIN_BROWSER_CALLABLE_OPTIONS,
   async (request) => {
+    const adminUid = assertAdminAuthorization(
+      request.auth,
+      'Apenas administradores podem recuperar o processamento de vídeos.'
+    );
     const limit = normalizeLimit(
       request.data?.limit,
       DEFAULT_RECOVERY_QUEUE_LIMIT,
@@ -158,7 +175,7 @@ export const listVideoProcessingRecoveryJobs = onCall<
     );
 
     await applyAdminRateLimit({
-      actorUid: cleanId(request.auth?.uid),
+      actorUid: adminUid,
       action: 'ADMIN_QUEUE',
       resourceKey: 'video-processing-recovery-queue',
       cost: limit,
@@ -173,8 +190,13 @@ export const recoverVideoProcessingJob = onCall<
 >(
   ADMIN_BROWSER_CALLABLE_OPTIONS,
   async (request) => {
+    const adminUid = assertAdminAuthorization(
+      request.auth,
+      'Apenas administradores podem recuperar o processamento de vídeos.'
+    );
+
     await applyAdminRateLimit({
-      actorUid: cleanId(request.auth?.uid),
+      actorUid: adminUid,
       action: 'ADMIN_PROCESSING_RECOVERY',
       resourceKey: mediaResourceKey(
         'video-processing-recovery',

--- a/functions/src/media/application/protected-media-callables.handler.ts
+++ b/functions/src/media/application/protected-media-callables.handler.ts
@@ -2,6 +2,9 @@ import { onCall } from 'firebase-functions/v2/https';
 
 import { PROTECTED_CALLABLE_OPTIONS } from '../../config/protected-callable-options';
 import {
+  assertAdminAuthorization,
+} from './admin-authorization.policy';
+import {
   authorizePublicVideoShare as authorizePublicVideoShareCore,
 } from './authorize-public-video-share.handler';
 import {
@@ -265,8 +268,13 @@ export const reviewVideoContentReport = onCall<
 >(
   PROTECTED_CALLABLE_OPTIONS,
   async (request) => {
+    const adminUid = assertAdminAuthorization(
+      request.auth,
+      'Apenas administradores podem revisar denúncias de vídeo.'
+    );
+
     await consumeLimit({
-      actorUid: request.auth?.uid,
+      actorUid: adminUid,
       action: 'REPORT_MODERATE',
       resourceKey: `report:${keyPart(request.data?.reportId)}`,
     });

--- a/functions/src/media/application/video-view-session.policy.test.ts
+++ b/functions/src/media/application/video-view-session.policy.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
+import './admin-authorization.policy.test';
 import './media-callable-rate-limit.policy.test';
 import './media-mutation-idempotency.policy.test';
 import './photo-audience-access.policy.test';

--- a/src/app/admin-dashboard/video-moderation/video-moderation.component.html
+++ b/src/app/admin-dashboard/video-moderation/video-moderation.component.html
@@ -13,11 +13,27 @@
       type="button"
       class="app-action app-action--ghost"
       (click)="retry()"
+      [disabled]="refreshCooldown().active"
     >
       <i class="fas fa-rotate" aria-hidden="true"></i>
-      Atualizar fila
+      {{ refreshCooldown().active
+        ? 'Aguarde ' + refreshCooldown().remainingSeconds + 's'
+        : 'Atualizar fila' }}
     </button>
   </header>
+
+  @if (cooldownMessage(); as message) {
+    @if (message) {
+      <p
+        class="video-moderation__warning"
+        role="status"
+        aria-live="polite"
+      >
+        <i class="fas fa-hourglass-half" aria-hidden="true"></i>
+        {{ message }}
+      </p>
+    }
+  }
 
   @if (processingState$ | async; as processing) {
     <section
@@ -163,8 +179,15 @@
         >
           <i class="fas fa-triangle-exclamation" aria-hidden="true"></i>
           <span>Não foi possível carregar os jobs de recuperação.</span>
-          <button type="button" class="app-action app-action--ghost" (click)="retry()">
-            Tentar novamente
+          <button
+            type="button"
+            class="app-action app-action--ghost"
+            (click)="retry()"
+            [disabled]="refreshCooldown().active"
+          >
+            {{ refreshCooldown().active
+              ? 'Aguarde ' + refreshCooldown().remainingSeconds + 's'
+              : 'Tentar novamente' }}
           </button>
         </div>
       } @else if (recoveryState.status === 'empty') {
@@ -261,7 +284,7 @@
                             maxlength="900"
                             [ngModel]="recoveryReason(item)"
                             (ngModelChange)="setRecoveryReason(item, $event)"
-                            [disabled]="isRecoveryBusy(item)"
+                            [disabled]="isRecoveryBusy(item) || recoveryActionCooldown().active"
                             placeholder="Descreva por que esta intervenção é necessária."
                           ></textarea>
                           <small>{{ recoveryReason(item).length }}/900</small>
@@ -272,10 +295,14 @@
                             type="button"
                             class="app-action app-action--primary"
                             (click)="confirmRecovery(item, action)"
-                            [disabled]="isRecoveryBusy(item)"
+                            [disabled]="isRecoveryBusy(item) || recoveryActionCooldown().active"
                           >
                             <i class="fas fa-check" aria-hidden="true"></i>
-                            {{ isRecoveryBusy(item) ? 'Confirmando...' : 'Confirmar ação' }}
+                            {{ isRecoveryBusy(item)
+                              ? 'Confirmando...'
+                              : recoveryActionCooldown().active
+                                ? 'Aguarde ' + recoveryActionCooldown().remainingSeconds + 's'
+                                : 'Confirmar ação' }}
                           </button>
                           <button
                             type="button"
@@ -294,7 +321,7 @@
                         [class.app-action--danger]="action === 'CANCEL_ACTIVE'"
                         [class.app-action--ghost]="action !== 'CANCEL_ACTIVE'"
                         (click)="beginRecovery(item, action)"
-                        [disabled]="isRecoveryBusy(item)"
+                        [disabled]="isRecoveryBusy(item) || recoveryActionCooldown().active"
                       >
                         <i
                           class="fas"
@@ -302,7 +329,9 @@
                           [class.fa-ban]="action === 'CANCEL_ACTIVE'"
                           aria-hidden="true"
                         ></i>
-                        {{ recoveryActionLabel(action) }}
+                        {{ recoveryActionCooldown().active
+                          ? 'Aguarde ' + recoveryActionCooldown().remainingSeconds + 's'
+                          : recoveryActionLabel(action) }}
                       </button>
                     }
                   }
@@ -331,8 +360,15 @@
           <strong>Não foi possível carregar a fila.</strong>
           <span>Verifique a sessão administrativa e tente novamente.</span>
         </div>
-        <button type="button" class="app-action app-action--ghost" (click)="retry()">
-          Tentar novamente
+        <button
+          type="button"
+          class="app-action app-action--ghost"
+          (click)="retry()"
+          [disabled]="refreshCooldown().active"
+        >
+          {{ refreshCooldown().active
+            ? 'Aguarde ' + refreshCooldown().remainingSeconds + 's'
+            : 'Tentar novamente' }}
         </button>
       </div>
     } @else if (state.status === 'empty') {
@@ -407,7 +443,7 @@
                   maxlength="900"
                   [ngModel]="reason(item)"
                   (ngModelChange)="setReason(item, $event)"
-                  [disabled]="isBusy(item)"
+                  [disabled]="isBusy(item) || moderationActionCooldown().active"
                   placeholder="Obrigatória para rejeição; opcional para aprovação."
                 ></textarea>
                 <small>{{ reason(item).length }}/900</small>
@@ -418,20 +454,28 @@
                   type="button"
                   class="app-action app-action--primary"
                   (click)="approve(item)"
-                  [disabled]="isBusy(item)"
+                  [disabled]="isBusy(item) || moderationActionCooldown().active"
                 >
                   <i class="fas fa-check" aria-hidden="true"></i>
-                  {{ isBusy(item) ? 'Processando...' : 'Aprovar vídeo' }}
+                  {{ isBusy(item)
+                    ? 'Processando...'
+                    : moderationActionCooldown().active
+                      ? 'Aguarde ' + moderationActionCooldown().remainingSeconds + 's'
+                      : 'Aprovar vídeo' }}
                 </button>
 
                 <button
                   type="button"
                   class="app-action app-action--danger"
                   (click)="reject(item)"
-                  [disabled]="isBusy(item)"
+                  [disabled]="isBusy(item) || moderationActionCooldown().active"
                 >
                   <i class="fas fa-ban" aria-hidden="true"></i>
-                  {{ isBusy(item) ? 'Processando...' : 'Rejeitar vídeo' }}
+                  {{ isBusy(item)
+                    ? 'Processando...'
+                    : moderationActionCooldown().active
+                      ? 'Aguarde ' + moderationActionCooldown().remainingSeconds + 's'
+                      : 'Rejeitar vídeo' }}
                 </button>
               </div>
             </div>

--- a/src/app/admin-dashboard/video-moderation/video-moderation.component.ts
+++ b/src/app/admin-dashboard/video-moderation/video-moderation.component.ts
@@ -3,10 +3,14 @@ import {
   ChangeDetectionStrategy,
   Component,
   DestroyRef,
+  computed,
   inject,
   signal,
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import {
+  takeUntilDestroyed,
+  toSignal,
+} from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import {
@@ -25,6 +29,12 @@ import {
   switchMap,
 } from 'rxjs/operators';
 
+import {
+  ICallableCooldownState,
+} from 'src/app/core/services/error-handler/callable-cooldown.policy';
+import {
+  CallableCooldownService,
+} from 'src/app/core/services/error-handler/callable-cooldown.service';
 import { ErrorNotificationService } from 'src/app/core/services/error-handler/error-notification.service';
 import {
   AdminVideoModerationDecision,
@@ -70,6 +80,23 @@ type ReasonDrafts = Record<string, string>;
 
 const ACCESS_REFRESH_INTERVAL_MS = 8 * 60 * 1000;
 const PROCESSING_STATUS_REFRESH_INTERVAL_MS = 60 * 1000;
+const COOLDOWN_SCOPE = {
+  status: 'admin-video-processing-status',
+  moderationQueue: 'admin-video-moderation-queue',
+  recoveryQueue: 'admin-video-recovery-queue',
+  moderationAction: 'admin-video-moderation-action',
+  recoveryAction: 'admin-video-recovery-action',
+} as const;
+
+function inactiveCooldown(scope: string): ICallableCooldownState {
+  return {
+    scope,
+    active: false,
+    expiresAt: 0,
+    remainingMs: 0,
+    remainingSeconds: 0,
+  };
+}
 
 @Component({
   selector: 'app-video-moderation',
@@ -87,6 +114,7 @@ export class VideoModerationComponent {
   private readonly moderation = inject(AdminVideoModerationService);
   private readonly recovery = inject(AdminVideoProcessingRecoveryService);
   private readonly notification = inject(ErrorNotificationService);
+  private readonly cooldowns = inject(CallableCooldownService);
 
   private readonly refreshSubject = new BehaviorSubject<number>(0);
   readonly busyVideoKey = signal<string | null>(null);
@@ -95,6 +123,57 @@ export class VideoModerationComponent {
   readonly recoveryReasonDrafts = signal<ReasonDrafts>({});
   readonly pendingRecoveryConfirmation =
     signal<PendingRecoveryConfirmation | null>(null);
+
+  readonly statusCooldown = toSignal(
+    this.cooldowns.state$(COOLDOWN_SCOPE.status),
+    { initialValue: inactiveCooldown(COOLDOWN_SCOPE.status) }
+  );
+  readonly moderationQueueCooldown = toSignal(
+    this.cooldowns.state$(COOLDOWN_SCOPE.moderationQueue),
+    { initialValue: inactiveCooldown(COOLDOWN_SCOPE.moderationQueue) }
+  );
+  readonly recoveryQueueCooldown = toSignal(
+    this.cooldowns.state$(COOLDOWN_SCOPE.recoveryQueue),
+    { initialValue: inactiveCooldown(COOLDOWN_SCOPE.recoveryQueue) }
+  );
+  readonly moderationActionCooldown = toSignal(
+    this.cooldowns.state$(COOLDOWN_SCOPE.moderationAction),
+    { initialValue: inactiveCooldown(COOLDOWN_SCOPE.moderationAction) }
+  );
+  readonly recoveryActionCooldown = toSignal(
+    this.cooldowns.state$(COOLDOWN_SCOPE.recoveryAction),
+    { initialValue: inactiveCooldown(COOLDOWN_SCOPE.recoveryAction) }
+  );
+
+  readonly refreshCooldown = computed(() => {
+    const states = [
+      this.statusCooldown(),
+      this.moderationQueueCooldown(),
+      this.recoveryQueueCooldown(),
+    ];
+
+    return states.reduce((longest, current) =>
+      current.remainingMs > longest.remainingMs ? current : longest
+    );
+  });
+
+  readonly cooldownMessage = computed(() => {
+    const active = [
+      this.refreshCooldown(),
+      this.moderationActionCooldown(),
+      this.recoveryActionCooldown(),
+    ].filter((state) => state.active);
+
+    if (active.length === 0) {
+      return '';
+    }
+
+    const remainingSeconds = Math.max(
+      ...active.map((state) => state.remainingSeconds)
+    );
+
+    return `Proteção contra excesso de chamadas ativa. Tente novamente em ${remainingSeconds} segundo(s).`;
+  });
 
   readonly processingState$: Observable<VideoProcessingPanelState> = merge(
     this.refreshSubject,
@@ -113,10 +192,17 @@ export class VideoModerationComponent {
           status: 'loading',
           data: null,
         } as VideoProcessingPanelState),
-        catchError(() => of({
-          status: 'error',
-          data: null,
-        } as VideoProcessingPanelState))
+        catchError((error) => {
+          this.cooldowns.captureResourceExhausted(
+            error,
+            COOLDOWN_SCOPE.status,
+            3_000
+          );
+          return of({
+            status: 'error',
+            data: null,
+          } as VideoProcessingPanelState);
+        })
       )
     ),
     shareReplay({ bufferSize: 1, refCount: true })
@@ -143,12 +229,19 @@ export class VideoModerationComponent {
           skippedItems: 0,
           checkedAt: 0,
         } as VideoProcessingRecoveryPanelState),
-        catchError(() => of({
-          status: 'error',
-          items: [],
-          skippedItems: 0,
-          checkedAt: 0,
-        } as VideoProcessingRecoveryPanelState))
+        catchError((error) => {
+          this.cooldowns.captureResourceExhausted(
+            error,
+            COOLDOWN_SCOPE.recoveryQueue,
+            2_000
+          );
+          return of({
+            status: 'error',
+            items: [],
+            skippedItems: 0,
+            checkedAt: 0,
+          } as VideoProcessingRecoveryPanelState);
+        })
       )
     ),
     shareReplay({ bufferSize: 1, refCount: true })
@@ -170,17 +263,28 @@ export class VideoModerationComponent {
           items: [],
           skippedItems: 0,
         } as VideoModerationQueueState),
-        catchError(() => of({
-          status: 'error',
-          items: [],
-          skippedItems: 0,
-        } as VideoModerationQueueState))
+        catchError((error) => {
+          this.cooldowns.captureResourceExhausted(
+            error,
+            COOLDOWN_SCOPE.moderationQueue,
+            2_000
+          );
+          return of({
+            status: 'error',
+            items: [],
+            skippedItems: 0,
+          } as VideoModerationQueueState);
+        })
       )
     ),
     shareReplay({ bufferSize: 1, refCount: true })
   );
 
   retry(): void {
+    if (this.cooldowns.notifyIfActive(this.refreshCooldown().scope)) {
+      return;
+    }
+
     this.refreshSubject.next(this.refreshSubject.value + 1);
   }
 
@@ -298,6 +402,7 @@ export class VideoModerationComponent {
     action: AdminVideoProcessingRecoveryAction
   ): void {
     if (
+      this.cooldowns.notifyIfActive(COOLDOWN_SCOPE.recoveryAction) ||
       this.busyRecoveryKey() ||
       !item.availableActions.includes(action)
     ) {
@@ -330,7 +435,11 @@ export class VideoModerationComponent {
     const key = this.recoveryItemKey(item);
     const reason = this.recoveryReason(item).trim();
 
-    if (!this.isRecoveryConfirmation(item, action) || this.busyRecoveryKey()) {
+    if (
+      this.cooldowns.notifyIfActive(COOLDOWN_SCOPE.recoveryAction) ||
+      !this.isRecoveryConfirmation(item, action) ||
+      this.busyRecoveryKey()
+    ) {
       return;
     }
 
@@ -369,10 +478,18 @@ export class VideoModerationComponent {
         );
         this.retry();
       },
-      error: () => {
-        this.notification.showError(
-          'Não foi possível concluir a recuperação deste processamento.'
-        );
+      error: (error) => {
+        if (
+          !this.cooldowns.captureResourceExhausted(
+            error,
+            COOLDOWN_SCOPE.recoveryAction,
+            3_000
+          )
+        ) {
+          this.notification.showError(
+            'Não foi possível concluir a recuperação deste processamento.'
+          );
+        }
       },
     });
   }
@@ -473,7 +590,11 @@ export class VideoModerationComponent {
   ): void {
     const key = this.itemKey(item);
 
-    if (!key || this.busyVideoKey()) {
+    if (
+      this.cooldowns.notifyIfActive(COOLDOWN_SCOPE.moderationAction) ||
+      !key ||
+      this.busyVideoKey()
+    ) {
       return;
     }
 
@@ -499,10 +620,18 @@ export class VideoModerationComponent {
         );
         this.retry();
       },
-      error: () => {
-        this.notification.showError(
-          'Não foi possível concluir a revisão deste vídeo.'
-        );
+      error: (error) => {
+        if (
+          !this.cooldowns.captureResourceExhausted(
+            error,
+            COOLDOWN_SCOPE.moderationAction,
+            2_000
+          )
+        ) {
+          this.notification.showError(
+            'Não foi possível concluir a revisão deste vídeo.'
+          );
+        }
       },
     });
   }

--- a/src/app/core/services/error-handler/callable-cooldown.policy.spec.ts
+++ b/src/app/core/services/error-handler/callable-cooldown.policy.spec.ts
@@ -1,0 +1,57 @@
+import {
+  buildCallableCooldownState,
+  isCallableResourceExhausted,
+  resolveCallableRetryAfterMs,
+} from './callable-cooldown.policy';
+
+describe('callable-cooldown.policy', () => {
+  it('reconhece o código normalizado das Functions', () => {
+    expect(isCallableResourceExhausted({
+      code: 'functions/resource-exhausted',
+    })).toBe(true);
+    expect(isCallableResourceExhausted({
+      original: { code: 'resource-exhausted' },
+    })).toBe(true);
+    expect(isCallableResourceExhausted({
+      code: 'functions/permission-denied',
+    })).toBe(false);
+  });
+
+  it('lê retryAfterMs em detalhes aninhados', () => {
+    expect(resolveCallableRetryAfterMs({
+      code: 'functions/resource-exhausted',
+      details: { retryAfterMs: 12_345 },
+    })).toBe(12_345);
+
+    expect(resolveCallableRetryAfterMs({
+      original: {
+        code: 'resource-exhausted',
+        customData: {
+          details: { retryAfterMs: 8_000 },
+        },
+      },
+    })).toBe(8_000);
+  });
+
+  it('aplica limites seguros ao retry', () => {
+    expect(resolveCallableRetryAfterMs({
+      details: { retryAfterMs: 10 },
+    })).toBe(1_000);
+    expect(resolveCallableRetryAfterMs({
+      details: { retryAfterMs: 99_999_999 },
+    })).toBe(10 * 60 * 1_000);
+  });
+
+  it('produz contagem regressiva acessível', () => {
+    expect(buildCallableCooldownState('admin', 15_500, 10_000)).toEqual({
+      scope: 'admin',
+      active: true,
+      expiresAt: 15_500,
+      remainingMs: 5_500,
+      remainingSeconds: 6,
+    });
+
+    expect(buildCallableCooldownState('admin', 9_000, 10_000).active)
+      .toBe(false);
+  });
+});

--- a/src/app/core/services/error-handler/callable-cooldown.policy.ts
+++ b/src/app/core/services/error-handler/callable-cooldown.policy.ts
@@ -1,0 +1,123 @@
+export interface ICallableCooldownState {
+  scope: string;
+  active: boolean;
+  expiresAt: number;
+  remainingMs: number;
+  remainingSeconds: number;
+}
+
+const MIN_RETRY_AFTER_MS = 1_000;
+const MAX_RETRY_AFTER_MS = 10 * 60 * 1_000;
+const DEFAULT_RETRY_AFTER_MS = 5_000;
+
+interface ErrorCandidate {
+  code?: unknown;
+  details?: unknown;
+  data?: unknown;
+  customData?: unknown;
+  original?: unknown;
+  cause?: unknown;
+}
+
+function normalizePositiveInteger(value: unknown): number | null {
+  const numeric = Number(value);
+
+  return Number.isFinite(numeric) && numeric > 0
+    ? Math.trunc(numeric)
+    : null;
+}
+
+function normalizeRetryAfterMs(value: unknown, fallbackMs: number): number {
+  const numeric = normalizePositiveInteger(value) ??
+    normalizePositiveInteger(fallbackMs) ??
+    DEFAULT_RETRY_AFTER_MS;
+
+  return Math.max(
+    MIN_RETRY_AFTER_MS,
+    Math.min(MAX_RETRY_AFTER_MS, numeric)
+  );
+}
+
+function normalizeCode(value: unknown): string {
+  return String(value ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/^functions\//, '')
+    .replace(/^firebase-functions\//, '');
+}
+
+function objectRecord(value: unknown): Readonly<Record<string, unknown>> | null {
+  return typeof value === 'object' && value !== null
+    ? value as Readonly<Record<string, unknown>>
+    : null;
+}
+
+function errorCandidates(error: unknown): Readonly<Record<string, unknown>>[] {
+  const queue: unknown[] = [error];
+  const visited = new Set<object>();
+  const result: Readonly<Record<string, unknown>>[] = [];
+
+  while (queue.length > 0 && result.length < 12) {
+    const current = queue.shift();
+    const record = objectRecord(current);
+
+    if (!record || visited.has(record as object)) {
+      continue;
+    }
+
+    visited.add(record as object);
+    result.push(record);
+
+    const candidate = record as ErrorCandidate;
+    queue.push(
+      candidate.original,
+      candidate.cause,
+      candidate.details,
+      candidate.data,
+      candidate.customData
+    );
+  }
+
+  return result;
+}
+
+export function isCallableResourceExhausted(error: unknown): boolean {
+  return errorCandidates(error).some(
+    (candidate) => normalizeCode(candidate['code']) === 'resource-exhausted'
+  );
+}
+
+export function resolveCallableRetryAfterMs(
+  error: unknown,
+  fallbackMs = DEFAULT_RETRY_AFTER_MS
+): number {
+  for (const candidate of errorCandidates(error)) {
+    const direct = normalizePositiveInteger(candidate['retryAfterMs']);
+
+    if (direct !== null) {
+      return normalizeRetryAfterMs(direct, fallbackMs);
+    }
+  }
+
+  return normalizeRetryAfterMs(fallbackMs, DEFAULT_RETRY_AFTER_MS);
+}
+
+export function buildCallableCooldownState(
+  scope: string,
+  expiresAt: number,
+  now = Date.now()
+): ICallableCooldownState {
+  const safeExpiresAt = normalizePositiveInteger(expiresAt) ?? 0;
+  const safeNow = normalizePositiveInteger(now) ?? 0;
+  const remainingMs = Math.max(0, safeExpiresAt - safeNow);
+
+  return {
+    scope: String(scope ?? '').trim(),
+    active: remainingMs > 0,
+    expiresAt: safeExpiresAt,
+    remainingMs,
+    remainingSeconds: remainingMs > 0
+      ? Math.max(1, Math.ceil(remainingMs / 1_000))
+      : 0,
+  };
+}

--- a/src/app/core/services/error-handler/callable-cooldown.service.spec.ts
+++ b/src/app/core/services/error-handler/callable-cooldown.service.spec.ts
@@ -1,0 +1,65 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ErrorNotificationService } from './error-notification.service';
+import { CallableCooldownService } from './callable-cooldown.service';
+
+describe('CallableCooldownService', () => {
+  let service: CallableCooldownService;
+  let warnings: string[];
+  let infos: string[];
+
+  beforeEach(() => {
+    warnings = [];
+    infos = [];
+
+    TestBed.configureTestingModule({
+      providers: [
+        CallableCooldownService,
+        {
+          provide: ErrorNotificationService,
+          useValue: {
+            showWarning: (message: string) => warnings.push(message),
+            showInfo: (message: string) => infos.push(message),
+          },
+        },
+      ],
+    });
+
+    service = TestBed.inject(CallableCooldownService);
+  });
+
+  it('registra resource-exhausted e expõe snapshot ativo', () => {
+    const error = {
+      code: 'functions/resource-exhausted',
+      details: { retryAfterMs: 4_000 },
+    };
+
+    expect(service.captureResourceExhausted(error, 'admin')).toBe(true);
+    expect(service.snapshot('admin').active).toBe(true);
+    expect(service.snapshot('admin').remainingSeconds).toBeGreaterThan(0);
+    expect(service.wasHandled(error)).toBe(true);
+    expect(warnings.length).toBe(1);
+  });
+
+  it('ignora erros que não representam limite', () => {
+    const error = { code: 'functions/permission-denied' };
+
+    expect(service.captureResourceExhausted(error, 'admin')).toBe(false);
+    expect(service.snapshot('admin').active).toBe(false);
+    expect(service.wasHandled(error)).toBe(false);
+    expect(warnings).toEqual([]);
+  });
+
+  it('orienta o usuário quando a ação ainda está bloqueada', () => {
+    service.captureResourceExhausted(
+      {
+        code: 'resource-exhausted',
+        details: { retryAfterMs: 3_000 },
+      },
+      'admin'
+    );
+
+    expect(service.notifyIfActive('admin')).toBe(true);
+    expect(infos.length).toBe(1);
+  });
+});

--- a/src/app/core/services/error-handler/callable-cooldown.service.ts
+++ b/src/app/core/services/error-handler/callable-cooldown.service.ts
@@ -1,0 +1,142 @@
+import { Injectable, inject } from '@angular/core';
+import {
+  BehaviorSubject,
+  Observable,
+  distinctUntilChanged,
+  map,
+  of,
+  shareReplay,
+  switchMap,
+  tap,
+  timer,
+} from 'rxjs';
+
+import {
+  ICallableCooldownState,
+  buildCallableCooldownState,
+  isCallableResourceExhausted,
+  resolveCallableRetryAfterMs,
+} from './callable-cooldown.policy';
+import { ErrorNotificationService } from './error-notification.service';
+
+const EMPTY_EXPIRATIONS: Readonly<Record<string, number>> = Object.freeze({});
+
+@Injectable({ providedIn: 'root' })
+export class CallableCooldownService {
+  private readonly notification = inject(ErrorNotificationService);
+  private readonly expirationsSubject = new BehaviorSubject<
+    Readonly<Record<string, number>>
+  >(EMPTY_EXPIRATIONS);
+  private readonly handledErrors = new WeakSet<object>();
+
+  state$(scope: string): Observable<ICallableCooldownState> {
+    const safeScope = this.normalizeScope(scope);
+
+    return this.expirationsSubject.pipe(
+      map((expirations) => expirations[safeScope] ?? 0),
+      distinctUntilChanged(),
+      switchMap((expiresAt) => {
+        const initial = buildCallableCooldownState(safeScope, expiresAt);
+
+        if (!initial.active) {
+          return of(initial);
+        }
+
+        return timer(0, 1_000).pipe(
+          map(() => buildCallableCooldownState(safeScope, expiresAt)),
+          tap((state) => {
+            if (!state.active) {
+              this.clearExpiredScope(safeScope, expiresAt);
+            }
+          }),
+          distinctUntilChanged(
+            (previous, current) =>
+              previous.active === current.active &&
+              previous.remainingSeconds === current.remainingSeconds &&
+              previous.expiresAt === current.expiresAt
+          )
+        );
+      }),
+      shareReplay({ bufferSize: 1, refCount: true })
+    );
+  }
+
+  captureResourceExhausted(
+    error: unknown,
+    scope: string,
+    fallbackMs = 5_000
+  ): boolean {
+    if (!isCallableResourceExhausted(error)) {
+      return false;
+    }
+
+    const safeScope = this.normalizeScope(scope);
+    const retryAfterMs = resolveCallableRetryAfterMs(error, fallbackMs);
+    const currentExpiration = this.expirationsSubject.value[safeScope] ?? 0;
+    const expiresAt = Math.max(currentExpiration, Date.now() + retryAfterMs);
+
+    this.expirationsSubject.next({
+      ...this.expirationsSubject.value,
+      [safeScope]: expiresAt,
+    });
+    this.markHandled(error);
+
+    const seconds = Math.max(1, Math.ceil(retryAfterMs / 1_000));
+    this.notification.showWarning(
+      `Limite temporário atingido. Aguarde ${seconds} segundo(s) antes de tentar novamente.`
+    );
+
+    return true;
+  }
+
+  notifyIfActive(scope: string): boolean {
+    const state = this.snapshot(scope);
+
+    if (!state.active) {
+      return false;
+    }
+
+    this.notification.showInfo(
+      `Esta ação estará disponível novamente em ${state.remainingSeconds} segundo(s).`
+    );
+
+    return true;
+  }
+
+  snapshot(scope: string): ICallableCooldownState {
+    const safeScope = this.normalizeScope(scope);
+    return buildCallableCooldownState(
+      safeScope,
+      this.expirationsSubject.value[safeScope] ?? 0
+    );
+  }
+
+  wasHandled(error: unknown): boolean {
+    return typeof error === 'object' && error !== null
+      ? this.handledErrors.has(error)
+      : false;
+  }
+
+  private markHandled(error: unknown): void {
+    if (typeof error === 'object' && error !== null) {
+      this.handledErrors.add(error);
+    }
+  }
+
+  private clearExpiredScope(scope: string, expectedExpiration: number): void {
+    const current = this.expirationsSubject.value;
+
+    if (current[scope] !== expectedExpiration) {
+      return;
+    }
+
+    const next = { ...current };
+    delete next[scope];
+    this.expirationsSubject.next(next);
+  }
+
+  private normalizeScope(value: unknown): string {
+    const normalized = String(value ?? '').trim();
+    return normalized || 'callable';
+  }
+}


### PR DESCRIPTION
## Dependência

PR empilhado sobre o #57 (`agent/media-p0-upload-core-admin-app-check`). Nenhum merge é realizado por este pacote.

## Escopo

Este pacote centraliza a autorização administrativa na borda pública das callables de mídia e adiciona cooldown reativo no painel Angular para respostas `resource-exhausted`.

## Política de autorização administrativa

Foi criada `admin-authorization.policy.ts` para interpretar exclusivamente os formatos de claims já usados pela plataforma:

- `admin: true`;
- `role: 'admin'`;
- `roles: ['admin']`.

A política:

- normaliza UID e roles sem coerção booleana;
- rejeita identidade inválida como `unauthenticated`;
- preserva mensagens específicas de permissão de cada domínio;
- devolve o UID administrativo normalizado para rate limiting e logs.

## Borda pública protegida

A autorização central passa a ocorrer antes do rate limiting em:

- `getVideoProcessingOperationalStatus`;
- `listVideoModerationQueue`;
- `reviewVideoModeration`;
- `listVideoProcessingRecoveryJobs`;
- `recoverVideoProcessingJob`;
- `reviewVideoContentReport`.

Assim, um usuário autenticado sem claim administrativa não consome documentos de limite nem alcança leituras ou mutações administrativas.

Os `assertAdmin` locais dos handlers de domínio não foram removidos neste diff. Eles permanecem como segunda barreira quando um core é executado diretamente em testes ou por código interno. A fonte canônica da borda pública é a nova política compartilhada.

## Cooldown reativo no Angular

Foram criados:

- `callable-cooldown.policy.ts`;
- `callable-cooldown.service.ts`.

O serviço central:

- reconhece `resource-exhausted` e `functions/resource-exhausted`;
- lê `retryAfterMs` inclusive em estruturas aninhadas de erro;
- limita a janela local entre 1 segundo e 10 minutos;
- mantém expirações por escopo em `BehaviorSubject`;
- expõe estado por Observable com contagem regressiva;
- usa `ErrorNotificationService` para feedback seguro;
- deduplica mensagens pela infraestrutura existente;
- nunca exibe detalhes técnicos do Firebase.

## Painel de moderação

O painel agora possui escopos independentes para:

- diagnóstico operacional;
- fila de moderação;
- fila de recuperação;
- decisões de moderação;
- comandos de recuperação.

Durante o cooldown:

- botões ficam desabilitados;
- o texto do botão mostra os segundos restantes;
- uma mensagem `aria-live` informa o estado;
- cliques locais são bloqueados antes de nova chamada;
- erros que não representam limite continuam usando o tratamento central existente.

Os timers automáticos e os métodos públicos dos serviços foram preservados.

## Supressões e substituições intencionais

### Leitura de claims na borda

Foi suprimida dos wrappers a dependência exclusiva do `assertAdmin` duplicado dentro dos handlers. A borda agora usa `assertAdminAuthorization` antes de rate limiting e delegação.

Os checks internos não foram ocultados nem removidos; foram preservados deliberadamente como defesa em profundidade.

### Erro genérico após rate limit

Foi suprimida no componente a notificação genérica quando o erro é `resource-exhausted`. Ela foi substituída por aviso com contagem regressiva emitido pelo serviço central de cooldown.

Erros de outra natureza continuam exibindo as mensagens anteriores.

## Compatibilidade e acessibilidade

- nomes públicos das Functions preservados;
- contratos de request/response preservados;
- Observables continuam sendo a fonte reativa;
- signals são usados somente para projeção de estado na UI;
- controles usam `disabled`, `aria-live` e mensagens em português;
- layout e componentes existentes foram mantidos;
- nenhuma Firestore Rule ou rotina interna foi alterada.

## Testes adicionados

Backend:

- claim booleana;
- `role` e `roles` normalizados;
- rejeição de coerção insegura;
- UID inválido;
- preservação da mensagem de domínio.

Angular:

- reconhecimento de códigos Functions;
- leitura aninhada de `retryAfterMs`;
- limites mínimo e máximo;
- cálculo da contagem regressiva;
- captura e estado do serviço;
- bloqueio local e feedback.

## Validação concluída

- lint, build e testes das Functions: aprovados;
- política administrativa e testes de claims: aprovados;
- testes Angular, incluindo política e serviço de cooldown: aprovados;
- template do painel com contagem regressiva: compilado;
- build Angular seguro: aprovado;
- Firestore Rules: aprovadas;
- índices do Firestore: aprovados;
- Quality Gate agregado: aprovado;
- Angular CI Validation: aprovado;
- build da configuração do Emulator: aprovado.

Todos os jobs passaram no primeiro head, sem commit corretivo.