### PR TITLE
feat(media): proteger visualizações de fotos com sessão

### DIFF
--- a/functions/src/media/application/issue-photo-view-session.handler.ts
+++ b/functions/src/media/application/issue-photo-view-session.handler.ts
@@ -1,0 +1,254 @@
+import { randomBytes } from 'node:crypto';
+
+import { logger } from 'firebase-functions';
+import { HttpsError, onCall } from 'firebase-functions/v2/https';
+import { onSchedule } from 'firebase-functions/v2/scheduler';
+
+import { FUNCTIONS_REGION } from '../../config/functions-region';
+import { PROTECTED_CALLABLE_OPTIONS } from '../../config/protected-callable-options';
+import { db } from '../../firebaseApp';
+import {
+  type PhotoPublicationAudienceDocument,
+  type PublicPhotoAudienceDocument,
+  resolveCanonicalPhotoAudienceTarget,
+} from './photo-audience-access.policy';
+import {
+  PHOTO_VIEW_SESSION_GLOBAL_MAX_PER_WINDOW,
+  PHOTO_VIEW_SESSION_PHOTO_MAX_PER_WINDOW,
+  PHOTO_VIEW_SESSION_TTL_MS,
+  buildPhotoViewSessionRateDecision,
+  type PhotoViewSessionRateState,
+} from './photo-view-session.policy';
+import {
+  PHOTO_VIEW_SESSION_COLLECTION,
+  PHOTO_VIEW_SESSION_RATE_LIMIT_COLLECTION,
+  cleanPhotoViewSource,
+  getPhotoViewSessionRef,
+  hashPhotoViewRateLimitKey,
+} from './photo-view-session.store';
+import {
+  createVideoAudienceAccessEvaluator,
+} from './video-audience-access.policy';
+
+interface IssuePhotoViewSessionRequest {
+  ownerUid?: unknown;
+  photoId?: unknown;
+  source?: unknown;
+}
+
+interface IssuePhotoViewSessionResponse {
+  ok: true;
+  ownerUid: string;
+  photoId: string;
+  sessionId: string;
+  issuedAt: number;
+  expiresAt: number;
+}
+
+const CLEANUP_BATCH_LIMIT = 240;
+const RATE_LIMIT_RETENTION_MS = 24 * 60 * 60 * 1000;
+
+function cleanId(value: unknown): string {
+  const normalized = String(value ?? '').trim();
+  return /^[A-Za-z0-9_-]{1,128}$/.test(normalized) ? normalized : '';
+}
+
+function cleanAppId(value: unknown): string {
+  const normalized = String(value ?? '').trim();
+  return normalized.length > 0 && normalized.length <= 256
+    ? normalized
+    : '';
+}
+
+function getGlobalRateLimitRef(viewerUid: string) {
+  return db.collection(PHOTO_VIEW_SESSION_RATE_LIMIT_COLLECTION).doc(
+    hashPhotoViewRateLimitKey(`global:${viewerUid}`)
+  );
+}
+
+function getPhotoRateLimitRef(
+  viewerUid: string,
+  ownerUid: string,
+  photoId: string
+) {
+  return db.collection(PHOTO_VIEW_SESSION_RATE_LIMIT_COLLECTION).doc(
+    hashPhotoViewRateLimitKey(`photo:${viewerUid}:${ownerUid}:${photoId}`)
+  );
+}
+
+function rateState(
+  data: FirebaseFirestore.DocumentData | undefined
+): Partial<PhotoViewSessionRateState> {
+  return {
+    windowStartedAt: data?.windowStartedAt,
+    count: data?.count,
+    lastIssuedAt: data?.lastIssuedAt,
+  };
+}
+
+function throwRateLimit(retryAfterMs: number): never {
+  throw new HttpsError(
+    'resource-exhausted',
+    'Muitas sessões de visualização foram solicitadas. Tente novamente em instantes.',
+    { retryAfterMs: Math.max(1_000, Math.ceil(retryAfterMs)) }
+  );
+}
+
+export const issuePhotoViewSession = onCall<IssuePhotoViewSessionRequest>(
+  PROTECTED_CALLABLE_OPTIONS,
+  async (request): Promise<IssuePhotoViewSessionResponse> => {
+    const viewerUid = cleanId(request.auth?.uid);
+    const ownerUid = cleanId(request.data?.ownerUid);
+    const photoId = cleanId(request.data?.photoId);
+    const source = cleanPhotoViewSource(request.data?.source);
+    const appId = cleanAppId(request.app?.appId);
+
+    if (!viewerUid) {
+      throw new HttpsError('unauthenticated', 'Usuário não autenticado.');
+    }
+
+    if (!ownerUid || !photoId) {
+      throw new HttpsError('invalid-argument', 'Foto inválida.');
+    }
+
+    if (viewerUid === ownerUid) {
+      throw new HttpsError(
+        'failed-precondition',
+        'Visualizações do próprio autor não são contabilizadas.'
+      );
+    }
+
+    const audience = await createVideoAudienceAccessEvaluator(viewerUid);
+    const publicPhotoRef = db.doc(
+      `public_profiles/${ownerUid}/public_photos/${photoId}`
+    );
+    const publicationRef = db.doc(
+      `users/${ownerUid}/photo_publications/${photoId}`
+    );
+    const globalRateRef = getGlobalRateLimitRef(viewerUid);
+    const photoRateRef = getPhotoRateLimitRef(viewerUid, ownerUid, photoId);
+    const sessionId = randomBytes(32).toString('base64url');
+    const sessionRef = getPhotoViewSessionRef(sessionId);
+    const now = Date.now();
+    const expiresAt = now + PHOTO_VIEW_SESSION_TTL_MS;
+
+    await db.runTransaction(async (transaction) => {
+      const [
+        publicPhotoSnapshot,
+        publicationSnapshot,
+        globalRateSnapshot,
+        photoRateSnapshot,
+      ] = await Promise.all([
+        transaction.get(publicPhotoRef),
+        transaction.get(publicationRef),
+        transaction.get(globalRateRef),
+        transaction.get(photoRateRef),
+      ]);
+
+      if (!publicPhotoSnapshot.exists || !publicationSnapshot.exists) {
+        throw new HttpsError('not-found', 'Foto pública não encontrada.');
+      }
+
+      const target = resolveCanonicalPhotoAudienceTarget({
+        ownerUid,
+        photoId,
+        publicPhoto:
+          publicPhotoSnapshot.data() as PublicPhotoAudienceDocument,
+        publication:
+          publicationSnapshot.data() as PhotoPublicationAudienceDocument,
+      });
+
+      if (!target) {
+        throw new HttpsError(
+          'failed-precondition',
+          'A foto possui dados de publicação inconsistentes.'
+        );
+      }
+
+      await audience.assertInTransaction(transaction, target);
+
+      const globalDecision = buildPhotoViewSessionRateDecision({
+        now,
+        state: rateState(globalRateSnapshot.data()),
+        maxPerWindow: PHOTO_VIEW_SESSION_GLOBAL_MAX_PER_WINDOW,
+      });
+      const photoDecision = buildPhotoViewSessionRateDecision({
+        now,
+        state: rateState(photoRateSnapshot.data()),
+        maxPerWindow: PHOTO_VIEW_SESSION_PHOTO_MAX_PER_WINDOW,
+      });
+
+      if (!globalDecision.allowed || !photoDecision.allowed) {
+        throwRateLimit(Math.max(
+          globalDecision.retryAfterMs,
+          photoDecision.retryAfterMs
+        ));
+      }
+
+      transaction.set(globalRateRef, {
+        scope: 'viewer',
+        ...globalDecision.nextState,
+        updatedAt: now,
+      });
+      transaction.set(photoRateRef, {
+        scope: 'viewer-photo',
+        ...photoDecision.nextState,
+        updatedAt: now,
+      });
+      transaction.set(sessionRef, {
+        viewerUid,
+        ownerUid,
+        photoId,
+        source,
+        appId: appId || null,
+        issuedAt: now,
+        expiresAt,
+      });
+    });
+
+    return {
+      ok: true,
+      ownerUid,
+      photoId,
+      sessionId,
+      issuedAt: now,
+      expiresAt,
+    };
+  }
+);
+
+export const cleanupExpiredPhotoViewSessions = onSchedule(
+  {
+    schedule: 'every 6 hours',
+    timeZone: 'America/Sao_Paulo',
+    region: FUNCTIONS_REGION,
+  },
+  async () => {
+    const now = Date.now();
+    const rateLimitCutoff = now - RATE_LIMIT_RETENTION_MS;
+    const [sessions, staleRateLimits] = await Promise.all([
+      db.collection(PHOTO_VIEW_SESSION_COLLECTION)
+        .where('expiresAt', '<=', now)
+        .limit(CLEANUP_BATCH_LIMIT)
+        .get(),
+      db.collection(PHOTO_VIEW_SESSION_RATE_LIMIT_COLLECTION)
+        .where('updatedAt', '<=', rateLimitCutoff)
+        .limit(CLEANUP_BATCH_LIMIT)
+        .get(),
+    ]);
+
+    if (sessions.empty && staleRateLimits.empty) {
+      return;
+    }
+
+    const batch = db.batch();
+    sessions.docs.forEach((document) => batch.delete(document.ref));
+    staleRateLimits.docs.forEach((document) => batch.delete(document.ref));
+    await batch.commit();
+
+    logger.info('[cleanupExpiredPhotoViewSessions] Dados removidos.', {
+      sessions: sessions.size,
+      rateLimits: staleRateLimits.size,
+    });
+  }
+);

--- a/functions/src/media/application/photo-view-session.policy.test.ts
+++ b/functions/src/media/application/photo-view-session.policy.test.ts
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  PHOTO_VIEW_MIN_VISIBLE_MS,
+  PHOTO_VIEW_SESSION_RATE_WINDOW_MS,
+  buildPhotoViewSessionRateDecision,
+  normalizePhotoViewEvidence,
+  normalizePhotoViewSessionToken,
+} from './photo-view-session.policy';
+
+describe('photo-view-session.policy', () => {
+  it('aceita apenas token opaco no formato esperado', () => {
+    assert.equal(normalizePhotoViewSessionToken('curto'), '');
+    assert.equal(normalizePhotoViewSessionToken('a'.repeat(32)), 'a'.repeat(32));
+    assert.equal(normalizePhotoViewSessionToken(`${'a'.repeat(31)}/`), '');
+    assert.equal(normalizePhotoViewSessionToken('a'.repeat(129)), '');
+  });
+
+  it('exige permanência mínima e timestamp de qualificação', () => {
+    const sessionId = 'a'.repeat(32);
+
+    assert.equal(normalizePhotoViewEvidence({
+      sessionId,
+      visibleMs: PHOTO_VIEW_MIN_VISIBLE_MS - 1,
+      qualifiedAt: 1_800_000_000_000,
+    }), null);
+
+    assert.deepEqual(normalizePhotoViewEvidence({
+      sessionId,
+      visibleMs: PHOTO_VIEW_MIN_VISIBLE_MS,
+      qualifiedAt: 1_800_000_000_000,
+    }), {
+      sessionId,
+      visibleMs: PHOTO_VIEW_MIN_VISIBLE_MS,
+      qualifiedAt: 1_800_000_000_000,
+    });
+  });
+
+  it('autoriza primeira emissão e incrementa a janela', () => {
+    const now = 1_800_000_000_000;
+    const decision = buildPhotoViewSessionRateDecision({
+      now,
+      state: null,
+      maxPerWindow: 10,
+    });
+
+    assert.equal(decision.allowed, true);
+    assert.deepEqual(decision.nextState, {
+      windowStartedAt: now,
+      count: 1,
+      lastIssuedAt: now,
+    });
+  });
+
+  it('bloqueia rajada e informa o intervalo restante', () => {
+    const now = 1_800_000_000_000;
+    const decision = buildPhotoViewSessionRateDecision({
+      now: now + 500,
+      state: {
+        windowStartedAt: now,
+        count: 1,
+        lastIssuedAt: now,
+      },
+      maxPerWindow: 10,
+    });
+
+    assert.equal(decision.allowed, false);
+    assert.equal(decision.retryAfterMs, 500);
+    assert.equal(decision.nextState.count, 1);
+  });
+
+  it('bloqueia ao atingir o teto da janela', () => {
+    const now = 1_800_000_000_000;
+    const decision = buildPhotoViewSessionRateDecision({
+      now: now + 30_000,
+      state: {
+        windowStartedAt: now,
+        count: 10,
+        lastIssuedAt: now,
+      },
+      maxPerWindow: 10,
+    });
+
+    assert.equal(decision.allowed, false);
+    assert.equal(
+      decision.retryAfterMs,
+      PHOTO_VIEW_SESSION_RATE_WINDOW_MS - 30_000
+    );
+  });
+
+  it('reinicia uma janela expirada', () => {
+    const now = 1_800_000_000_000;
+    const nextWindow = now + PHOTO_VIEW_SESSION_RATE_WINDOW_MS;
+    const decision = buildPhotoViewSessionRateDecision({
+      now: nextWindow,
+      state: {
+        windowStartedAt: now,
+        count: 99,
+        lastIssuedAt: now,
+      },
+      maxPerWindow: 10,
+    });
+
+    assert.equal(decision.allowed, true);
+    assert.deepEqual(decision.nextState, {
+      windowStartedAt: nextWindow,
+      count: 1,
+      lastIssuedAt: nextWindow,
+    });
+  });
+});

--- a/functions/src/media/application/photo-view-session.policy.ts
+++ b/functions/src/media/application/photo-view-session.policy.ts
@@ -1,0 +1,151 @@
+export const PHOTO_VIEW_MIN_VISIBLE_MS = 2_000;
+export const PHOTO_VIEW_SESSION_TTL_MS = 10 * 60 * 1000;
+export const PHOTO_VIEW_SESSION_RATE_WINDOW_MS = 10 * 60 * 1000;
+export const PHOTO_VIEW_SESSION_GLOBAL_MAX_PER_WINDOW = 60;
+export const PHOTO_VIEW_SESSION_PHOTO_MAX_PER_WINDOW = 10;
+export const PHOTO_VIEW_SESSION_MIN_INTERVAL_MS = 1_000;
+
+const MIN_SESSION_TOKEN_LENGTH = 32;
+const MAX_SESSION_TOKEN_LENGTH = 128;
+
+export interface PhotoViewSessionRateState {
+  windowStartedAt: number;
+  count: number;
+  lastIssuedAt: number;
+}
+
+export interface PhotoViewSessionRateDecision {
+  allowed: boolean;
+  retryAfterMs: number;
+  nextState: PhotoViewSessionRateState;
+}
+
+export interface PhotoViewEvidenceInput {
+  sessionId?: unknown;
+  visibleMs?: unknown;
+  qualifiedAt?: unknown;
+}
+
+export interface NormalizedPhotoViewEvidence {
+  sessionId: string;
+  visibleMs: number;
+  qualifiedAt: number;
+}
+
+function normalizeNonNegativeNumber(value: unknown): number {
+  const numberValue = Number(value ?? 0);
+  return Number.isFinite(numberValue) && numberValue > 0
+    ? Math.floor(numberValue)
+    : 0;
+}
+
+export function normalizePhotoViewSessionToken(value: unknown): string {
+  const token = String(value ?? '').trim();
+
+  if (
+    token.length < MIN_SESSION_TOKEN_LENGTH ||
+    token.length > MAX_SESSION_TOKEN_LENGTH ||
+    !/^[A-Za-z0-9_-]+$/.test(token)
+  ) {
+    return '';
+  }
+
+  return token;
+}
+
+export function normalizePhotoViewEvidence(
+  evidence: PhotoViewEvidenceInput | null | undefined
+): NormalizedPhotoViewEvidence | null {
+  const sessionId = normalizePhotoViewSessionToken(evidence?.sessionId);
+  const visibleMs = normalizeNonNegativeNumber(evidence?.visibleMs);
+  const qualifiedAt = normalizeNonNegativeNumber(evidence?.qualifiedAt);
+
+  if (
+    !sessionId ||
+    visibleMs < PHOTO_VIEW_MIN_VISIBLE_MS ||
+    visibleMs > PHOTO_VIEW_SESSION_TTL_MS ||
+    !qualifiedAt
+  ) {
+    return null;
+  }
+
+  return {
+    sessionId,
+    visibleMs,
+    qualifiedAt,
+  };
+}
+
+export function buildPhotoViewSessionRateDecision(input: {
+  now: number;
+  state: Partial<PhotoViewSessionRateState> | null | undefined;
+  maxPerWindow: number;
+  windowMs?: number;
+  minIntervalMs?: number;
+}): PhotoViewSessionRateDecision {
+  const now = normalizeNonNegativeNumber(input.now);
+  const windowMs = Math.max(
+    1,
+    normalizeNonNegativeNumber(input.windowMs) ||
+      PHOTO_VIEW_SESSION_RATE_WINDOW_MS
+  );
+  const minIntervalMs = Math.max(
+    0,
+    normalizeNonNegativeNumber(input.minIntervalMs) ||
+      PHOTO_VIEW_SESSION_MIN_INTERVAL_MS
+  );
+  const maxPerWindow = Math.max(1, Math.floor(input.maxPerWindow));
+  const previousWindowStartedAt = normalizeNonNegativeNumber(
+    input.state?.windowStartedAt
+  );
+  const previousCount = normalizeNonNegativeNumber(input.state?.count);
+  const previousLastIssuedAt = normalizeNonNegativeNumber(
+    input.state?.lastIssuedAt
+  );
+  const windowExpired =
+    previousWindowStartedAt <= 0 ||
+    now - previousWindowStartedAt >= windowMs;
+  const windowStartedAt = windowExpired ? now : previousWindowStartedAt;
+  const count = windowExpired ? 0 : previousCount;
+  const intervalRemainingMs = previousLastIssuedAt > 0
+    ? Math.max(0, minIntervalMs - (now - previousLastIssuedAt))
+    : 0;
+  const windowRemainingMs = Math.max(
+    0,
+    windowMs - (now - windowStartedAt)
+  );
+
+  if (intervalRemainingMs > 0) {
+    return {
+      allowed: false,
+      retryAfterMs: intervalRemainingMs,
+      nextState: {
+        windowStartedAt,
+        count,
+        lastIssuedAt: previousLastIssuedAt,
+      },
+    };
+  }
+
+  if (count >= maxPerWindow) {
+    return {
+      allowed: false,
+      retryAfterMs: windowRemainingMs,
+      nextState: {
+        windowStartedAt,
+        count,
+        lastIssuedAt: previousLastIssuedAt,
+      },
+    };
+  }
+
+  return {
+    allowed: true,
+    retryAfterMs: 0,
+    nextState: {
+      windowStartedAt,
+      count: count + 1,
+      lastIssuedAt: now,
+    },
+  };
+}

--- a/functions/src/media/application/photo-view-session.store.ts
+++ b/functions/src/media/application/photo-view-session.store.ts
@@ -1,0 +1,55 @@
+import { createHash } from 'node:crypto';
+
+import { db } from '../../firebaseApp';
+
+export const PHOTO_VIEW_SESSION_COLLECTION = 'media_photo_view_sessions';
+export const PHOTO_VIEW_SESSION_RATE_LIMIT_COLLECTION =
+  'media_photo_view_session_rate_limits';
+
+export type PhotoViewSource =
+  | 'discover'
+  | 'profile'
+  | 'latest'
+  | 'top'
+  | 'boosted'
+  | 'unknown';
+
+export interface PhotoViewSessionDocument {
+  viewerUid?: unknown;
+  ownerUid?: unknown;
+  photoId?: unknown;
+  source?: unknown;
+  appId?: unknown;
+  issuedAt?: unknown;
+  expiresAt?: unknown;
+}
+
+export function cleanPhotoViewSource(value: unknown): PhotoViewSource {
+  const normalized = String(value ?? '').trim().toLowerCase();
+
+  if (
+    normalized === 'discover' ||
+    normalized === 'profile' ||
+    normalized === 'latest' ||
+    normalized === 'top' ||
+    normalized === 'boosted'
+  ) {
+    return normalized;
+  }
+
+  return 'unknown';
+}
+
+export function hashPhotoViewSessionToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+export function hashPhotoViewRateLimitKey(key: string): string {
+  return createHash('sha256').update(key).digest('hex');
+}
+
+export function getPhotoViewSessionRef(sessionId: string) {
+  return db.collection(PHOTO_VIEW_SESSION_COLLECTION).doc(
+    hashPhotoViewSessionToken(sessionId)
+  );
+}

--- a/functions/src/media/application/record-photo-view-orchestrator.handler.ts
+++ b/functions/src/media/application/record-photo-view-orchestrator.handler.ts
@@ -1,22 +1,12 @@
 import { onCall } from 'firebase-functions/v2/https';
 
+import { PROTECTED_CALLABLE_OPTIONS } from '../../config/protected-callable-options';
 import {
-  assertInteractionAccess,
-} from '../../account_lifecycle/interaction-access.policy';
-import { FUNCTIONS_REGION } from '../../config/functions-region';
-import {
-  recordPhotoView as recordPhotoViewCore,
+  recordPhotoViewCore,
+  type RecordPhotoViewRequest,
 } from './record-photo-view.handler';
 
-export const recordPhotoView = onCall(
-  { region: FUNCTIONS_REGION },
-  async (request) => {
-    const viewerUid = String(request.auth?.uid ?? '').trim();
-
-    if (viewerUid) {
-      await assertInteractionAccess(viewerUid);
-    }
-
-    return recordPhotoViewCore.run(request as any);
-  }
+export const recordPhotoView = onCall<RecordPhotoViewRequest>(
+  PROTECTED_CALLABLE_OPTIONS,
+  recordPhotoViewCore
 );

--- a/functions/src/media/application/record-photo-view.handler.ts
+++ b/functions/src/media/application/record-photo-view.handler.ts
@@ -1,61 +1,64 @@
-// functions/src/media/application/record-photo-view.handler.ts
-// -----------------------------------------------------------------------------
-// PHOTO VIEW TRACKING
-// -----------------------------------------------------------------------------
-// Registra visualizações públicas de fotos via backend confiável.
-//
-// Semântica:
-// - viewsCount: visualizações contabilizadas respeitando janela antifraude;
-// - uniqueViewersCount da foto: pessoas únicas daquela foto;
-// - uniqueViewersCount do perfil: pessoas únicas em qualquer mídia do perfil;
-// - profile_viewers/{viewerUid}: índice privado e backend-only da audiência real.
-// -----------------------------------------------------------------------------
-
-import { HttpsError, onCall } from 'firebase-functions/v2/https';
+import type { CallableRequest } from 'firebase-functions/v2/https';
+import { HttpsError } from 'firebase-functions/v2/https';
 
 import { db, FieldValue } from '../../firebaseApp';
-import { FUNCTIONS_REGION } from '../../config/functions-region';
+import {
+  type PhotoPublicationAudienceDocument,
+  type PublicPhotoAudienceDocument,
+  resolveCanonicalPhotoAudienceTarget,
+} from './photo-audience-access.policy';
+import {
+  PHOTO_VIEW_MIN_VISIBLE_MS,
+  type PhotoViewEvidenceInput,
+  normalizePhotoViewEvidence,
+} from './photo-view-session.policy';
+import {
+  type PhotoViewSessionDocument,
+  type PhotoViewSource,
+  cleanPhotoViewSource,
+  getPhotoViewSessionRef,
+  hashPhotoViewSessionToken,
+} from './photo-view-session.store';
 import {
   PROFILE_VIEWER_INDEX_VERSION,
   PROFILE_VIEWERS_COLLECTION,
   calculatePublicProfileEngagementScore,
   ensurePublicProfileViewerIndex,
 } from './public-profile-media-metrics';
+import {
+  createVideoAudienceAccessEvaluator,
+} from './video-audience-access.policy';
 
-interface RecordPhotoViewRequest {
+export interface RecordPhotoViewRequest {
   ownerUid?: string;
   photoId?: string;
-  source?: 'discover' | 'profile' | 'latest' | 'top' | 'boosted' | 'unknown';
+  source?: PhotoViewSource;
+  evidence?: PhotoViewEvidenceInput;
 }
 
-interface RecordPhotoViewResponse {
+export interface RecordPhotoViewResponse {
   ok: true;
   ownerUid: string;
   photoId: string;
+  counted: boolean;
+  uniqueViewer: boolean;
+  retryAfterMs: number;
 }
 
 const VIEW_COUNT_INTERVAL_MS = 5 * 60 * 1000;
+const VIEWER_TOUCH_INTERVAL_MS = 5 * 60 * 1000;
+const QUALIFICATION_CLOCK_TOLERANCE_MS = 1_500;
 
 function cleanId(value: unknown): string {
-  return String(value ?? '').trim();
+  const normalized = String(value ?? '').trim();
+  return /^[A-Za-z0-9_-]{1,128}$/.test(normalized) ? normalized : '';
 }
 
-function cleanSource(
-  value: unknown
-): NonNullable<RecordPhotoViewRequest['source']> {
-  const source = String(value ?? '').trim();
-
-  if (
-    source === 'discover' ||
-    source === 'profile' ||
-    source === 'latest' ||
-    source === 'top' ||
-    source === 'boosted'
-  ) {
-    return source;
-  }
-
-  return 'unknown';
+function cleanAppId(value: unknown): string {
+  const normalized = String(value ?? '').trim();
+  return normalized.length > 0 && normalized.length <= 256
+    ? normalized
+    : '';
 }
 
 function safeNumber(value: unknown): number {
@@ -64,7 +67,7 @@ function safeNumber(value: unknown): number {
     : 0;
 }
 
-function assertPublicApprovedPhoto(
+function assertApprovedPhoto(
   exists: boolean,
   data: FirebaseFirestore.DocumentData | undefined
 ): void {
@@ -72,13 +75,52 @@ function assertPublicApprovedPhoto(
     throw new HttpsError('not-found', 'Foto pública não encontrada.');
   }
 
+  if (String(data?.moderationStatus ?? '').trim().toUpperCase() !== 'APPROVED') {
+    throw new HttpsError(
+      'failed-precondition',
+      'Foto indisponível para visualização.'
+    );
+  }
+}
+
+function assertPhotoViewSession(input: {
+  session: PhotoViewSessionDocument;
+  viewerUid: string;
+  ownerUid: string;
+  photoId: string;
+  source: PhotoViewSource;
+  appId: string;
+  visibleMs: number;
+  qualifiedAt: number;
+  now: number;
+}): void {
+  const sessionViewerUid = cleanId(input.session.viewerUid);
+  const sessionOwnerUid = cleanId(input.session.ownerUid);
+  const sessionPhotoId = cleanId(input.session.photoId);
+  const sessionSource = cleanPhotoViewSource(input.session.source);
+  const sessionAppId = cleanAppId(input.session.appId);
+  const issuedAt = safeNumber(input.session.issuedAt);
+  const expiresAt = safeNumber(input.session.expiresAt);
+  const elapsedAtQualification = input.qualifiedAt - issuedAt;
+
   if (
-    data?.visibility !== 'PUBLIC' ||
-    data?.moderationStatus !== 'APPROVED'
+    sessionViewerUid !== input.viewerUid ||
+    sessionOwnerUid !== input.ownerUid ||
+    sessionPhotoId !== input.photoId ||
+    sessionSource !== input.source ||
+    !issuedAt ||
+    !expiresAt ||
+    input.now > expiresAt ||
+    input.qualifiedAt > input.now + QUALIFICATION_CLOCK_TOLERANCE_MS ||
+    input.qualifiedAt < issuedAt + PHOTO_VIEW_MIN_VISIBLE_MS ||
+    input.qualifiedAt > expiresAt ||
+    input.visibleMs < PHOTO_VIEW_MIN_VISIBLE_MS ||
+    input.visibleMs > elapsedAtQualification + QUALIFICATION_CLOCK_TOLERANCE_MS ||
+    (sessionAppId && sessionAppId !== input.appId)
   ) {
     throw new HttpsError(
       'failed-precondition',
-      'Foto indisponível para visualização pública.'
+      'A sessão de visualização é inválida ou expirou.'
     );
   }
 }
@@ -99,157 +141,227 @@ function calculateViewScore(input: {
   );
 }
 
-export const recordPhotoView = onCall<RecordPhotoViewRequest>(
-  { region: FUNCTIONS_REGION },
-  async (request): Promise<RecordPhotoViewResponse> => {
-    const viewerUid = request.auth?.uid ?? null;
-    const ownerUid = cleanId(request.data?.ownerUid);
-    const photoId = cleanId(request.data?.photoId);
-    const source = cleanSource(request.data?.source);
+export async function recordPhotoViewCore(
+  request: CallableRequest<RecordPhotoViewRequest>
+): Promise<RecordPhotoViewResponse> {
+  const viewerUid = cleanId(request.auth?.uid);
+  const ownerUid = cleanId(request.data?.ownerUid);
+  const photoId = cleanId(request.data?.photoId);
+  const source = cleanPhotoViewSource(request.data?.source);
+  const evidence = normalizePhotoViewEvidence(request.data?.evidence);
+  const appId = cleanAppId(request.app?.appId);
 
-    if (!viewerUid) {
-      throw new HttpsError('unauthenticated', 'Usuário não autenticado.');
-    }
+  if (!viewerUid) {
+    throw new HttpsError('unauthenticated', 'Usuário não autenticado.');
+  }
 
-    if (!ownerUid || !photoId) {
-      throw new HttpsError('invalid-argument', 'Foto inválida.');
-    }
+  if (!ownerUid || !photoId) {
+    throw new HttpsError('invalid-argument', 'Foto inválida.');
+  }
 
-    if (viewerUid === ownerUid) {
-      return {
-        ok: true,
-        ownerUid,
-        photoId,
-      };
-    }
+  if (viewerUid === ownerUid) {
+    return {
+      ok: true,
+      ownerUid,
+      photoId,
+      counted: false,
+      uniqueViewer: false,
+      retryAfterMs: 0,
+    };
+  }
 
-    const publicProfileRef = db.doc(`public_profiles/${ownerUid}`);
-    const publicPhotoRef = db.doc(
-      `public_profiles/${ownerUid}/public_photos/${photoId}`
+  if (!evidence) {
+    throw new HttpsError(
+      'failed-precondition',
+      'A foto ainda não permaneceu visível pelo tempo mínimo.'
     );
+  }
 
-    /**
-     * Preflight barato: impede que um photoId inexistente acione o backfill
-     * histórico do perfil. A transação revalida o documento depois.
-     */
-    const preflightPhotoSnapshot = await publicPhotoRef.get();
-    assertPublicApprovedPhoto(
-      preflightPhotoSnapshot.exists,
-      preflightPhotoSnapshot.data()
+  const publicProfileRef = db.doc(`public_profiles/${ownerUid}`);
+  const publicPhotoRef = db.doc(
+    `public_profiles/${ownerUid}/public_photos/${photoId}`
+  );
+  const publicationRef = db.doc(
+    `users/${ownerUid}/photo_publications/${photoId}`
+  );
+  const sessionRef = getPhotoViewSessionRef(evidence.sessionId);
+  const preflightPhotoSnapshot = await publicPhotoRef.get();
+
+  assertApprovedPhoto(
+    preflightPhotoSnapshot.exists,
+    preflightPhotoSnapshot.data()
+  );
+
+  const audience = await createVideoAudienceAccessEvaluator(viewerUid);
+  await ensurePublicProfileViewerIndex(ownerUid);
+
+  const now = Date.now();
+  const photoViewerRef = publicPhotoRef.collection('views').doc(viewerUid);
+  const profileViewerRef = publicProfileRef
+    .collection(PROFILE_VIEWERS_COLLECTION)
+    .doc(viewerUid);
+
+  const outcome = await db.runTransaction(async (transaction) => {
+    const [
+      publicProfileSnap,
+      publicPhotoSnap,
+      publicationSnap,
+      photoViewerSnap,
+      profileViewerSnap,
+      sessionSnap,
+    ] = await Promise.all([
+      transaction.get(publicProfileRef),
+      transaction.get(publicPhotoRef),
+      transaction.get(publicationRef),
+      transaction.get(photoViewerRef),
+      transaction.get(profileViewerRef),
+      transaction.get(sessionRef),
+    ]);
+
+    if (!publicProfileSnap.exists) {
+      throw new HttpsError('not-found', 'Perfil público não encontrado.');
+    }
+
+    assertApprovedPhoto(publicPhotoSnap.exists, publicPhotoSnap.data());
+
+    if (!publicationSnap.exists) {
+      throw new HttpsError('not-found', 'Publicação da foto não encontrada.');
+    }
+
+    if (!sessionSnap.exists) {
+      throw new HttpsError(
+        'failed-precondition',
+        'A sessão de visualização já foi utilizada ou expirou.'
+      );
+    }
+
+    const publicProfile = publicProfileSnap.data() ?? {};
+    const publicPhoto = publicPhotoSnap.data() ?? {};
+    const publication =
+      publicationSnap.data() as PhotoPublicationAudienceDocument;
+    const photoViewerData = photoViewerSnap.data() ?? {};
+    const profileViewerData = profileViewerSnap.data() ?? {};
+    const target = resolveCanonicalPhotoAudienceTarget({
+      ownerUid,
+      photoId,
+      publicPhoto: publicPhoto as PublicPhotoAudienceDocument,
+      publication,
+    });
+
+    if (!target) {
+      throw new HttpsError(
+        'failed-precondition',
+        'A foto possui dados de publicação inconsistentes.'
+      );
+    }
+
+    await audience.assertInTransaction(transaction, target);
+    assertPhotoViewSession({
+      session: sessionSnap.data() as PhotoViewSessionDocument,
+      viewerUid,
+      ownerUid,
+      photoId,
+      source,
+      appId,
+      visibleMs: evidence.visibleMs,
+      qualifiedAt: evidence.qualifiedAt,
+      now,
+    });
+
+    const isUniquePhotoViewer = !photoViewerSnap.exists;
+    const isUniqueProfileViewer = !profileViewerSnap.exists;
+    const lastCountedAt = safeNumber(
+      photoViewerData.lastCountedAt ?? photoViewerData.lastViewedAt
     );
+    const canCountView =
+      isUniquePhotoViewer || now - lastCountedAt >= VIEW_COUNT_INTERVAL_MS;
+    const retryAfterMs = canCountView
+      ? 0
+      : Math.max(0, VIEW_COUNT_INTERVAL_MS - (now - lastCountedAt));
+    const sessionHash = hashPhotoViewSessionToken(evidence.sessionId);
 
-    /**
-     * Migração lazy e idempotente. Executa leitura histórica apenas enquanto o
-     * perfil ainda não possui o índice canônico versionado.
-     */
-    await ensurePublicProfileViewerIndex(ownerUid);
+    const currentPhotoViewsCount = safeNumber(publicPhoto.viewsCount);
+    const currentPhotoUniqueViewersCount = safeNumber(
+      publicPhoto.uniqueViewersCount
+    );
+    const currentPhotoViewScore = safeNumber(publicPhoto.viewScore);
+    const nextPhotoViewsCount = canCountView
+      ? currentPhotoViewsCount + 1
+      : currentPhotoViewsCount;
+    const nextPhotoUniqueViewersCount = isUniquePhotoViewer
+      ? currentPhotoUniqueViewersCount + 1
+      : currentPhotoUniqueViewersCount;
+    const publishedAt = safeNumber(publicPhoto.publishedAt) || now;
+    const nextPhotoViewScore = canCountView
+      ? calculateViewScore({
+        viewsCount: nextPhotoViewsCount,
+        uniqueViewersCount: nextPhotoUniqueViewersCount,
+        lastViewedAt: now,
+        publishedAt,
+      })
+      : currentPhotoViewScore;
 
-    const now = Date.now();
-    const photoViewerRef = publicPhotoRef.collection('views').doc(viewerUid);
-    const profileViewerRef = publicProfileRef
-      .collection(PROFILE_VIEWERS_COLLECTION)
-      .doc(viewerUid);
+    const currentProfileViewsCount = safeNumber(
+      publicProfile.profileViewsCount ?? publicProfile.viewsCount
+    );
+    const currentProfileUniqueViewersCount = safeNumber(
+      publicProfile.profileUniqueViewersCount ??
+        publicProfile.uniqueViewersCount
+    );
+    const currentMediaUniqueViewersCount = safeNumber(
+      publicProfile.mediaUniqueViewersCount
+    );
+    const currentProfileViewScore = safeNumber(publicProfile.viewScore);
+    const nextProfileViewsCount = canCountView
+      ? currentProfileViewsCount + 1
+      : currentProfileViewsCount;
+    const nextProfileUniqueViewersCount = isUniqueProfileViewer
+      ? currentProfileUniqueViewersCount + 1
+      : currentProfileUniqueViewersCount;
+    const nextMediaUniqueViewersCount = isUniquePhotoViewer
+      ? currentMediaUniqueViewersCount + 1
+      : currentMediaUniqueViewersCount;
+    const nextProfileViewScore = canCountView
+      ? Math.max(
+        0,
+        currentProfileViewScore -
+          currentPhotoViewScore +
+          nextPhotoViewScore
+      )
+      : currentProfileViewScore;
 
-    await db.runTransaction(async (transaction) => {
-      const publicProfileSnap = await transaction.get(publicProfileRef);
-      const publicPhotoSnap = await transaction.get(publicPhotoRef);
-      const photoViewerSnap = await transaction.get(photoViewerRef);
-      const profileViewerSnap = await transaction.get(profileViewerRef);
+    const engagementScore = calculatePublicProfileEngagementScore({
+      mediaCount: safeNumber(
+        publicProfile.mediaCount ?? publicProfile.publicMediaCount
+      ),
+      photosCount: safeNumber(
+        publicProfile.photosCount ?? publicProfile.publicPhotosCount
+      ),
+      videosCount: safeNumber(
+        publicProfile.videosCount ?? publicProfile.publicVideosCount
+      ),
+      viewsCount: nextProfileViewsCount,
+      uniqueViewersCount: nextProfileUniqueViewersCount,
+      reactionsCount: safeNumber(
+        publicProfile.reactionsCount ??
+          publicProfile.likesCount ??
+          publicProfile.publicLikesCount
+      ),
+    });
 
-      if (!publicProfileSnap.exists) {
-        throw new HttpsError('not-found', 'Perfil público não encontrado.');
-      }
+    const shouldTouchPhotoViewer =
+      canCountView ||
+      now - safeNumber(photoViewerData.lastViewedAt) >=
+        VIEWER_TOUCH_INTERVAL_MS;
+    const shouldTouchProfileViewer =
+      canCountView ||
+      isUniqueProfileViewer ||
+      now - safeNumber(profileViewerData.lastViewedAt) >=
+        VIEWER_TOUCH_INTERVAL_MS;
 
-      assertPublicApprovedPhoto(
-        publicPhotoSnap.exists,
-        publicPhotoSnap.data()
-      );
+    transaction.delete(sessionRef);
 
-      const publicProfile = publicProfileSnap.data() ?? {};
-      const publicPhoto = publicPhotoSnap.data() ?? {};
-      const photoViewerData = photoViewerSnap.data() ?? {};
-      const profileViewerData = profileViewerSnap.data() ?? {};
-
-      const isUniquePhotoViewer = !photoViewerSnap.exists;
-      const isUniqueProfileViewer = !profileViewerSnap.exists;
-      const lastCountedAt = safeNumber(
-        photoViewerData.lastCountedAt ?? photoViewerData.lastViewedAt
-      );
-      const canCountView =
-        isUniquePhotoViewer || now - lastCountedAt >= VIEW_COUNT_INTERVAL_MS;
-
-      const currentPhotoViewsCount = safeNumber(publicPhoto.viewsCount);
-      const currentPhotoUniqueViewersCount = safeNumber(
-        publicPhoto.uniqueViewersCount
-      );
-      const currentPhotoViewScore = safeNumber(publicPhoto.viewScore);
-
-      const nextPhotoViewsCount = canCountView
-        ? currentPhotoViewsCount + 1
-        : currentPhotoViewsCount;
-      const nextPhotoUniqueViewersCount = isUniquePhotoViewer
-        ? currentPhotoUniqueViewersCount + 1
-        : currentPhotoUniqueViewersCount;
-
-      const publishedAt = safeNumber(publicPhoto.publishedAt) || now;
-      const nextPhotoViewScore = canCountView
-        ? calculateViewScore({
-          viewsCount: nextPhotoViewsCount,
-          uniqueViewersCount: nextPhotoUniqueViewersCount,
-          lastViewedAt: now,
-          publishedAt,
-        })
-        : currentPhotoViewScore;
-
-      const currentProfileViewsCount = safeNumber(
-        publicProfile.profileViewsCount ?? publicProfile.viewsCount
-      );
-      const currentProfileUniqueViewersCount = safeNumber(
-        publicProfile.profileUniqueViewersCount ??
-          publicProfile.uniqueViewersCount
-      );
-      const currentMediaUniqueViewersCount = safeNumber(
-        publicProfile.mediaUniqueViewersCount
-      );
-      const currentProfileViewScore = safeNumber(publicProfile.viewScore);
-
-      const nextProfileViewsCount = canCountView
-        ? currentProfileViewsCount + 1
-        : currentProfileViewsCount;
-      const nextProfileUniqueViewersCount = isUniqueProfileViewer
-        ? currentProfileUniqueViewersCount + 1
-        : currentProfileUniqueViewersCount;
-      const nextMediaUniqueViewersCount = isUniquePhotoViewer
-        ? currentMediaUniqueViewersCount + 1
-        : currentMediaUniqueViewersCount;
-      const nextProfileViewScore = canCountView
-        ? Math.max(
-          0,
-          currentProfileViewScore -
-              currentPhotoViewScore +
-              nextPhotoViewScore
-        )
-        : currentProfileViewScore;
-
-      const engagementScore = calculatePublicProfileEngagementScore({
-        mediaCount: safeNumber(
-          publicProfile.mediaCount ?? publicProfile.publicMediaCount
-        ),
-        photosCount: safeNumber(
-          publicProfile.photosCount ?? publicProfile.publicPhotosCount
-        ),
-        videosCount: safeNumber(
-          publicProfile.videosCount ?? publicProfile.publicVideosCount
-        ),
-        viewsCount: nextProfileViewsCount,
-        uniqueViewersCount: nextProfileUniqueViewersCount,
-        reactionsCount: safeNumber(
-          publicProfile.reactionsCount ??
-            publicProfile.likesCount ??
-            publicProfile.publicLikesCount
-        ),
-      });
-
+    if (shouldTouchPhotoViewer) {
       transaction.set(
         photoViewerRef,
         {
@@ -261,16 +373,20 @@ export const recordPhotoView = onCall<RecordPhotoViewRequest>(
             ? now
             : photoViewerData.firstViewedAt ?? now,
           lastViewedAt: now,
+          lastQualifiedVisibleMs: evidence.visibleMs,
           ...(canCountView
             ? {
               lastCountedAt: now,
+              lastCountedSessionHash: sessionHash,
               viewsCount: FieldValue.increment(1),
             }
             : {}),
         },
         { merge: true }
       );
+    }
 
+    if (shouldTouchProfileViewer) {
       transaction.set(
         profileViewerRef,
         {
@@ -293,45 +409,52 @@ export const recordPhotoView = onCall<RecordPhotoViewRequest>(
         },
         { merge: true }
       );
+    }
 
-      if (canCountView) {
-        transaction.set(
-          publicPhotoRef,
-          {
-            viewsCount: nextPhotoViewsCount,
-            uniqueViewersCount: nextPhotoUniqueViewersCount,
-            lastViewedAt: now,
-            viewScore: nextPhotoViewScore,
-            updatedAt: now,
-          },
-          { merge: true }
-        );
-      }
+    if (canCountView) {
+      transaction.set(
+        publicPhotoRef,
+        {
+          viewsCount: nextPhotoViewsCount,
+          uniqueViewersCount: nextPhotoUniqueViewersCount,
+          lastViewedAt: now,
+          viewScore: nextPhotoViewScore,
+          updatedAt: now,
+        },
+        { merge: true }
+      );
+    }
 
-      if (canCountView || isUniqueProfileViewer) {
-        transaction.set(
-          publicProfileRef,
-          {
-            viewsCount: nextProfileViewsCount,
-            profileViewsCount: nextProfileViewsCount,
-            uniqueViewersCount: nextProfileUniqueViewersCount,
-            profileUniqueViewersCount: nextProfileUniqueViewersCount,
-            mediaUniqueViewersCount: nextMediaUniqueViewersCount,
-            viewScore: nextProfileViewScore,
-            engagementScore,
-            lastViewedAt: now,
-            profileViewerIndexVersion: PROFILE_VIEWER_INDEX_VERSION,
-            mediaMetricsUpdatedAt: FieldValue.serverTimestamp(),
-          },
-          { merge: true }
-        );
-      }
-    });
+    if (canCountView || isUniqueProfileViewer) {
+      transaction.set(
+        publicProfileRef,
+        {
+          viewsCount: nextProfileViewsCount,
+          profileViewsCount: nextProfileViewsCount,
+          uniqueViewersCount: nextProfileUniqueViewersCount,
+          profileUniqueViewersCount: nextProfileUniqueViewersCount,
+          mediaUniqueViewersCount: nextMediaUniqueViewersCount,
+          viewScore: nextProfileViewScore,
+          engagementScore,
+          lastViewedAt: now,
+          profileViewerIndexVersion: PROFILE_VIEWER_INDEX_VERSION,
+          mediaMetricsUpdatedAt: FieldValue.serverTimestamp(),
+        },
+        { merge: true }
+      );
+    }
 
     return {
-      ok: true,
-      ownerUid,
-      photoId,
+      counted: canCountView,
+      uniqueViewer: isUniquePhotoViewer,
+      retryAfterMs,
     };
-  }
-);
+  });
+
+  return {
+    ok: true,
+    ownerUid,
+    photoId,
+    ...outcome,
+  };
+}

--- a/functions/src/media/application/video-view-session.policy.test.ts
+++ b/functions/src/media/application/video-view-session.policy.test.ts
@@ -5,6 +5,7 @@ import './admin-authorization.policy.test';
 import './media-callable-rate-limit.policy.test';
 import './media-mutation-idempotency.policy.test';
 import './photo-audience-access.policy.test';
+import './photo-view-session.policy.test';
 import {
   VIDEO_VIEW_SESSION_MIN_INTERVAL_MS,
   VIDEO_VIEW_SESSION_RATE_WINDOW_MS,

--- a/functions/src/media/index.ts
+++ b/functions/src/media/index.ts
@@ -97,6 +97,10 @@ export {
 } from './application/cleanup-published-video-assets.handler';
 
 export {
+  issuePhotoViewSession,
+  cleanupExpiredPhotoViewSessions,
+} from './application/issue-photo-view-session.handler';
+export {
   issueVideoViewSession,
   cleanupExpiredVideoViewSessions,
 } from './application/issue-video-view-session.handler';

--- a/src/app/core/services/media/media-publication.service.ts
+++ b/src/app/core/services/media/media-publication.service.ts
@@ -5,14 +5,9 @@
 // - separar publicação da biblioteca privada;
 // - ler configuração privada de publicação;
 // - solicitar publicação/despublicação/capa via Cloud Functions;
-// - registrar visualização pública por backend confiável;
+// - delegar visualização pública ao serviço canônico de tracking;
 // - manter Observable na API pública;
 // - impedir escrita direta do cliente na projeção pública.
-//
-// Segurança:
-// - cliente não escreve public_profiles/{uid}/public_photos;
-// - cliente não atualiza score/contadores/moderação;
-// - publicação e visualização passam pelo backend.
 
 import { Injectable, inject } from '@angular/core';
 import {
@@ -33,6 +28,11 @@ import {
   TPhotoCommentsPolicy,
   TPhotoVisibility,
 } from 'src/app/core/interfaces/media/i-photo-publication-config';
+import {
+  PhotoViewEvidence,
+  PhotoViewTrackingService,
+  TPhotoViewSource,
+} from './photo-view-tracking.service';
 
 const MAX_PUBLICATION_CAPTION_LENGTH = 800;
 
@@ -47,14 +47,6 @@ export interface IPublishPhotoCommand {
   commentsPolicy?: TPhotoCommentsPolicy;
   reactionsEnabled?: boolean;
 }
-
-type TRecordPhotoViewSource =
-  | 'discover'
-  | 'profile'
-  | 'latest'
-  | 'top'
-  | 'boosted'
-  | 'unknown';
 
 interface PublishPhotoCallableRequest {
   ownerUid: string;
@@ -78,16 +70,11 @@ interface PhotoIdCallableRequest {
   photoId: string;
 }
 
-interface RecordPhotoViewCallableRequest {
-  ownerUid: string;
-  photoId: string;
-  source: TRecordPhotoViewSource;
-}
-
 @Injectable({ providedIn: 'root' })
 export class MediaPublicationService {
   private readonly firestore = inject(Firestore);
   private readonly functions = inject(Functions);
+  private readonly photoViewTracking = inject(PhotoViewTrackingService);
 
   constructor(
     private readonly firestoreCtx: FirestoreContextService,
@@ -125,21 +112,16 @@ export class MediaPublicationService {
             isPublished: !!item.isPublished,
             visibility: item.visibility ?? 'PRIVATE',
             caption: this.normalizeCaption(item.caption),
-
             isCover: !!item.isCover,
             orderIndex: item.orderIndex ?? 0,
-
             commentsEnabled: item.commentsEnabled ?? false,
             commentsPolicy: item.commentsPolicy ?? 'OFF',
             commentsCount: item.commentsCount ?? 0,
-
             reactionsEnabled: item.reactionsEnabled ?? false,
             reactionsCount: item.reactionsCount ?? 0,
-
             moderationStatus: item.moderationStatus ?? 'PRIVATE',
             moderationReason: item.moderationReason ?? null,
             reportsCount: item.reportsCount ?? 0,
-
             score: item.score ?? 0,
             scoreBreakdown: item.scoreBreakdown ?? {
               rankingScore: 0,
@@ -147,7 +129,6 @@ export class MediaPublicationService {
               engagementScore: 0,
               safetyScore: 100,
             },
-
             publishedAt: item.publishedAt ?? null,
             updatedAt: item.updatedAt,
             lastModeratedAt: item.lastModeratedAt ?? null,
@@ -176,25 +157,19 @@ export class MediaPublicationService {
     return {
       photoId,
       ownerUid,
-
       isPublished: false,
       visibility: 'PRIVATE',
       caption: null,
-
       isCover: false,
       orderIndex: 0,
-
       commentsEnabled: false,
       commentsPolicy: 'OFF',
       commentsCount: 0,
-
       reactionsEnabled: false,
       reactionsCount: 0,
-
       moderationStatus: 'PRIVATE',
       moderationReason: null,
       reportsCount: 0,
-
       score: 0,
       scoreBreakdown: {
         rankingScore: 0,
@@ -202,7 +177,6 @@ export class MediaPublicationService {
         engagementScore: 0,
         safetyScore: 100,
       },
-
       publishedAt: null,
       updatedAt: Date.now(),
       lastModeratedAt: null,
@@ -327,46 +301,33 @@ export class MediaPublicationService {
     );
   }
 
+  /**
+   * Fachada preservada para consumidores existentes que já possuem evidência.
+   * Novos visualizadores devem usar trackQualifiedPhotoView$ após o load.
+   */
   recordPhotoView$(
     ownerUid: string,
     photoId: string,
-    source: TRecordPhotoViewSource = 'profile'
+    source: TPhotoViewSource = 'profile',
+    evidence?: PhotoViewEvidence
   ): Observable<void> {
-    const safeOwnerUid = (ownerUid ?? '').trim();
-    const safePhotoId = (photoId ?? '').trim();
+    return this.photoViewTracking.recordPhotoView$(
+      ownerUid,
+      photoId,
+      source,
+      evidence
+    );
+  }
 
-    if (!safeOwnerUid || !safePhotoId) {
-      return of(void 0);
-    }
-
-    return this.firestoreCtx.deferPromise$(async () => {
-      const callable = httpsCallable<
-        RecordPhotoViewCallableRequest,
-        { ok: true }
-      >(this.functions, 'recordPhotoView');
-
-      await callable({
-        ownerUid: safeOwnerUid,
-        photoId: safePhotoId,
-        source,
-      });
-    }).pipe(
-      map(() => void 0),
-      catchError((error) => {
-        this.reportError(
-          'Erro ao registrar visualização da foto.',
-          error,
-          {
-            op: 'recordPhotoView$',
-            ownerUid: safeOwnerUid,
-            photoId: safePhotoId,
-            source,
-          },
-          true
-        );
-
-        return of(void 0);
-      })
+  trackQualifiedPhotoView$(
+    ownerUid: string,
+    photoId: string,
+    source: TPhotoViewSource = 'profile'
+  ): Observable<void> {
+    return this.photoViewTracking.trackQualifiedPhotoView$(
+      ownerUid,
+      photoId,
+      source
     );
   }
 

--- a/src/app/core/services/media/photo-view-tracking.service.spec.ts
+++ b/src/app/core/services/media/photo-view-tracking.service.spec.ts
@@ -1,0 +1,128 @@
+import { TestBed } from '@angular/core/testing';
+import { Functions } from '@angular/fire/functions';
+import { of } from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AuthSessionService } from 'src/app/core/services/autentication/auth/auth-session.service';
+import { FirestoreContextService } from 'src/app/core/services/data-handling/firestore/core/firestore-context.service';
+import { GlobalErrorHandlerService } from 'src/app/core/services/error-handler/global-error-handler.service';
+import {
+  PhotoViewTrackingService,
+  type PhotoViewSession,
+} from './photo-view-tracking.service';
+
+const SESSION: PhotoViewSession = {
+  ownerUid: 'owner-1',
+  photoId: 'photo-1',
+  sessionId: 'a'.repeat(43),
+  issuedAt: 1_800_000_000_000,
+  expiresAt: 1_800_000_600_000,
+};
+
+describe('PhotoViewTrackingService', () => {
+  let service: PhotoViewTrackingService;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(SESSION.issuedAt));
+
+    TestBed.configureTestingModule({
+      providers: [
+        PhotoViewTrackingService,
+        { provide: Functions, useValue: {} },
+        {
+          provide: FirestoreContextService,
+          useValue: { deferPromise$: vi.fn() },
+        },
+        {
+          provide: AuthSessionService,
+          useValue: { uid$: of('viewer-1') },
+        },
+        {
+          provide: GlobalErrorHandlerService,
+          useValue: { handleError: vi.fn() },
+        },
+      ],
+    });
+
+    service = TestBed.inject(PhotoViewTrackingService);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    TestBed.resetTestingModule();
+  });
+
+  it('não envia registro sem evidência qualificada', () => {
+    const next = vi.fn();
+
+    service.recordPhotoView$(
+      'owner-1',
+      'photo-1',
+      'profile'
+    ).subscribe(next);
+
+    expect(next).toHaveBeenCalledWith(undefined);
+  });
+
+  it('registra depois de dois segundos com a página visível', () => {
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: 'visible',
+    });
+
+    vi.spyOn(service, 'preparePhotoViewSession$').mockReturnValue(of(SESSION));
+    const record = vi.spyOn(service, 'recordPhotoView$')
+      .mockReturnValue(of(void 0));
+
+    service.trackQualifiedPhotoView$(
+      'owner-1',
+      'photo-1',
+      'discover'
+    ).subscribe();
+
+    vi.advanceTimersByTime(2_200);
+
+    expect(record).toHaveBeenCalledTimes(1);
+    expect(record).toHaveBeenCalledWith(
+      'owner-1',
+      'photo-1',
+      'discover',
+      expect.objectContaining({
+        sessionId: SESSION.sessionId,
+        visibleMs: expect.any(Number),
+        qualifiedAt: expect.any(Number),
+      })
+    );
+    expect(record.mock.calls[0]?.[3]?.visibleMs).toBeGreaterThanOrEqual(2_000);
+  });
+
+  it('não acumula permanência enquanto a aba está oculta', () => {
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: 'hidden',
+    });
+
+    vi.spyOn(service, 'preparePhotoViewSession$').mockReturnValue(of(SESSION));
+    const record = vi.spyOn(service, 'recordPhotoView$')
+      .mockReturnValue(of(void 0));
+
+    service.trackQualifiedPhotoView$(
+      'owner-1',
+      'photo-1',
+      'profile'
+    ).subscribe();
+
+    vi.advanceTimersByTime(3_000);
+    expect(record).not.toHaveBeenCalled();
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: 'visible',
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+    vi.advanceTimersByTime(2_200);
+
+    expect(record).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/core/services/media/photo-view-tracking.service.ts
+++ b/src/app/core/services/media/photo-view-tracking.service.ts
@@ -1,9 +1,17 @@
-// src\app\core\services\media\photo-view-tracking.service.ts
-import { Injectable, inject } from '@angular/core';
+import { DestroyRef, Injectable, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Functions, httpsCallable } from '@angular/fire/functions';
 import { Observable, of } from 'rxjs';
-import { catchError, map } from 'rxjs/operators';
+import {
+  catchError,
+  distinctUntilChanged,
+  finalize,
+  map,
+  shareReplay,
+  switchMap,
+} from 'rxjs/operators';
 
+import { AuthSessionService } from 'src/app/core/services/autentication/auth/auth-session.service';
 import { FirestoreContextService } from 'src/app/core/services/data-handling/firestore/core/firestore-context.service';
 import { GlobalErrorHandlerService } from 'src/app/core/services/error-handler/global-error-handler.service';
 
@@ -15,82 +23,426 @@ export type TPhotoViewSource =
   | 'boosted'
   | 'unknown';
 
-interface IRecordPhotoViewRequest {
+export interface PhotoViewEvidence {
+  sessionId: string;
+  visibleMs: number;
+  qualifiedAt: number;
+}
+
+export interface PhotoViewSession {
+  ownerUid: string;
+  photoId: string;
+  sessionId: string;
+  issuedAt: number;
+  expiresAt: number;
+}
+
+interface IssuePhotoViewSessionRequest {
   ownerUid: string;
   photoId: string;
   source: TPhotoViewSource;
 }
 
-interface IRecordPhotoViewResponse {
+interface IssuePhotoViewSessionResponse extends PhotoViewSession {
+  ok: true;
+}
+
+interface RecordPhotoViewRequest {
+  ownerUid: string;
+  photoId: string;
+  source: TPhotoViewSource;
+  evidence: PhotoViewEvidence;
+}
+
+interface RecordPhotoViewResponse {
   ok: true;
   ownerUid: string;
   photoId: string;
+  counted: boolean;
+  uniqueViewer: boolean;
+  retryAfterMs: number;
 }
+
+interface PhotoViewTrackingError extends Error {
+  original?: unknown;
+  context?: Record<string, unknown>;
+  skipUserNotification?: boolean;
+}
+
+const PHOTO_VIEW_MIN_VISIBLE_MS = 2_000;
+const SESSION_EXPIRY_SAFETY_WINDOW_MS = 10_000;
+const VISIBILITY_TICK_MS = 200;
+const MAX_TICK_DELTA_MS = 1_000;
 
 @Injectable({ providedIn: 'root' })
 export class PhotoViewTrackingService {
+  private readonly destroyRef = inject(DestroyRef);
   private readonly functions = inject(Functions);
+  private readonly nextEligibleAt = new Map<string, number>();
+  private readonly inFlight = new Map<string, Observable<void>>();
+  private readonly sessions = new Map<string, PhotoViewSession>();
+  private readonly sessionInFlight = new Map<
+    string,
+    Observable<PhotoViewSession | null>
+  >();
+  private lastSessionUid: string | null | undefined = undefined;
 
   constructor(
     private readonly firestoreCtx: FirestoreContextService,
+    private readonly authSession: AuthSessionService,
     private readonly errorHandler: GlobalErrorHandlerService
-  ) {}
+  ) {
+    this.authSession.uid$
+      .pipe(
+        distinctUntilChanged(),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((uid) => {
+        const normalizedUid = uid?.trim() || null;
 
-  recordPhotoView$(
+        if (
+          this.lastSessionUid !== undefined &&
+          this.lastSessionUid !== normalizedUid
+        ) {
+          this.nextEligibleAt.clear();
+          this.inFlight.clear();
+          this.sessions.clear();
+          this.sessionInFlight.clear();
+        }
+
+        this.lastSessionUid = normalizedUid;
+      });
+  }
+
+  preparePhotoViewSession$(
     ownerUid: string,
     photoId: string,
     source: TPhotoViewSource = 'unknown'
-  ): Observable<void> {
+  ): Observable<PhotoViewSession | null> {
     const safeOwnerUid = (ownerUid ?? '').trim();
     const safePhotoId = (photoId ?? '').trim();
 
     if (!safeOwnerUid || !safePhotoId) {
-      return of(void 0);
+      return of(null);
     }
 
-    return this.firestoreCtx.deferPromise$(async () => {
-      const callable = httpsCallable<
-        IRecordPhotoViewRequest,
-        IRecordPhotoViewResponse
-      >(this.functions, 'recordPhotoView');
+    const viewKey = this.buildViewKey(safeOwnerUid, safePhotoId);
+    const cached = this.sessions.get(viewKey);
 
-      await callable({
+    if (
+      cached &&
+      cached.expiresAt > Date.now() + SESSION_EXPIRY_SAFETY_WINDOW_MS
+    ) {
+      return of(cached);
+    }
+
+    this.sessions.delete(viewKey);
+
+    const pending = this.sessionInFlight.get(viewKey);
+    if (pending) {
+      return pending;
+    }
+
+    const request$ = this.firestoreCtx.deferPromise$(async () => {
+      const callable = httpsCallable<
+        IssuePhotoViewSessionRequest,
+        IssuePhotoViewSessionResponse
+      >(this.functions, 'issuePhotoViewSession');
+      const response = await callable({
         ownerUid: safeOwnerUid,
         photoId: safePhotoId,
         source,
       });
+
+      return response.data;
     }).pipe(
-      map(() => void 0),
+      map((candidate) => this.normalizeSession(
+        candidate,
+        safeOwnerUid,
+        safePhotoId
+      )),
+      map((session) => {
+        if (session) {
+          this.sessions.set(viewKey, session);
+        }
+        return session;
+      }),
       catchError((error: unknown) => {
         this.reportError(error, {
-          op: 'recordPhotoView$',
-          ownerUid: safeOwnerUid,
-          photoId: safePhotoId,
+          op: 'preparePhotoViewSession$',
+          hasOwnerUid: true,
+          hasPhotoId: true,
           source,
         });
+        return of(null);
+      }),
+      finalize(() => this.sessionInFlight.delete(viewKey)),
+      shareReplay({ bufferSize: 1, refCount: false })
+    );
 
+    this.sessionInFlight.set(viewKey, request$);
+    return request$;
+  }
+
+  trackQualifiedPhotoView$(
+    ownerUid: string,
+    photoId: string,
+    source: TPhotoViewSource = 'unknown'
+  ): Observable<void> {
+    return this.preparePhotoViewSession$(ownerUid, photoId, source).pipe(
+      switchMap((session) => {
+        if (!session) {
+          return of(void 0);
+        }
+
+        return this.waitForVisibleEvidence$(session).pipe(
+          switchMap((evidence) =>
+            this.recordPhotoView$(ownerUid, photoId, source, evidence)
+          )
+        );
+      }),
+      catchError((error: unknown) => {
+        this.reportError(error, {
+          op: 'trackQualifiedPhotoView$',
+          hasOwnerUid: !!ownerUid,
+          hasPhotoId: !!photoId,
+          source,
+        });
         return of(void 0);
       })
     );
   }
 
-  private reportError(error: unknown, context: Record<string, unknown>): void {
-    try {
-      const err =
-        error instanceof Error
-          ? error
-          : new Error('Erro ao registrar visualização da foto.');
+  recordPhotoView$(
+    ownerUid: string,
+    photoId: string,
+    source: TPhotoViewSource = 'unknown',
+    evidence?: PhotoViewEvidence
+  ): Observable<void> {
+    const safeOwnerUid = (ownerUid ?? '').trim();
+    const safePhotoId = (photoId ?? '').trim();
+    const safeEvidence = this.normalizeEvidence(evidence);
 
-      (err as any).original = error;
-      (err as any).context = {
+    if (!safeOwnerUid || !safePhotoId || !safeEvidence) {
+      return of(void 0);
+    }
+
+    const viewKey = this.buildViewKey(safeOwnerUid, safePhotoId);
+    const preparedSession = this.sessions.get(viewKey);
+
+    if (
+      !preparedSession ||
+      preparedSession.sessionId !== safeEvidence.sessionId ||
+      preparedSession.expiresAt <= Date.now()
+    ) {
+      this.sessions.delete(viewKey);
+      return of(void 0);
+    }
+
+    const now = Date.now();
+
+    if ((this.nextEligibleAt.get(viewKey) ?? 0) > now) {
+      this.sessions.delete(viewKey);
+      return of(void 0);
+    }
+
+    const pending = this.inFlight.get(viewKey);
+    if (pending) {
+      return pending;
+    }
+
+    this.sessions.delete(viewKey);
+
+    const request$ = this.firestoreCtx.deferPromise$(async () => {
+      const callable = httpsCallable<
+        RecordPhotoViewRequest,
+        RecordPhotoViewResponse
+      >(this.functions, 'recordPhotoView');
+      const response = await callable({
+        ownerUid: safeOwnerUid,
+        photoId: safePhotoId,
+        source,
+        evidence: safeEvidence,
+      });
+
+      return response.data;
+    }).pipe(
+      map((response) => {
+        const retryAfterMs = Number(response.retryAfterMs ?? 0);
+
+        if (Number.isFinite(retryAfterMs) && retryAfterMs > 0) {
+          this.nextEligibleAt.set(viewKey, Date.now() + retryAfterMs);
+        }
+
+        return void 0;
+      }),
+      catchError((error: unknown) => {
+        this.reportError(error, {
+          op: 'recordPhotoView$',
+          hasOwnerUid: true,
+          hasPhotoId: true,
+          source,
+          visibleMs: safeEvidence.visibleMs,
+        });
+        return of(void 0);
+      }),
+      finalize(() => this.inFlight.delete(viewKey)),
+      shareReplay({ bufferSize: 1, refCount: false })
+    );
+
+    this.inFlight.set(viewKey, request$);
+    return request$;
+  }
+
+  private waitForVisibleEvidence$(
+    session: PhotoViewSession
+  ): Observable<PhotoViewEvidence> {
+    return new Observable<PhotoViewEvidence>((subscriber) => {
+      if (typeof document === 'undefined') {
+        subscriber.complete();
+        return undefined;
+      }
+
+      let visibleMs = 0;
+      let lastTickAt = this.monotonicNow();
+
+      const resetTick = (): void => {
+        lastTickAt = this.monotonicNow();
+      };
+
+      const tick = (): void => {
+        const tickAt = this.monotonicNow();
+        const deltaMs = Math.max(
+          0,
+          Math.min(MAX_TICK_DELTA_MS, tickAt - lastTickAt)
+        );
+        lastTickAt = tickAt;
+
+        if (document.visibilityState !== 'visible') {
+          return;
+        }
+
+        visibleMs += deltaMs;
+
+        if (visibleMs < PHOTO_VIEW_MIN_VISIBLE_MS) {
+          return;
+        }
+
+        subscriber.next({
+          sessionId: session.sessionId,
+          visibleMs: Math.round(visibleMs),
+          qualifiedAt: Date.now(),
+        });
+        subscriber.complete();
+      };
+
+      document.addEventListener('visibilitychange', resetTick, {
+        passive: true,
+      });
+      const intervalId = setInterval(tick, VISIBILITY_TICK_MS);
+
+      return () => {
+        clearInterval(intervalId);
+        document.removeEventListener('visibilitychange', resetTick);
+      };
+    });
+  }
+
+  private buildViewKey(ownerUid: string, photoId: string): string {
+    return `${ownerUid}:${photoId}`;
+  }
+
+  private monotonicNow(): number {
+    return typeof performance !== 'undefined' &&
+      typeof performance.now === 'function'
+      ? performance.now()
+      : Date.now();
+  }
+
+  private normalizeSession(
+    candidate: IssuePhotoViewSessionResponse,
+    expectedOwnerUid: string,
+    expectedPhotoId: string
+  ): PhotoViewSession | null {
+    const ownerUid = String(candidate?.ownerUid ?? '').trim();
+    const photoId = String(candidate?.photoId ?? '').trim();
+    const sessionId = String(candidate?.sessionId ?? '').trim();
+    const issuedAt = Number(candidate?.issuedAt ?? 0);
+    const expiresAt = Number(candidate?.expiresAt ?? 0);
+
+    if (
+      candidate?.ok !== true ||
+      ownerUid !== expectedOwnerUid ||
+      photoId !== expectedPhotoId ||
+      sessionId.length < 32 ||
+      sessionId.length > 128 ||
+      !/^[A-Za-z0-9_-]+$/.test(sessionId) ||
+      !Number.isFinite(issuedAt) ||
+      issuedAt <= 0 ||
+      !Number.isFinite(expiresAt) ||
+      expiresAt <= Date.now() + SESSION_EXPIRY_SAFETY_WINDOW_MS
+    ) {
+      return null;
+    }
+
+    return {
+      ownerUid,
+      photoId,
+      sessionId,
+      issuedAt: Math.floor(issuedAt),
+      expiresAt: Math.floor(expiresAt),
+    };
+  }
+
+  private normalizeEvidence(
+    evidence: PhotoViewEvidence | undefined
+  ): PhotoViewEvidence | null {
+    if (!evidence) {
+      return null;
+    }
+
+    const sessionId = String(evidence.sessionId ?? '').trim();
+    const visibleMs = Number(evidence.visibleMs);
+    const qualifiedAt = Number(evidence.qualifiedAt);
+
+    if (
+      sessionId.length < 32 ||
+      sessionId.length > 128 ||
+      !/^[A-Za-z0-9_-]+$/.test(sessionId) ||
+      !Number.isFinite(visibleMs) ||
+      visibleMs < PHOTO_VIEW_MIN_VISIBLE_MS ||
+      !Number.isFinite(qualifiedAt) ||
+      qualifiedAt <= 0
+    ) {
+      return null;
+    }
+
+    return {
+      sessionId,
+      visibleMs: Math.round(visibleMs),
+      qualifiedAt: Math.round(qualifiedAt),
+    };
+  }
+
+  private reportError(
+    error: unknown,
+    context: Record<string, unknown>
+  ): void {
+    try {
+      const normalizedError: PhotoViewTrackingError = error instanceof Error
+        ? error
+        : new Error('Erro ao registrar visualização da foto.');
+
+      normalizedError.original = error;
+      normalizedError.context = {
         scope: 'PhotoViewTrackingService',
         ...context,
       };
-      (err as any).skipUserNotification = true;
+      normalizedError.skipUserNotification = true;
 
-      this.errorHandler.handleError(err);
+      this.errorHandler.handleError(normalizedError);
     } catch {
-      // noop
+      // Métricas não podem interromper a exibição da foto.
     }
   }
 }

--- a/src/app/explore/pages/social-explore-page/social-explore-page.component.html
+++ b/src/app/explore/pages/social-explore-page/social-explore-page.component.html
@@ -202,6 +202,7 @@
       <app-public-photo-lightbox
         [items]="activeLightboxItems"
         [activeIndex]="lightboxState.index"
+        [viewSource]="resolveViewSource(lightboxState.section)"
         title="Publicação"
         (closed)="closeViewer()"
         (prevRequested)="prev()"

--- a/src/app/explore/pages/social-explore-page/social-explore-page.component.ts
+++ b/src/app/explore/pages/social-explore-page/social-explore-page.component.ts
@@ -16,12 +16,12 @@ import {
   take,
 } from 'rxjs/operators';
 import { IPublicPhotoItem } from 'src/app/core/interfaces/media/i-public-photo-item';
+import type { TPhotoViewSource } from 'src/app/core/services/media/photo-view-tracking.service';
 import { PublicPhotoCardComponent } from 'src/app/media/shared/components/public-photo-card/public-photo-card.component';
 import { PublicPhotoLightboxComponent } from 'src/app/media/shared/components/public-photo-lightbox/public-photo-lightbox.component';
 import { ExploreFeedFacade } from '../../facades/explore-feed.facade';
 import { IExploreFeedVm } from '../../services/explore-feed.service';
 import { TExploreSectionId } from '../../models/i-explore-section';
-import { PhotoViewTrackingService } from 'src/app/core/services/media/photo-view-tracking.service';
 import { IUserDados } from 'src/app/core/interfaces/iuser-dados';
 import { CurrentUserStoreService } from 'src/app/core/services/autentication/auth/current-user-store.service';
 import { AuthSessionService } from 'src/app/core/services/autentication/auth/auth-session.service';
@@ -80,7 +80,6 @@ export class SocialExplorePageComponent {
 
   private readonly exploreFeedFacade = inject(ExploreFeedFacade);
   private readonly personalMedia = inject(ExplorePersonalMediaService);
-  private readonly photoViewTracking = inject(PhotoViewTrackingService);
   private readonly currentUserStore = inject(CurrentUserStoreService);
   private readonly authSession = inject(AuthSessionService);
   private readonly statusService = inject(UserIntentStatusService);
@@ -115,10 +114,6 @@ export class SocialExplorePageComponent {
     shareReplay({ bufferSize: 1, refCount: true })
   );
 
-  /**
-   * Pool de fotos já priorizado por amizade, compatibilidade e recência.
-   * Momentos temporários são inseridos somente depois desse ranking pessoal.
-   */
   private readonly photoFeedPool$: Observable<readonly IPublicPhotoItem[]> =
     this.vm$.pipe(
       map((vm) =>
@@ -129,11 +124,6 @@ export class SocialExplorePageComponent {
       shareReplay({ bufferSize: 1, refCount: true })
     );
 
-  /**
-   * Momentos públicos da região são consultados apenas quando existe algum
-   * vínculo pessoal resolvido. O modelo puro faz o filtro final por autor e
-   * exclui o próprio usuário, cujo momento ocupa o primeiro cartão da timeline.
-   */
   private readonly relatedStatuses$ = combineLatest([
     this.authUid$,
     this.vm$,
@@ -251,20 +241,6 @@ export class SocialExplorePageComponent {
 
   openPhoto(section: TExplorePhotoSection, index: number): void {
     this.lightboxStateSubject.next({ section, index });
-
-    this.activeLightboxItems$.pipe(take(1)).subscribe((items) => {
-      const item = items[index];
-      if (!item) return;
-
-      this.photoViewTracking
-        .recordPhotoView$(
-          item.ownerUid,
-          item.id,
-          this.resolveViewSource(section)
-        )
-        .pipe(take(1))
-        .subscribe();
-    });
   }
 
   loadMoreFeed(): void {
@@ -309,7 +285,7 @@ export class SocialExplorePageComponent {
     return item.key;
   }
 
-  private resolveViewSource(section: TExplorePhotoSection) {
+  resolveViewSource(section: TExplorePhotoSection): TPhotoViewSource {
     switch (section) {
       case 'feed':
       case 'mostViewed':

--- a/src/app/media/photos/photo-viewer/photo-viewer.component.html
+++ b/src/app/media/photos/photo-viewer/photo-viewer.component.html
@@ -43,6 +43,7 @@
             [alt]="current.alt || 'Foto do perfil'"
             loading="eager"
             referrerpolicy="no-referrer"
+            (load)="onCurrentPhotoLoaded()"
           />
         } @else {
           <p class="empty">Nenhuma foto para exibir.</p>

--- a/src/app/media/photos/photo-viewer/photo-viewer.component.ts
+++ b/src/app/media/photos/photo-viewer/photo-viewer.component.ts
@@ -14,7 +14,7 @@
 //
 // Observação de manutenção:
 // - Este componente não deve escrever diretamente no Firestore.
-// - Visualizações passam por MediaPublicationService.
+// - Visualizações passam por PhotoViewTrackingService.
 // - Comentários e moderação passam por MediaPhotoCommentsService.
 // - Reações passam por MediaReactionsService.
 // - Regras reais de permissão ficam no backend/rules; o template apenas melhora UX.
@@ -24,6 +24,7 @@ import {
   Component,
   HostListener,
   Inject,
+  OnDestroy,
   inject,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
@@ -31,7 +32,14 @@ import { RouterModule } from '@angular/router';
 import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
 
-import { BehaviorSubject, EMPTY, Observable, combineLatest, of } from 'rxjs';
+import {
+  BehaviorSubject,
+  EMPTY,
+  Observable,
+  Subscription,
+  combineLatest,
+  of,
+} from 'rxjs';
 import {
   catchError,
   distinctUntilChanged,
@@ -47,7 +55,7 @@ import { CurrentUserStoreService } from 'src/app/core/services/autentication/aut
 import { ErrorNotificationService } from 'src/app/core/services/error-handler/error-notification.service';
 import { PrivacyDebugLoggerService } from 'src/app/core/services/privacy/privacy-debug-logger.service';
 import { MediaPhotoCommentsService } from 'src/app/core/services/media/media-photo-comments.service';
-import { MediaPublicationService } from 'src/app/core/services/media/media-publication.service';
+import { PhotoViewTrackingService } from 'src/app/core/services/media/photo-view-tracking.service';
 import { MediaReactionsService } from 'src/app/core/services/media/media-reactions.service';
 
 import { IPhotoComment } from 'src/app/core/interfaces/media/i-photo-comment';
@@ -122,12 +130,14 @@ type TPhotoCommentThread = {
   styleUrls: ['./photo-viewer.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class PhotoViewerComponent {
+export class PhotoViewerComponent implements OnDestroy {
   private readonly currentUserStore = inject(CurrentUserStoreService);
-  private readonly mediaPublication = inject(MediaPublicationService);
+  private readonly photoViewTracking = inject(PhotoViewTrackingService);
   private readonly privacyDebug = inject(PrivacyDebugLoggerService);
 
   private readonly recordedViewKeys = new Set<string>();
+  private viewTrackingSubscription: Subscription | null = null;
+  private activeViewKey: string | null = null;
 
   index: number;
 
@@ -290,13 +300,16 @@ export class PhotoViewerComponent {
     );
 
     this.syncCurrentPhotoId();
-    this.recordCurrentPhotoView();
 
     this.debug('init', {
       index: this.index,
       count: data.items?.length ?? 0,
       hasOwnerUid: !!data.ownerUid,
     });
+  }
+
+  ngOnDestroy(): void {
+    this.cancelCurrentPhotoViewTracking();
   }
 
   get current(): IProfilePhotoItem | null {
@@ -332,6 +345,7 @@ export class PhotoViewerComponent {
   }
 
   close(): void {
+    this.cancelCurrentPhotoViewTracking();
     this.dialogRef.close();
   }
 
@@ -340,11 +354,11 @@ export class PhotoViewerComponent {
       return;
     }
 
+    this.cancelCurrentPhotoViewTracking();
     this.index -= 1;
     this.commentControl.setValue('');
     this.cancelReply();
     this.syncCurrentPhotoId();
-    this.recordCurrentPhotoView();
   }
 
   next(): void {
@@ -352,11 +366,60 @@ export class PhotoViewerComponent {
       return;
     }
 
+    this.cancelCurrentPhotoViewTracking();
     this.index += 1;
     this.commentControl.setValue('');
     this.cancelReply();
     this.syncCurrentPhotoId();
-    this.recordCurrentPhotoView();
+  }
+
+  onCurrentPhotoLoaded(): void {
+    const current = this.current;
+    const ownerUid = (current?.ownerUid || this.data.ownerUid || '').trim();
+    const photoId = (current?.id || '').trim();
+    const state = this.getPhotoInteractionState(current);
+
+    if (!ownerUid || !photoId || state.moderationStatus !== 'APPROVED') {
+      return;
+    }
+
+    const viewKey = `${ownerUid}:${photoId}`;
+
+    if (
+      this.recordedViewKeys.has(viewKey) ||
+      this.activeViewKey === viewKey
+    ) {
+      return;
+    }
+
+    this.cancelCurrentPhotoViewTracking();
+    this.activeViewKey = viewKey;
+
+    this.viewTrackingSubscription = combineLatest([
+      this.viewerUid$,
+      this.viewerIsOwner$,
+    ]).pipe(
+      take(1),
+      switchMap(([viewerUid, viewerIsOwner]) => {
+        if (!viewerUid || viewerIsOwner) {
+          return EMPTY;
+        }
+
+        return this.photoViewTracking.trackQualifiedPhotoView$(
+          ownerUid,
+          photoId,
+          this.data.source ?? 'profile'
+        );
+      }),
+      catchError(() => EMPTY),
+      finalize(() => {
+        if (this.activeViewKey === viewKey) {
+          this.activeViewKey = null;
+        }
+      })
+    ).subscribe(() => {
+      this.recordedViewKeys.add(viewKey);
+    });
   }
 
   toggleLike(): void {
@@ -591,41 +654,10 @@ export class PhotoViewerComponent {
     return !!comment?.id && comment.id === replyingToCommentId;
   }
 
-  private recordCurrentPhotoView(): void {
-    const current = this.current;
-    const ownerUid = (current?.ownerUid || this.data.ownerUid || '').trim();
-    const photoId = (current?.id || '').trim();
-    const state = this.getPhotoInteractionState(current);
-
-    if (!ownerUid || !photoId || state.moderationStatus !== 'APPROVED') {
-      return;
-    }
-
-    const viewKey = `${ownerUid}:${photoId}`;
-
-    if (this.recordedViewKeys.has(viewKey)) {
-      return;
-    }
-
-    combineLatest([this.viewerUid$, this.viewerIsOwner$])
-      .pipe(
-        take(1),
-        switchMap(([viewerUid, viewerIsOwner]) => {
-          if (!viewerUid || viewerIsOwner) {
-            return EMPTY;
-          }
-
-          this.recordedViewKeys.add(viewKey);
-
-          return this.mediaPublication.recordPhotoView$(
-            ownerUid,
-            photoId,
-            this.data.source ?? 'profile'
-          );
-        }),
-        catchError(() => EMPTY)
-      )
-      .subscribe();
+  private cancelCurrentPhotoViewTracking(): void {
+    this.viewTrackingSubscription?.unsubscribe();
+    this.viewTrackingSubscription = null;
+    this.activeViewKey = null;
   }
 
   private moderateComment(

--- a/src/app/media/shared/components/public-photo-lightbox/public-photo-lightbox.component.html
+++ b/src/app/media/shared/components/public-photo-lightbox/public-photo-lightbox.component.html
@@ -1,4 +1,3 @@
-<!-- src/app/media/photos/shared/public-photo-lightbox/public-photo-lightbox.component.html -->
 @let photo = currentPhoto();
 <div
   class="lightbox-backdrop"
@@ -19,29 +18,29 @@
       </div>
 
       @if (photo && profileLink()) {
-  <a
-    class="lightbox-owner"
-    [routerLink]="profileLink()"
-    (click)="close()"
-    [attr.aria-label]="'Abrir perfil de ' + getOwnerName(photo)"
-  >
-    @if (photo.ownerPhotoURL) {
-      <img
-        class="lightbox-owner__avatar"
-        [src]="photo.ownerPhotoURL"
-        [alt]="'Avatar de ' + getOwnerName(photo)"
-      />
-    }
+        <a
+          class="lightbox-owner"
+          [routerLink]="profileLink()"
+          (click)="close()"
+          [attr.aria-label]="'Abrir perfil de ' + getOwnerName(photo)"
+        >
+          @if (photo.ownerPhotoURL) {
+            <img
+              class="lightbox-owner__avatar"
+              [src]="photo.ownerPhotoURL"
+              [alt]="'Avatar de ' + getOwnerName(photo)"
+            />
+          }
 
-    <span>
-      <strong>{{ getOwnerName(photo) }}</strong>
+          <span>
+            <strong>{{ getOwnerName(photo) }}</strong>
 
-      @if (getOwnerLocation(photo)) {
-        <small>{{ getOwnerLocation(photo) }}</small>
+            @if (getOwnerLocation(photo)) {
+              <small>{{ getOwnerLocation(photo) }}</small>
+            }
+          </span>
+        </a>
       }
-    </span>
-  </a>
-}
 
       <button
         type="button"
@@ -57,7 +56,8 @@
         <img
           class="lightbox-img"
           [src]="photo.url"
-          [alt]="photo.alt || 'Foto pública ampliada'" />
+          [alt]="photo.alt || 'Foto pública ampliada'"
+          (load)="onImageLoaded()" />
       } @else {
         <p class="empty-state">Nenhuma foto disponível.</p>
       }

--- a/src/app/media/shared/components/public-photo-lightbox/public-photo-lightbox.component.ts
+++ b/src/app/media/shared/components/public-photo-lightbox/public-photo-lightbox.component.ts
@@ -1,19 +1,25 @@
-//src\app\media\shared\components\public-photo-lightbox\public-photo-lightbox.component.ts
 import {
   AfterViewInit,
   ChangeDetectionStrategy,
   Component,
   ElementRef,
   HostListener,
+  OnDestroy,
   ViewChild,
   computed,
+  inject,
   input,
   output,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { Subscription } from 'rxjs';
 
 import { IPublicPhotoItem } from 'src/app/core/interfaces/media/i-public-photo-item';
-import { RouterModule } from '@angular/router';
+import {
+  PhotoViewTrackingService,
+  TPhotoViewSource,
+} from 'src/app/core/services/media/photo-view-tracking.service';
 
 @Component({
   selector: 'app-public-photo-lightbox',
@@ -23,10 +29,14 @@ import { RouterModule } from '@angular/router';
   styleUrls: ['./public-photo-lightbox.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class PublicPhotoLightboxComponent implements AfterViewInit {
+export class PublicPhotoLightboxComponent
+implements AfterViewInit, OnDestroy {
+  private readonly photoViewTracking = inject(PhotoViewTrackingService);
+
   readonly items = input.required<readonly IPublicPhotoItem[]>();
   readonly activeIndex = input<number>(0);
   readonly title = input<string>('Foto pública');
+  readonly viewSource = input<TPhotoViewSource>('unknown');
 
   readonly closed = output<void>();
   readonly prevRequested = output<void>();
@@ -36,6 +46,9 @@ export class PublicPhotoLightboxComponent implements AfterViewInit {
   private dialogRoot!: ElementRef<HTMLDivElement>;
 
   private previouslyFocused: HTMLElement | null = null;
+  private viewTrackingSubscription: Subscription | null = null;
+  private activeViewKey: string | null = null;
+  private readonly recordedViewKeys = new Set<string>();
 
   readonly currentPhoto = computed(() => {
     const collection = this.items();
@@ -47,31 +60,34 @@ export class PublicPhotoLightboxComponent implements AfterViewInit {
   readonly hasNext = computed(() => this.activeIndex() < this.items().length - 1);
 
   readonly profileLink = computed(() => {
-  const photo = this.currentPhoto();
+    const photo = this.currentPhoto();
+    return photo?.ownerUid ? ['/outro-perfil', photo.ownerUid] : null;
+  });
 
-  return photo?.ownerUid ? ['/outro-perfil', photo.ownerUid] : null;
-});
+  getOwnerName(photo: IPublicPhotoItem): string {
+    return photo.ownerNickname?.trim() || 'Ver perfil';
+  }
 
-getOwnerName(photo: IPublicPhotoItem): string {
-  return photo.ownerNickname?.trim() || 'Ver perfil';
-}
+  getOwnerLocation(photo: IPublicPhotoItem): string | null {
+    const parts = [
+      photo.ownerMunicipio,
+      photo.ownerEstado,
+    ]
+      .map((value) => value?.trim())
+      .filter(Boolean);
 
-getOwnerLocation(photo: IPublicPhotoItem): string | null {
-  const parts = [
-    photo.ownerMunicipio,
-    photo.ownerEstado,
-  ]
-    .map((value) => value?.trim())
-    .filter(Boolean);
-
-  return parts.length ? parts.join(', ') : null;
-}
+    return parts.length ? parts.join(', ') : null;
+  }
 
   ngAfterViewInit(): void {
     this.previouslyFocused = document.activeElement as HTMLElement | null;
     queueMicrotask(() => {
       this.dialogRoot?.nativeElement?.focus();
     });
+  }
+
+  ngOnDestroy(): void {
+    this.cancelViewTracking();
   }
 
   @HostListener('document:keydown.escape')
@@ -93,17 +109,58 @@ getOwnerLocation(photo: IPublicPhotoItem): string | null {
     }
   }
 
+  onImageLoaded(): void {
+    const photo = this.currentPhoto();
+    const ownerUid = String(photo?.ownerUid ?? '').trim();
+    const photoId = String(photo?.id ?? '').trim();
+
+    if (!ownerUid || !photoId) {
+      return;
+    }
+
+    const viewKey = `${ownerUid}:${photoId}`;
+
+    if (
+      this.recordedViewKeys.has(viewKey) ||
+      this.activeViewKey === viewKey
+    ) {
+      return;
+    }
+
+    this.cancelViewTracking();
+    this.activeViewKey = viewKey;
+    this.viewTrackingSubscription = this.photoViewTracking
+      .trackQualifiedPhotoView$(ownerUid, photoId, this.viewSource())
+      .subscribe({
+        next: () => this.recordedViewKeys.add(viewKey),
+        complete: () => {
+          if (this.activeViewKey === viewKey) {
+            this.activeViewKey = null;
+          }
+        },
+      });
+  }
+
   close(): void {
+    this.cancelViewTracking();
     this.restoreFocus();
     this.closed.emit();
   }
 
   prev(): void {
+    this.cancelViewTracking();
     this.prevRequested.emit();
   }
 
   next(): void {
+    this.cancelViewTracking();
     this.nextRequested.emit();
+  }
+
+  private cancelViewTracking(): void {
+    this.viewTrackingSubscription?.unsubscribe();
+    this.viewTrackingSubscription = null;
+    this.activeViewKey = null;
   }
 
   private restoreFocus(): void {


### PR DESCRIPTION
## Dependência

PR empilhado sobre o #58 (`agent/media-p0-admin-claims-cooldown`). Nenhum merge é realizado por este pacote.

## Escopo

Este pacote fecha a assimetria entre visualizações de fotos e vídeos. A contabilização de fotos passa a exigir App Check, sessão emitida pelo backend, permanência mínima e consumo único transacional.

## Sessão protegida de visualização

Foi criada a callable `issuePhotoViewSession`, preservando `recordPhotoView` como nome público do registro.

A sessão:

- exige autenticação e App Check na nuvem;
- revalida lifecycle e audiência antes da emissão;
- resolve a projeção pública e a publicação privada como alvo canônico;
- suporta `PUBLIC`, `COMPATIBLE`, `FRIENDS`, `SUBSCRIBERS` e `PREMIUM` quando a audiência é válida;
- vincula usuário, proprietário, foto, origem, App ID, emissão e expiração;
- usa token aleatório de 256 bits;
- persiste somente o hash SHA-256 do token como ID do documento;
- expira em 10 minutos;
- é consumida uma única vez.

## Permanência qualificada

Uma visualização só é enviada depois de:

1. a imagem disparar o evento real de `load`;
2. a sessão ser emitida pelo backend;
3. a foto permanecer visível por pelo menos 2 segundos;
4. a aba permanecer em estado `visible` durante a contagem.

O contador usa relógio monotônico no cliente e limita saltos de timer. Tempo em aba oculta não é acumulado.

Navegar para outra foto, fechar o modal ou destruir o componente cancela o Observable e o timer em andamento.

## Consumo transacional e antifraude

`recordPhotoView` agora:

- usa core tipado com `CallableRequest`;
- exige App Check pela borda pública;
- valida evidência e coerência temporal;
- revalida publicação, moderação, lifecycle, bloqueio bilateral e audiência dentro da transação;
- valida origem, App ID e identidade da sessão;
- remove a sessão na mesma transação que atualiza métricas;
- mantém intervalo de 5 minutos por usuário/foto para nova contagem;
- retorna `counted`, `uniqueViewer` e `retryAfterMs`;
- grava somente o hash da sessão consumida no documento privado de audiência.

Foram preservados os contadores e índices existentes:

- `viewsCount`;
- visualizadores únicos da foto;
- visualizadores únicos do perfil;
- índice privado `profile_viewers`;
- `viewScore` e `engagementScore` do perfil.

## Rate limiting de emissão

- 60 sessões por visitante a cada 10 minutos;
- 10 sessões por visitante/foto a cada 10 minutos;
- intervalo mínimo de 1 segundo entre emissões;
- erro `resource-exhausted` com `retryAfterMs` seguro;
- documentos de limite armazenam apenas escopo, janela e contadores, sem IDs brutos;
- retenção máxima de 24 horas para limites inativos.

Uma rotina a cada seis horas remove sessões expiradas e documentos antigos de rate limit.

## Integração Angular

`PhotoViewTrackingService` passa a ser o ponto canônico e reativo para métricas de foto:

- `preparePhotoViewSession$`;
- `trackQualifiedPhotoView$`;
- `recordPhotoView$` preservado para compatibilidade e consumo com evidência;
- cache de sessão somente em memória;
- deduplicação de requests concorrentes com `shareReplay`;
- limpeza de caches ao trocar de usuário;
- falhas silenciosas encaminhadas ao `GlobalErrorHandlerService`;
- métricas nunca interrompem a exibição da foto.

O visualizador de perfil e o lightbox compartilhado iniciam o fluxo somente após o `load` da imagem. O lightbox recebe a origem da seção quando disponível e usa `unknown` como fallback seguro nos demais consumidores.

## Supressões e substituições intencionais

### Contagem imediata

Foi suprimida a contabilização no construtor do visualizador e no clique que abre o lightbox. Esse comportamento contabilizava antes do download e sem permanência real.

Foi substituído pelo fluxo `load → sessão → 2 segundos visíveis → consumo`.

### Orquestrador sem App Check e cast inseguro

Foram suprimidos:

- `onCall({ region })` sem App Check;
- validação isolada de lifecycle no orquestrador;
- `recordPhotoViewCore.run(request as any)`.

A callable agora usa `PROTECTED_CALLABLE_OPTIONS` e delegação tipada direta para `recordPhotoViewCore`. Lifecycle e audiência não foram removidos: são revalidados de forma central e novamente dentro da transação.

### Implementação duplicada no `MediaPublicationService`

Foi suprimida a chamada direta antiga para `recordPhotoView` sem evidência. O método público `recordPhotoView$` foi preservado como fachada para `PhotoViewTrackingService`, e `trackQualifiedPhotoView$` foi exposto para novos consumidores.

## Compatibilidade

- nomes públicos das Functions preservados;
- Observables mantidos na API Angular;
- falha da métrica não bloqueia imagem, navegação, comentários ou reações;
- comportamento responsivo e acessível dos visualizadores preservado;
- nenhuma Firestore Rule foi afrouxada;
- nenhum índice composto novo é necessário;
- Emulator Suite continua suportado pela política central de App Check.

## Testes adicionados

Functions:

- formato do token;
- permanência mínima;
- primeira emissão;
- bloqueio de rajada;
- teto da janela;
- reinício após expiração.

Angular:

- chamada sem evidência não alcança o backend;
- registro após 2 segundos com aba visível;
- pausa completa enquanto a aba está oculta;
- retomada após `visibilitychange`.

## Validação concluída

- lint, build e testes das Functions: aprovados;
- política de sessão e rate limiting de fotos: aprovada;
- testes Angular do tracking visível: aprovados;
- templates do visualizador e lightbox: compilados;
- build Angular seguro: aprovado;
- Firestore Rules: aprovadas;
- índices do Firestore: aprovados;
- Quality Gate agregado: aprovado;
- Angular CI Validation: aprovado;
- build da configuração do Emulator: aprovado.

Todos os jobs passaram no primeiro head do PR, sem commit corretivo de código.

## Nota operacional

Durante a preparação, quatro arquivos placeholder vazios foram criados por roteamento incorreto da ferramenta e removidos imediatamente antes da abertura do PR. Eles não aparecem no diff final e não alteram código ou artefatos do projeto; permanecem apenas como pares de commits de criação/remoção no histórico da branch.