### PR TITLE
feat(media): unificar ranking qualificado de fotos

### DIFF
--- a/functions/src/media/application/manage-photo-comment.handler.ts
+++ b/functions/src/media/application/manage-photo-comment.handler.ts
@@ -8,7 +8,7 @@
 // - permitir resposta do dono da foto a um comentário;
 // - permitir moderação pelo dono da foto;
 // - permitir remoção suave pelo autor do comentário;
-// - atualizar commentsCount e score no backend.
+// - atualizar commentsCount e ranking pela infraestrutura canônica de mídia.
 //
 // Segurança:
 // - cliente não edita comentário diretamente;
@@ -20,29 +20,21 @@ import { HttpsError, onCall } from 'firebase-functions/v2/https';
 
 import { db } from '../../firebaseApp';
 import { FUNCTIONS_REGION } from '../../config/functions-region';
+import { normalizeMediaCount } from './media-engagement-score';
+import {
+  buildPhotoRankingUpdate,
+  type PublicPhotoRankingDocument,
+} from './photo-ranking-score';
 
 type CommentStatus = 'VISIBLE' | 'PENDING_REVIEW' | 'HIDDEN' | 'DELETED';
 
-type ScoreBreakdown = {
-  rankingScore: number;
-  qualityScore: number;
-  engagementScore: number;
-  safetyScore: number;
-};
-
-type PublicPhotoDoc = {
+type PublicPhotoDoc = PublicPhotoRankingDocument & {
   ownerUid?: string;
   visibility?: string;
   moderationStatus?: string;
   commentsEnabled?: boolean;
   commentsPolicy?: string;
   reactionsEnabled?: boolean;
-  reactionsCount?: number;
-  likesCount?: number;
-  commentsCount?: number;
-  score?: number;
-  engagementScore?: number;
-  scoreBreakdown?: Partial<ScoreBreakdown>;
 };
 
 type PublicProfileDoc = {
@@ -110,80 +102,24 @@ function cleanContent(value: unknown): string {
     .slice(0, 500);
 }
 
-function normalizeCount(value: unknown): number {
-  const count = Number(value ?? 0);
-
-  if (!Number.isFinite(count) || count < 0) {
-    return 0;
-  }
-
-  return Math.floor(count);
-}
-
-function normalizeScore(value: unknown): number {
-  const score = Number(value ?? 0);
-
-  if (!Number.isFinite(score)) {
-    return 0;
-  }
-
-  return Math.max(0, Math.min(100, Math.round(score)));
-}
-
-function calculateEngagementScore(input: {
-  reactionsCount: number;
-  commentsCount: number;
-}): number {
-  const weightedEngagement =
-    input.reactionsCount * 2 +
-    input.commentsCount * 4;
-
-  return normalizeScore(Math.round(Math.log1p(weightedEngagement) * 18));
-}
-
-function calculateRankingScore(score: ScoreBreakdown): number {
-  const quality = normalizeScore(score.qualityScore);
-  const engagement = normalizeScore(score.engagementScore);
-  const safety = normalizeScore(score.safetyScore);
-
-  return normalizeScore(
-    Math.round(
-      quality * 0.25 +
-      engagement * 0.45 +
-      safety * 0.30
-    )
-  );
-}
-
-function buildNextScore(
+function buildRankingFields(
   photo: PublicPhotoDoc,
-  nextCommentsCount: number
-): {
-  score: number;
-  engagementScore: number;
-  scoreBreakdown: ScoreBreakdown;
-} {
-  const currentBreakdown = photo.scoreBreakdown ?? {};
-  const reactionsCount = normalizeCount(photo.reactionsCount ?? photo.likesCount ?? 0);
-
-  const engagementScore = calculateEngagementScore({
-    reactionsCount,
+  nextCommentsCount: number,
+  now: number
+) {
+  const ranking = buildPhotoRankingUpdate(photo, now, {
     commentsCount: nextCommentsCount,
   });
 
-  const scoreBreakdown: ScoreBreakdown = {
-    qualityScore: normalizeScore(currentBreakdown.qualityScore ?? 0),
-    safetyScore: normalizeScore(currentBreakdown.safetyScore ?? 100),
-    engagementScore,
-    rankingScore: 0,
-  };
-
-  scoreBreakdown.rankingScore = calculateRankingScore(scoreBreakdown);
-
   return {
-    score: scoreBreakdown.rankingScore,
-    engagementScore,
-    scoreBreakdown,
+    engagementScore: ranking.engagementScore,
+    viewScore: ranking.viewScore,
+    retentionScore: ranking.retentionScore,
+    freshnessScore: ranking.freshnessScore,
+    score: ranking.score,
+    scoreBreakdown: ranking.scoreBreakdown,
+    rankingVersion: ranking.rankingVersion,
+    rankingUpdatedAt: ranking.rankingUpdatedAt,
   };
 }
 
@@ -214,7 +150,10 @@ function assertPublicPhotoAllowsComments(photo: PublicPhotoDoc): void {
   }
 }
 
-function resolveNickname(profile: PublicProfileDoc | undefined, fallback = 'Usuário'): string {
+function resolveNickname(
+  profile: PublicProfileDoc | undefined,
+  fallback = 'Usuário'
+): string {
   const nickname =
     profile?.nickname ??
     profile?.displayName ??
@@ -253,7 +192,9 @@ export const createPhotoComment = onCall<CreatePhotoCommentRequest>(
       throw new HttpsError('invalid-argument', 'Comentário muito longo.');
     }
 
-    const photoRef = db.doc(`public_profiles/${ownerUid}/public_photos/${photoId}`);
+    const photoRef = db.doc(
+      `public_profiles/${ownerUid}/public_photos/${photoId}`
+    );
     const authorProfileRef = db.doc(`public_profiles/${authorUid}`);
     const commentsCollection = photoRef.collection('comments');
     const newCommentRef = commentsCollection.doc();
@@ -277,7 +218,9 @@ export const createPhotoComment = onCall<CreatePhotoCommentRequest>(
       assertPublicPhotoAllowsComments(photo);
 
       const authorNickname = resolveNickname(
-        authorProfileSnap.exists ? (authorProfileSnap.data() as PublicProfileDoc) : undefined
+        authorProfileSnap.exists
+          ? authorProfileSnap.data() as PublicProfileDoc
+          : undefined
       );
 
       let replyToAuthorUid: string | null = null;
@@ -296,7 +239,10 @@ export const createPhotoComment = onCall<CreatePhotoCommentRequest>(
         const parentSnap = await transaction.get(parentRef);
 
         if (!parentSnap.exists) {
-          throw new HttpsError('not-found', 'Comentário original não encontrado.');
+          throw new HttpsError(
+            'not-found',
+            'Comentário original não encontrado.'
+          );
         }
 
         const parent = parentSnap.data() as PhotoCommentDoc;
@@ -326,11 +272,15 @@ export const createPhotoComment = onCall<CreatePhotoCommentRequest>(
 
       const now = Date.now();
       const isRootComment = !parentCommentId;
-      const currentCommentsCount = normalizeCount(photo.commentsCount ?? 0);
+      const currentCommentsCount = normalizeMediaCount(photo.commentsCount);
       const nextCommentsCount = isRootComment
         ? currentCommentsCount + 1
         : currentCommentsCount;
-      const nextScore = buildNextScore(photo, nextCommentsCount);
+      const rankingFields = buildRankingFields(
+        photo,
+        nextCommentsCount,
+        now
+      );
 
       const commentDoc: PhotoCommentDoc = {
         ownerUid,
@@ -359,9 +309,7 @@ export const createPhotoComment = onCall<CreatePhotoCommentRequest>(
 
       transaction.update(photoRef, {
         commentsCount: nextCommentsCount,
-        engagementScore: nextScore.engagementScore,
-        score: nextScore.score,
-        scoreBreakdown: nextScore.scoreBreakdown,
+        ...rankingFields,
         updatedAt: now,
       });
 
@@ -386,7 +334,6 @@ export const moderatePhotoComment = onCall<ModeratePhotoCommentRequest>(
     const commentId = cleanId(request.data?.commentId);
     const action = String(request.data?.action ?? '').trim().toUpperCase();
 
-
     if (!ownerUid || !photoId || !commentId) {
       throw new HttpsError('invalid-argument', 'Comentário inválido.');
     }
@@ -395,7 +342,9 @@ export const moderatePhotoComment = onCall<ModeratePhotoCommentRequest>(
       throw new HttpsError('invalid-argument', 'Ação inválida.');
     }
 
-    const photoRef = db.doc(`public_profiles/${ownerUid}/public_photos/${photoId}`);
+    const photoRef = db.doc(
+      `public_profiles/${ownerUid}/public_photos/${photoId}`
+    );
     const commentRef = photoRef.collection('comments').doc(commentId);
 
     return db.runTransaction(async (transaction) => {
@@ -420,7 +369,10 @@ export const moderatePhotoComment = onCall<ModeratePhotoCommentRequest>(
       }
 
       if (comment.ownerUid !== ownerUid || comment.photoId !== photoId) {
-        throw new HttpsError('failed-precondition', 'Comentário inconsistente.');
+        throw new HttpsError(
+          'failed-precondition',
+          'Comentário inconsistente.'
+        );
       }
 
       const isPhotoOwner = requesterUid === ownerUid;
@@ -490,9 +442,16 @@ export const moderatePhotoComment = onCall<ModeratePhotoCommentRequest>(
       }
 
       const now = Date.now();
-      const currentCommentsCount = normalizeCount(photo.commentsCount ?? 0);
-      const nextCommentsCount = Math.max(0, currentCommentsCount + countDelta);
-      const nextScore = buildNextScore(photo, nextCommentsCount);
+      const currentCommentsCount = normalizeMediaCount(photo.commentsCount);
+      const nextCommentsCount = Math.max(
+        0,
+        currentCommentsCount + countDelta
+      );
+      const rankingFields = buildRankingFields(
+        photo,
+        nextCommentsCount,
+        now
+      );
 
       transaction.update(commentRef, {
         status: nextStatus,
@@ -503,16 +462,14 @@ export const moderatePhotoComment = onCall<ModeratePhotoCommentRequest>(
 
       transaction.update(photoRef, {
         commentsCount: nextCommentsCount,
-        engagementScore: nextScore.engagementScore,
-        score: nextScore.score,
-        scoreBreakdown: nextScore.scoreBreakdown,
+        ...rankingFields,
         updatedAt: now,
       });
 
       return {
         status: nextStatus,
         commentsCount: nextCommentsCount,
-        score: nextScore.score,
+        score: rankingFields.score,
       };
     });
   }

--- a/functions/src/media/application/photo-ranking-score-maintenance.handler.ts
+++ b/functions/src/media/application/photo-ranking-score-maintenance.handler.ts
@@ -1,0 +1,118 @@
+import { logger } from 'firebase-functions';
+import { onDocumentWritten } from 'firebase-functions/v2/firestore';
+import { onSchedule } from 'firebase-functions/v2/scheduler';
+
+import { FUNCTIONS_REGION } from '../../config/functions-region';
+import { db } from '../../firebaseApp';
+import {
+  buildPhotoRankingUpdate,
+  hasEquivalentPhotoRanking,
+  isRankablePhoto,
+  type PublicPhotoRankingDocument,
+} from './photo-ranking-score';
+import { MEDIA_RANKING_VERSION } from './media-engagement-score';
+import { refreshPublicProfileMediaMetrics } from './public-profile-media-metrics';
+
+const RANKING_REFRESH_LIMIT_PER_QUERY = 240;
+
+export const recalculatePhotoRankingOnWrite = onDocumentWritten(
+  {
+    document: 'public_profiles/{ownerUid}/public_photos/{photoId}',
+    region: FUNCTIONS_REGION,
+    maxInstances: 20,
+  },
+  async (event) => {
+    const after = event.data?.after;
+
+    if (!after?.exists) {
+      return;
+    }
+
+    const data = after.data() as PublicPhotoRankingDocument;
+
+    if (!isRankablePhoto(data)) {
+      return;
+    }
+
+    const update = buildPhotoRankingUpdate(data, Date.now());
+
+    if (hasEquivalentPhotoRanking(data, update)) {
+      return;
+    }
+
+    await after.ref.set(update, { merge: true });
+
+    const ownerUid = String(event.params.ownerUid ?? '').trim();
+    if (ownerUid) {
+      await refreshPublicProfileMediaMetrics(ownerUid);
+    }
+  }
+);
+
+export const refreshPublicPhotoRankingScores = onSchedule(
+  {
+    schedule: 'every 6 hours',
+    timeZone: 'America/Sao_Paulo',
+    region: FUNCTIONS_REGION,
+  },
+  async () => {
+    const rankablePhotos = db
+      .collectionGroup('public_photos')
+      .where('visibility', '==', 'PUBLIC')
+      .where('moderationStatus', '==', 'APPROVED');
+    const [topSnapshot, latestSnapshot] = await Promise.all([
+      rankablePhotos
+        .orderBy('score', 'desc')
+        .limit(RANKING_REFRESH_LIMIT_PER_QUERY)
+        .get(),
+      rankablePhotos
+        .orderBy('publishedAt', 'desc')
+        .limit(RANKING_REFRESH_LIMIT_PER_QUERY)
+        .get(),
+    ]);
+    const candidates = new Map<
+      string,
+      FirebaseFirestore.QueryDocumentSnapshot
+    >();
+
+    for (const document of [...topSnapshot.docs, ...latestSnapshot.docs]) {
+      candidates.set(document.ref.path, document);
+    }
+
+    const now = Date.now();
+    const changedOwners = new Set<string>();
+    let updatedPhotos = 0;
+
+    for (const document of candidates.values()) {
+      const data = document.data() as PublicPhotoRankingDocument;
+
+      if (!isRankablePhoto(data)) {
+        continue;
+      }
+
+      const update = buildPhotoRankingUpdate(data, now);
+
+      if (hasEquivalentPhotoRanking(data, update)) {
+        continue;
+      }
+
+      await document.ref.set(update, { merge: true });
+      const ownerUid = document.ref.parent.parent?.id ?? '';
+      if (ownerUid) {
+        changedOwners.add(ownerUid);
+      }
+      updatedPhotos += 1;
+    }
+
+    for (const ownerUid of changedOwners) {
+      await refreshPublicProfileMediaMetrics(ownerUid);
+    }
+
+    logger.info('[refreshPublicPhotoRankingScores] Ranking atualizado.', {
+      scannedPhotos: candidates.size,
+      updatedPhotos,
+      updatedProfiles: changedOwners.size,
+      rankingVersion: MEDIA_RANKING_VERSION,
+    });
+  }
+);

--- a/functions/src/media/application/photo-ranking-score-maintenance.handler.ts
+++ b/functions/src/media/application/photo-ranking-score-maintenance.handler.ts
@@ -42,6 +42,14 @@ function hasProfileAggregateInputChange(
     before.isCover !== after.isCover;
 }
 
+async function refreshOwnerProfile(ownerUidValue: unknown): Promise<void> {
+  const ownerUid = String(ownerUidValue ?? '').trim();
+
+  if (ownerUid) {
+    await refreshPublicProfileMediaMetrics(ownerUid);
+  }
+}
+
 export const recalculatePhotoRankingOnWrite = onDocumentWritten(
   {
     document: 'public_profiles/{ownerUid}/public_photos/{photoId}',
@@ -49,34 +57,41 @@ export const recalculatePhotoRankingOnWrite = onDocumentWritten(
     maxInstances: 20,
   },
   async (event) => {
-    const after = event.data?.after;
+    const beforeSnapshot = event.data?.before;
+    const afterSnapshot = event.data?.after;
+    const before = beforeSnapshot?.exists
+      ? beforeSnapshot.data() as PublicPhotoRankingDocument
+      : null;
 
-    if (!after?.exists) {
+    if (!afterSnapshot?.exists) {
+      if (before && isRankablePhoto(before)) {
+        await refreshOwnerProfile(event.params.ownerUid);
+      }
       return;
     }
 
-    const data = after.data() as PublicPhotoRankingDocument;
+    const data = afterSnapshot.data() as PublicPhotoRankingDocument;
 
     if (!isRankablePhoto(data)) {
+      if (
+        (before && isRankablePhoto(before)) ||
+        hasProfileAggregateInputChange(before, data)
+      ) {
+        await refreshOwnerProfile(event.params.ownerUid);
+      }
       return;
     }
 
-    const before = event.data?.before.exists
-      ? event.data.before.data() as PublicPhotoRankingDocument
-      : null;
     const update = buildPhotoRankingUpdate(data, Date.now());
     const rankingChanged = !hasEquivalentPhotoRanking(data, update);
     const aggregateInputChanged = hasProfileAggregateInputChange(before, data);
 
     if (rankingChanged) {
-      await after.ref.set(update, { merge: true });
+      await afterSnapshot.ref.set(update, { merge: true });
     }
 
     if (rankingChanged || aggregateInputChanged) {
-      const ownerUid = String(event.params.ownerUid ?? '').trim();
-      if (ownerUid) {
-        await refreshPublicProfileMediaMetrics(ownerUid);
-      }
+      await refreshOwnerProfile(event.params.ownerUid);
     }
   }
 );

--- a/functions/src/media/application/photo-ranking-score-maintenance.handler.ts
+++ b/functions/src/media/application/photo-ranking-score-maintenance.handler.ts
@@ -4,7 +4,10 @@ import { onSchedule } from 'firebase-functions/v2/scheduler';
 
 import { FUNCTIONS_REGION } from '../../config/functions-region';
 import { db } from '../../firebaseApp';
-import { MEDIA_RANKING_VERSION } from './media-engagement-score';
+import {
+  MEDIA_RANKING_VERSION,
+  normalizeMediaCount,
+} from './media-engagement-score';
 import {
   buildPhotoRankingUpdate,
   hasEquivalentPhotoRanking,
@@ -14,22 +17,29 @@ import {
 import { refreshPublicProfileMediaMetrics } from './public-profile-media-metrics';
 
 const RANKING_REFRESH_LIMIT_PER_QUERY = 240;
-const PROFILE_REFRESH_CONCURRENCY = 20;
 
-async function refreshChangedProfiles(
-  ownerUids: readonly string[]
-): Promise<void> {
-  for (
-    let index = 0;
-    index < ownerUids.length;
-    index += PROFILE_REFRESH_CONCURRENCY
-  ) {
-    await Promise.all(
-      ownerUids
-        .slice(index, index + PROFILE_REFRESH_CONCURRENCY)
-        .map((ownerUid) => refreshPublicProfileMediaMetrics(ownerUid))
-    );
+function normalizeEnum(value: unknown): string {
+  return String(value ?? '').trim().toUpperCase();
+}
+
+function hasProfileAggregateInputChange(
+  before: PublicPhotoRankingDocument | null,
+  after: PublicPhotoRankingDocument
+): boolean {
+  if (!before) {
+    return true;
   }
+
+  return normalizeEnum(before.visibility) !== normalizeEnum(after.visibility) ||
+    normalizeEnum(before.moderationStatus) !==
+      normalizeEnum(after.moderationStatus) ||
+    normalizeMediaCount(before.viewsCount) !==
+      normalizeMediaCount(after.viewsCount) ||
+    normalizeMediaCount(before.uniqueViewersCount) !==
+      normalizeMediaCount(after.uniqueViewersCount) ||
+    normalizeMediaCount(before.reactionsCount ?? before.likesCount) !==
+      normalizeMediaCount(after.reactionsCount ?? after.likesCount) ||
+    before.isCover !== after.isCover;
 }
 
 export const recalculatePhotoRankingOnWrite = onDocumentWritten(
@@ -51,17 +61,22 @@ export const recalculatePhotoRankingOnWrite = onDocumentWritten(
       return;
     }
 
+    const before = event.data?.before.exists
+      ? event.data.before.data() as PublicPhotoRankingDocument
+      : null;
     const update = buildPhotoRankingUpdate(data, Date.now());
+    const rankingChanged = !hasEquivalentPhotoRanking(data, update);
+    const aggregateInputChanged = hasProfileAggregateInputChange(before, data);
 
-    if (hasEquivalentPhotoRanking(data, update)) {
-      return;
+    if (rankingChanged) {
+      await after.ref.set(update, { merge: true });
     }
 
-    await after.ref.set(update, { merge: true });
-
-    const ownerUid = String(event.params.ownerUid ?? '').trim();
-    if (ownerUid) {
-      await refreshPublicProfileMediaMetrics(ownerUid);
+    if (rankingChanged || aggregateInputChanged) {
+      const ownerUid = String(event.params.ownerUid ?? '').trim();
+      if (ownerUid) {
+        await refreshPublicProfileMediaMetrics(ownerUid);
+      }
     }
   }
 );
@@ -97,7 +112,6 @@ export const refreshPublicPhotoRankingScores = onSchedule(
     }
 
     const now = Date.now();
-    const changedOwners = new Set<string>();
     const batch = db.batch();
     let updatedPhotos = 0;
 
@@ -115,22 +129,16 @@ export const refreshPublicPhotoRankingScores = onSchedule(
       }
 
       batch.set(document.ref, update, { merge: true });
-      const ownerUid = document.ref.parent.parent?.id ?? '';
-      if (ownerUid) {
-        changedOwners.add(ownerUid);
-      }
       updatedPhotos += 1;
     }
 
     if (updatedPhotos > 0) {
       await batch.commit();
-      await refreshChangedProfiles([...changedOwners]);
     }
 
     logger.info('[refreshPublicPhotoRankingScores] Ranking atualizado.', {
       scannedPhotos: candidates.size,
       updatedPhotos,
-      updatedProfiles: changedOwners.size,
       rankingVersion: MEDIA_RANKING_VERSION,
     });
   }

--- a/functions/src/media/application/photo-ranking-score-maintenance.handler.ts
+++ b/functions/src/media/application/photo-ranking-score-maintenance.handler.ts
@@ -4,16 +4,33 @@ import { onSchedule } from 'firebase-functions/v2/scheduler';
 
 import { FUNCTIONS_REGION } from '../../config/functions-region';
 import { db } from '../../firebaseApp';
+import { MEDIA_RANKING_VERSION } from './media-engagement-score';
 import {
   buildPhotoRankingUpdate,
   hasEquivalentPhotoRanking,
   isRankablePhoto,
   type PublicPhotoRankingDocument,
 } from './photo-ranking-score';
-import { MEDIA_RANKING_VERSION } from './media-engagement-score';
 import { refreshPublicProfileMediaMetrics } from './public-profile-media-metrics';
 
 const RANKING_REFRESH_LIMIT_PER_QUERY = 240;
+const PROFILE_REFRESH_CONCURRENCY = 20;
+
+async function refreshChangedProfiles(
+  ownerUids: readonly string[]
+): Promise<void> {
+  for (
+    let index = 0;
+    index < ownerUids.length;
+    index += PROFILE_REFRESH_CONCURRENCY
+  ) {
+    await Promise.all(
+      ownerUids
+        .slice(index, index + PROFILE_REFRESH_CONCURRENCY)
+        .map((ownerUid) => refreshPublicProfileMediaMetrics(ownerUid))
+    );
+  }
+}
 
 export const recalculatePhotoRankingOnWrite = onDocumentWritten(
   {
@@ -81,6 +98,7 @@ export const refreshPublicPhotoRankingScores = onSchedule(
 
     const now = Date.now();
     const changedOwners = new Set<string>();
+    const batch = db.batch();
     let updatedPhotos = 0;
 
     for (const document of candidates.values()) {
@@ -96,7 +114,7 @@ export const refreshPublicPhotoRankingScores = onSchedule(
         continue;
       }
 
-      await document.ref.set(update, { merge: true });
+      batch.set(document.ref, update, { merge: true });
       const ownerUid = document.ref.parent.parent?.id ?? '';
       if (ownerUid) {
         changedOwners.add(ownerUid);
@@ -104,8 +122,9 @@ export const refreshPublicPhotoRankingScores = onSchedule(
       updatedPhotos += 1;
     }
 
-    for (const ownerUid of changedOwners) {
-      await refreshPublicProfileMediaMetrics(ownerUid);
+    if (updatedPhotos > 0) {
+      await batch.commit();
+      await refreshChangedProfiles([...changedOwners]);
     }
 
     logger.info('[refreshPublicPhotoRankingScores] Ranking atualizado.', {

--- a/functions/src/media/application/photo-ranking-score.test.ts
+++ b/functions/src/media/application/photo-ranking-score.test.ts
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  PHOTO_RANKING_MAX_VISIBLE_SAMPLE_MS,
+  PHOTO_RANKING_QUALIFIED_VISIBLE_TARGET_MS,
+  buildNextPhotoQualificationMetrics,
+  buildPhotoRankingUpdate,
+  hasEquivalentPhotoRanking,
+  normalizePhotoQualifiedVisibleMs,
+} from './photo-ranking-score';
+
+describe('photo-ranking-score', () => {
+  it('limita uma amostra de permanência para evitar distorção', () => {
+    assert.equal(normalizePhotoQualifiedVisibleMs(-1), 0);
+    assert.equal(normalizePhotoQualifiedVisibleMs(2_500), 2_500);
+    assert.equal(
+      normalizePhotoQualifiedVisibleMs(120_000),
+      PHOTO_RANKING_MAX_VISIBLE_SAMPLE_MS
+    );
+  });
+
+  it('acumula visualização qualificada com meta estável', () => {
+    const metrics = buildNextPhotoQualificationMetrics({
+      currentQualifiedViewsCount: 2,
+      currentTotalQualifiedVisibleMs: 12_000,
+      currentTotalQualifiedTargetMs: 16_000,
+      visibleMs: 10_000,
+      counted: true,
+    });
+
+    assert.deepEqual(metrics, {
+      qualifiedViewsCount: 3,
+      totalQualifiedVisibleMs: 22_000,
+      totalQualifiedTargetMs:
+        16_000 + PHOTO_RANKING_QUALIFIED_VISIBLE_TARGET_MS,
+      averageQualifiedVisibleMs: 7_333,
+    });
+  });
+
+  it('não altera métricas quando a janela antifraude bloqueia a contagem', () => {
+    const metrics = buildNextPhotoQualificationMetrics({
+      currentQualifiedViewsCount: 4,
+      currentTotalQualifiedVisibleMs: 24_000,
+      currentTotalQualifiedTargetMs: 32_000,
+      visibleMs: 8_000,
+      counted: false,
+    });
+
+    assert.deepEqual(metrics, {
+      qualifiedViewsCount: 4,
+      totalQualifiedVisibleMs: 24_000,
+      totalQualifiedTargetMs: 32_000,
+      averageQualifiedVisibleMs: 6_000,
+    });
+  });
+
+  it('combina audiência única, permanência, recência e engajamento', () => {
+    const now = 1_800_000_000_000;
+    const ranking = buildPhotoRankingUpdate(
+      {
+        visibility: 'PUBLIC',
+        moderationStatus: 'APPROVED',
+        reactionsCount: 12,
+        commentsCount: 4,
+        viewsCount: 40,
+        uniqueViewersCount: 30,
+        qualifiedViewsCount: 30,
+        totalQualifiedVisibleMs: 210_000,
+        totalQualifiedTargetMs: 240_000,
+        publishedAt: now - 24 * 60 * 60 * 1000,
+        scoreBreakdown: {
+          qualityScore: 65,
+          safetyScore: 100,
+        },
+      },
+      now
+    );
+
+    assert.ok(ranking.score > 0);
+    assert.ok(ranking.viewScore > 0);
+    assert.ok(ranking.retentionScore > 0);
+    assert.ok(ranking.freshnessScore > 0);
+    assert.equal(ranking.score, ranking.scoreBreakdown.rankingScore);
+    assert.equal(ranking.averageQualifiedVisibleMs, 7_000);
+    assert.equal(hasEquivalentPhotoRanking({
+      ...ranking,
+      visibility: 'PUBLIC',
+      moderationStatus: 'APPROVED',
+    }, ranking), true);
+  });
+
+  it('reduz recência sem apagar evidências acumuladas', () => {
+    const publishedAt = 1_700_000_000_000;
+    const recent = buildPhotoRankingUpdate({
+      reactionsCount: 3,
+      commentsCount: 1,
+      viewsCount: 10,
+      uniqueViewersCount: 8,
+      qualifiedViewsCount: 8,
+      totalQualifiedVisibleMs: 48_000,
+      totalQualifiedTargetMs: 64_000,
+      publishedAt,
+    }, publishedAt + 60_000);
+    const old = buildPhotoRankingUpdate({
+      reactionsCount: 3,
+      commentsCount: 1,
+      viewsCount: 10,
+      uniqueViewersCount: 8,
+      qualifiedViewsCount: 8,
+      totalQualifiedVisibleMs: 48_000,
+      totalQualifiedTargetMs: 64_000,
+      publishedAt,
+    }, publishedAt + 30 * 24 * 60 * 60 * 1000);
+
+    assert.ok(recent.freshnessScore > old.freshnessScore);
+    assert.equal(recent.viewScore, old.viewScore);
+    assert.equal(recent.retentionScore, old.retentionScore);
+  });
+});

--- a/functions/src/media/application/photo-ranking-score.ts
+++ b/functions/src/media/application/photo-ranking-score.ts
@@ -1,0 +1,238 @@
+import {
+  MEDIA_RANKING_VERSION,
+  buildMediaEngagementScore,
+  normalizeMediaCount,
+  normalizeMediaScore,
+  normalizeMediaTimestamp,
+  normalizeMediaTotal,
+  type MediaScoreBreakdown,
+} from './media-engagement-score';
+
+export const PHOTO_RANKING_QUALIFIED_VISIBLE_TARGET_MS = 8_000;
+export const PHOTO_RANKING_MAX_VISIBLE_SAMPLE_MS = 30_000;
+
+export interface PublicPhotoRankingDocument
+  extends FirebaseFirestore.DocumentData {
+  visibility?: unknown;
+  moderationStatus?: unknown;
+  reactionsCount?: unknown;
+  likesCount?: unknown;
+  commentsCount?: unknown;
+  viewsCount?: unknown;
+  uniqueViewersCount?: unknown;
+  qualifiedViewsCount?: unknown;
+  totalQualifiedVisibleMs?: unknown;
+  totalQualifiedTargetMs?: unknown;
+  publishedAt?: unknown;
+  score?: unknown;
+  viewScore?: unknown;
+  retentionScore?: unknown;
+  freshnessScore?: unknown;
+  engagementScore?: unknown;
+  rankingVersion?: unknown;
+  scoreBreakdown?: Partial<MediaScoreBreakdown> | null;
+}
+
+export interface PhotoRankingOverrides {
+  reactionsCount?: unknown;
+  commentsCount?: unknown;
+  viewsCount?: unknown;
+  uniqueViewersCount?: unknown;
+  qualifiedViewsCount?: unknown;
+  totalQualifiedVisibleMs?: unknown;
+  totalQualifiedTargetMs?: unknown;
+  publishedAt?: unknown;
+}
+
+export interface PhotoRankingUpdate {
+  score: number;
+  engagementScore: number;
+  viewScore: number;
+  retentionScore: number;
+  freshnessScore: number;
+  scoreBreakdown: MediaScoreBreakdown;
+  qualifiedViewsCount: number;
+  totalQualifiedVisibleMs: number;
+  totalQualifiedTargetMs: number;
+  averageQualifiedVisibleMs: number;
+  rankingVersion: number;
+  rankingUpdatedAt: number;
+}
+
+export interface PhotoQualificationMetrics {
+  qualifiedViewsCount: number;
+  totalQualifiedVisibleMs: number;
+  totalQualifiedTargetMs: number;
+  averageQualifiedVisibleMs: number;
+}
+
+function valueOrFallback(
+  override: unknown,
+  fallback: unknown
+): unknown {
+  return override === undefined ? fallback : override;
+}
+
+export function normalizePhotoQualifiedVisibleMs(value: unknown): number {
+  const visibleMs = normalizeMediaTotal(value);
+
+  return Math.min(PHOTO_RANKING_MAX_VISIBLE_SAMPLE_MS, visibleMs);
+}
+
+export function buildNextPhotoQualificationMetrics(input: {
+  currentQualifiedViewsCount: unknown;
+  currentTotalQualifiedVisibleMs: unknown;
+  currentTotalQualifiedTargetMs: unknown;
+  visibleMs: unknown;
+  counted: boolean;
+}): PhotoQualificationMetrics {
+  const currentQualifiedViewsCount = normalizeMediaCount(
+    input.currentQualifiedViewsCount
+  );
+  const currentTotalQualifiedVisibleMs = normalizeMediaTotal(
+    input.currentTotalQualifiedVisibleMs
+  );
+  const currentTotalQualifiedTargetMs = normalizeMediaTotal(
+    input.currentTotalQualifiedTargetMs
+  );
+
+  if (!input.counted) {
+    return {
+      qualifiedViewsCount: currentQualifiedViewsCount,
+      totalQualifiedVisibleMs: currentTotalQualifiedVisibleMs,
+      totalQualifiedTargetMs: currentTotalQualifiedTargetMs,
+      averageQualifiedVisibleMs: currentQualifiedViewsCount > 0
+        ? Math.round(
+          currentTotalQualifiedVisibleMs / currentQualifiedViewsCount
+        )
+        : 0,
+    };
+  }
+
+  const qualifiedViewsCount = currentQualifiedViewsCount + 1;
+  const totalQualifiedVisibleMs = currentTotalQualifiedVisibleMs +
+    normalizePhotoQualifiedVisibleMs(input.visibleMs);
+  const totalQualifiedTargetMs = currentTotalQualifiedTargetMs +
+    PHOTO_RANKING_QUALIFIED_VISIBLE_TARGET_MS;
+
+  return {
+    qualifiedViewsCount,
+    totalQualifiedVisibleMs,
+    totalQualifiedTargetMs,
+    averageQualifiedVisibleMs: Math.round(
+      totalQualifiedVisibleMs / qualifiedViewsCount
+    ),
+  };
+}
+
+export function isRankablePhoto(
+  data: PublicPhotoRankingDocument
+): boolean {
+  return String(data.visibility ?? '').trim().toUpperCase() === 'PUBLIC' &&
+    String(data.moderationStatus ?? '').trim().toUpperCase() === 'APPROVED';
+}
+
+export function buildPhotoRankingUpdate(
+  data: PublicPhotoRankingDocument,
+  now: number,
+  overrides: PhotoRankingOverrides = {}
+): PhotoRankingUpdate {
+  const qualifiedViewsCount = normalizeMediaCount(
+    valueOrFallback(
+      overrides.qualifiedViewsCount,
+      data.qualifiedViewsCount
+    )
+  );
+  const totalQualifiedVisibleMs = normalizeMediaTotal(
+    valueOrFallback(
+      overrides.totalQualifiedVisibleMs,
+      data.totalQualifiedVisibleMs
+    )
+  );
+  const totalQualifiedTargetMs = normalizeMediaTotal(
+    valueOrFallback(
+      overrides.totalQualifiedTargetMs,
+      data.totalQualifiedTargetMs
+    )
+  );
+  const ranking = buildMediaEngagementScore({
+    reactionsCount: normalizeMediaCount(
+      valueOrFallback(
+        overrides.reactionsCount,
+        data.reactionsCount ?? data.likesCount
+      )
+    ),
+    commentsCount: normalizeMediaCount(
+      valueOrFallback(overrides.commentsCount, data.commentsCount)
+    ),
+    viewsCount: normalizeMediaCount(
+      valueOrFallback(overrides.viewsCount, data.viewsCount)
+    ),
+    uniqueViewersCount: normalizeMediaCount(
+      valueOrFallback(
+        overrides.uniqueViewersCount,
+        data.uniqueViewersCount
+      )
+    ),
+    qualifiedViewsCount,
+    totalQualifiedPlaybackMs: totalQualifiedVisibleMs,
+    totalQualifiedDurationMs: totalQualifiedTargetMs,
+    publishedAt: normalizeMediaTimestamp(
+      valueOrFallback(overrides.publishedAt, data.publishedAt)
+    ),
+    now,
+    currentBreakdown: data.scoreBreakdown,
+  });
+
+  return {
+    score: ranking.score,
+    engagementScore: ranking.engagementScore,
+    viewScore: ranking.viewScore,
+    retentionScore: ranking.retentionScore,
+    freshnessScore: ranking.freshnessScore,
+    scoreBreakdown: ranking.scoreBreakdown,
+    qualifiedViewsCount,
+    totalQualifiedVisibleMs,
+    totalQualifiedTargetMs,
+    averageQualifiedVisibleMs: qualifiedViewsCount > 0
+      ? Math.round(totalQualifiedVisibleMs / qualifiedViewsCount)
+      : 0,
+    rankingVersion: MEDIA_RANKING_VERSION,
+    rankingUpdatedAt: now,
+  };
+}
+
+export function hasEquivalentPhotoRanking(
+  data: PublicPhotoRankingDocument,
+  update: PhotoRankingUpdate
+): boolean {
+  const currentBreakdown = data.scoreBreakdown ?? {};
+  const nextBreakdown = update.scoreBreakdown;
+
+  return normalizeMediaCount(data.rankingVersion) === MEDIA_RANKING_VERSION &&
+    normalizeMediaScore(data.score) === update.score &&
+    normalizeMediaScore(data.engagementScore) === update.engagementScore &&
+    normalizeMediaScore(data.viewScore) === update.viewScore &&
+    normalizeMediaScore(data.retentionScore) === update.retentionScore &&
+    normalizeMediaScore(data.freshnessScore) === update.freshnessScore &&
+    normalizeMediaCount(data.qualifiedViewsCount) ===
+      update.qualifiedViewsCount &&
+    normalizeMediaTotal(data.totalQualifiedVisibleMs) ===
+      update.totalQualifiedVisibleMs &&
+    normalizeMediaTotal(data.totalQualifiedTargetMs) ===
+      update.totalQualifiedTargetMs &&
+    normalizeMediaScore(currentBreakdown.rankingScore) ===
+      nextBreakdown.rankingScore &&
+    normalizeMediaScore(currentBreakdown.qualityScore) ===
+      nextBreakdown.qualityScore &&
+    normalizeMediaScore(currentBreakdown.engagementScore) ===
+      nextBreakdown.engagementScore &&
+    normalizeMediaScore(currentBreakdown.viewScore) ===
+      nextBreakdown.viewScore &&
+    normalizeMediaScore(currentBreakdown.retentionScore) ===
+      nextBreakdown.retentionScore &&
+    normalizeMediaScore(currentBreakdown.freshnessScore) ===
+      nextBreakdown.freshnessScore &&
+    normalizeMediaScore(currentBreakdown.safetyScore) ===
+      nextBreakdown.safetyScore;
+}

--- a/functions/src/media/application/photo-ranking-score.ts
+++ b/functions/src/media/application/photo-ranking-score.ts
@@ -23,6 +23,7 @@ export interface PublicPhotoRankingDocument
   qualifiedViewsCount?: unknown;
   totalQualifiedVisibleMs?: unknown;
   totalQualifiedTargetMs?: unknown;
+  averageQualifiedVisibleMs?: unknown;
   publishedAt?: unknown;
   score?: unknown;
   viewScore?: unknown;
@@ -155,6 +156,9 @@ export function buildPhotoRankingUpdate(
       data.totalQualifiedTargetMs
     )
   );
+  const averageQualifiedVisibleMs = qualifiedViewsCount > 0
+    ? Math.round(totalQualifiedVisibleMs / qualifiedViewsCount)
+    : 0;
   const ranking = buildMediaEngagementScore({
     reactionsCount: normalizeMediaCount(
       valueOrFallback(
@@ -194,9 +198,7 @@ export function buildPhotoRankingUpdate(
     qualifiedViewsCount,
     totalQualifiedVisibleMs,
     totalQualifiedTargetMs,
-    averageQualifiedVisibleMs: qualifiedViewsCount > 0
-      ? Math.round(totalQualifiedVisibleMs / qualifiedViewsCount)
-      : 0,
+    averageQualifiedVisibleMs,
     rankingVersion: MEDIA_RANKING_VERSION,
     rankingUpdatedAt: now,
   };
@@ -221,6 +223,8 @@ export function hasEquivalentPhotoRanking(
       update.totalQualifiedVisibleMs &&
     normalizeMediaTotal(data.totalQualifiedTargetMs) ===
       update.totalQualifiedTargetMs &&
+    normalizeMediaTotal(data.averageQualifiedVisibleMs) ===
+      update.averageQualifiedVisibleMs &&
     normalizeMediaScore(currentBreakdown.rankingScore) ===
       nextBreakdown.rankingScore &&
     normalizeMediaScore(currentBreakdown.qualityScore) ===

--- a/functions/src/media/application/record-photo-view.handler.ts
+++ b/functions/src/media/application/record-photo-view.handler.ts
@@ -8,6 +8,11 @@ import {
   resolveCanonicalPhotoAudienceTarget,
 } from './photo-audience-access.policy';
 import {
+  buildNextPhotoQualificationMetrics,
+  buildPhotoRankingUpdate,
+  type PublicPhotoRankingDocument,
+} from './photo-ranking-score';
+import {
   PHOTO_VIEW_MIN_VISIBLE_MS,
   type PhotoViewEvidenceInput,
   normalizePhotoViewEvidence,
@@ -123,22 +128,6 @@ function assertPhotoViewSession(input: {
       'A sessão de visualização é inválida ou expirou.'
     );
   }
-}
-
-function calculateViewScore(input: {
-  viewsCount: number;
-  uniqueViewersCount: number;
-  lastViewedAt: number;
-  publishedAt: number;
-}): number {
-  const recencyBoost =
-    Math.max(0, input.lastViewedAt - input.publishedAt) / 1_000_000_000;
-
-  return Math.round(
-    input.viewsCount * 4 +
-      input.uniqueViewersCount * 6 +
-      recencyBoost
-  );
 }
 
 export async function recordPhotoViewCore(
@@ -291,15 +280,24 @@ export async function recordPhotoViewCore(
     const nextPhotoUniqueViewersCount = isUniquePhotoViewer
       ? currentPhotoUniqueViewersCount + 1
       : currentPhotoUniqueViewersCount;
-    const publishedAt = safeNumber(publicPhoto.publishedAt) || now;
-    const nextPhotoViewScore = canCountView
-      ? calculateViewScore({
+    const qualification = buildNextPhotoQualificationMetrics({
+      currentQualifiedViewsCount: publicPhoto.qualifiedViewsCount,
+      currentTotalQualifiedVisibleMs: publicPhoto.totalQualifiedVisibleMs,
+      currentTotalQualifiedTargetMs: publicPhoto.totalQualifiedTargetMs,
+      visibleMs: evidence.visibleMs,
+      counted: canCountView,
+    });
+    const nextPhotoRanking = buildPhotoRankingUpdate(
+      publicPhoto as PublicPhotoRankingDocument,
+      now,
+      {
         viewsCount: nextPhotoViewsCount,
         uniqueViewersCount: nextPhotoUniqueViewersCount,
-        lastViewedAt: now,
-        publishedAt,
-      })
-      : currentPhotoViewScore;
+        qualifiedViewsCount: qualification.qualifiedViewsCount,
+        totalQualifiedVisibleMs: qualification.totalQualifiedVisibleMs,
+        totalQualifiedTargetMs: qualification.totalQualifiedTargetMs,
+      }
+    );
 
     const currentProfileViewsCount = safeNumber(
       publicProfile.profileViewsCount ?? publicProfile.viewsCount
@@ -326,7 +324,7 @@ export async function recordPhotoViewCore(
         0,
         currentProfileViewScore -
           currentPhotoViewScore +
-          nextPhotoViewScore
+          nextPhotoRanking.viewScore
       )
       : currentProfileViewScore;
 
@@ -417,8 +415,19 @@ export async function recordPhotoViewCore(
         {
           viewsCount: nextPhotoViewsCount,
           uniqueViewersCount: nextPhotoUniqueViewersCount,
+          qualifiedViewsCount: qualification.qualifiedViewsCount,
+          totalQualifiedVisibleMs: qualification.totalQualifiedVisibleMs,
+          totalQualifiedTargetMs: qualification.totalQualifiedTargetMs,
+          averageQualifiedVisibleMs: qualification.averageQualifiedVisibleMs,
           lastViewedAt: now,
-          viewScore: nextPhotoViewScore,
+          score: nextPhotoRanking.score,
+          engagementScore: nextPhotoRanking.engagementScore,
+          viewScore: nextPhotoRanking.viewScore,
+          retentionScore: nextPhotoRanking.retentionScore,
+          freshnessScore: nextPhotoRanking.freshnessScore,
+          scoreBreakdown: nextPhotoRanking.scoreBreakdown,
+          rankingVersion: nextPhotoRanking.rankingVersion,
+          rankingUpdatedAt: nextPhotoRanking.rankingUpdatedAt,
           updatedAt: now,
         },
         { merge: true }

--- a/functions/src/media/application/toggle-photo-reaction.handler.ts
+++ b/functions/src/media/application/toggle-photo-reaction.handler.ts
@@ -7,7 +7,7 @@
 // - receber intenção autenticada de curtir/descurtir foto pública;
 // - validar que a foto está PUBLIC + APPROVED + reactionsEnabled;
 // - gravar/remover o like do usuário;
-// - recalcular reactionsCount, engagementScore, rankingScore e score no backend.
+// - recalcular o ranking pela infraestrutura canônica de mídia.
 //
 // Segurança:
 // - cliente não escreve score;
@@ -23,110 +23,46 @@ import {
 } from '../../account_lifecycle/interaction-access.policy';
 import { db } from '../../firebaseApp';
 import { FUNCTIONS_REGION } from '../../config/functions-region';
+import {
+  buildPhotoRankingUpdate,
+  type PublicPhotoRankingDocument,
+} from './photo-ranking-score';
+import { normalizeMediaCount } from './media-engagement-score';
 
 interface TogglePhotoReactionRequest {
   ownerUid?: string;
   photoId?: string;
 }
 
-type ScoreBreakdown = {
-  rankingScore: number;
-  qualityScore: number;
-  engagementScore: number;
-  safetyScore: number;
-};
-
-type PublicPhotoDoc = {
+type PublicPhotoDoc = PublicPhotoRankingDocument & {
   ownerUid?: string;
   visibility?: string;
   moderationStatus?: string;
   reactionsEnabled?: boolean;
-  reactionsCount?: number;
-  likesCount?: number;
-  commentsCount?: number;
-  score?: number;
-  engagementScore?: number;
-  scoreBreakdown?: Partial<ScoreBreakdown>;
 };
 
 function cleanId(value: unknown): string {
   return String(value ?? '').trim();
 }
 
-function normalizeCount(value: unknown): number {
-  const count = Number(value ?? 0);
-
-  if (!Number.isFinite(count) || count < 0) {
-    return 0;
-  }
-
-  return Math.floor(count);
-}
-
-function normalizeScore(value: unknown): number {
-  const score = Number(value ?? 0);
-
-  if (!Number.isFinite(score)) {
-    return 0;
-  }
-
-  return Math.max(0, Math.min(100, Math.round(score)));
-}
-
-function calculateEngagementScore(input: {
-  reactionsCount: number;
-  commentsCount: number;
-}): number {
-  const weightedEngagement =
-    input.reactionsCount * 2 +
-    input.commentsCount * 4;
-
-  return normalizeScore(Math.round(Math.log1p(weightedEngagement) * 18));
-}
-
-function calculateRankingScore(score: ScoreBreakdown): number {
-  const quality = normalizeScore(score.qualityScore);
-  const engagement = normalizeScore(score.engagementScore);
-  const safety = normalizeScore(score.safetyScore);
-
-  return normalizeScore(
-    Math.round(
-      quality * 0.25 +
-      engagement * 0.45 +
-      safety * 0.30
-    )
-  );
-}
-
-function buildNextScore(
+function buildRankingFields(
   photo: PublicPhotoDoc,
-  nextReactionsCount: number
-): {
-  score: number;
-  engagementScore: number;
-  scoreBreakdown: ScoreBreakdown;
-} {
-  const currentBreakdown = photo.scoreBreakdown ?? {};
-  const commentsCount = normalizeCount(photo.commentsCount ?? 0);
-
-  const engagementScore = calculateEngagementScore({
+  nextReactionsCount: number,
+  now: number
+) {
+  const ranking = buildPhotoRankingUpdate(photo, now, {
     reactionsCount: nextReactionsCount,
-    commentsCount,
   });
 
-  const scoreBreakdown: ScoreBreakdown = {
-    qualityScore: normalizeScore(currentBreakdown.qualityScore ?? 0),
-    safetyScore: normalizeScore(currentBreakdown.safetyScore ?? 100),
-    engagementScore,
-    rankingScore: 0,
-  };
-
-  scoreBreakdown.rankingScore = calculateRankingScore(scoreBreakdown);
-
   return {
-    score: scoreBreakdown.rankingScore,
-    engagementScore,
-    scoreBreakdown,
+    engagementScore: ranking.engagementScore,
+    viewScore: ranking.viewScore,
+    retentionScore: ranking.retentionScore,
+    freshnessScore: ranking.freshnessScore,
+    score: ranking.score,
+    scoreBreakdown: ranking.scoreBreakdown,
+    rankingVersion: ranking.rankingVersion,
+    rankingUpdatedAt: ranking.rankingUpdatedAt,
   };
 }
 
@@ -208,37 +144,32 @@ export const togglePhotoReaction = onCall<TogglePhotoReactionRequest>(
       }
 
       const likeSnap = await transaction.get(likeRef);
-      const currentCount = normalizeCount(
-        photo.reactionsCount ?? photo.likesCount ?? 0
+      const currentCount = normalizeMediaCount(
+        photo.reactionsCount ?? photo.likesCount
       );
+      const now = Date.now();
 
       if (likeSnap.exists) {
         const nextCount = Math.max(0, currentCount - 1);
-        const nextScore = buildNextScore(photo, nextCount);
-        const now = Date.now();
+        const rankingFields = buildRankingFields(photo, nextCount, now);
 
         transaction.delete(likeRef);
         transaction.update(photoRef, {
           reactionsCount: nextCount,
           likesCount: nextCount,
-
-          engagementScore: nextScore.engagementScore,
-          score: nextScore.score,
-          scoreBreakdown: nextScore.scoreBreakdown,
-
+          ...rankingFields,
           updatedAt: now,
         });
 
         return {
           liked: false,
           reactionsCount: nextCount,
-          score: nextScore.score,
+          score: rankingFields.score,
         };
       }
 
-      const now = Date.now();
       const nextCount = currentCount + 1;
-      const nextScore = buildNextScore(photo, nextCount);
+      const rankingFields = buildRankingFields(photo, nextCount, now);
 
       transaction.set(likeRef, {
         uid: viewerUid,
@@ -248,18 +179,14 @@ export const togglePhotoReaction = onCall<TogglePhotoReactionRequest>(
       transaction.update(photoRef, {
         reactionsCount: nextCount,
         likesCount: nextCount,
-
-        engagementScore: nextScore.engagementScore,
-        score: nextScore.score,
-        scoreBreakdown: nextScore.scoreBreakdown,
-
+        ...rankingFields,
         updatedAt: now,
       });
 
       return {
         liked: true,
         reactionsCount: nextCount,
-        score: nextScore.score,
+        score: rankingFields.score,
       };
     });
   }

--- a/functions/src/media/application/video-view-session.policy.test.ts
+++ b/functions/src/media/application/video-view-session.policy.test.ts
@@ -5,6 +5,7 @@ import './admin-authorization.policy.test';
 import './media-callable-rate-limit.policy.test';
 import './media-mutation-idempotency.policy.test';
 import './photo-audience-access.policy.test';
+import './photo-ranking-score.test';
 import './photo-view-session.policy.test';
 import {
   VIDEO_VIEW_SESSION_MIN_INTERVAL_MS,

--- a/functions/src/media/index.ts
+++ b/functions/src/media/index.ts
@@ -112,6 +112,10 @@ export {
 } from './application/record-video-view-orchestrator.handler';
 
 export {
+  recalculatePhotoRankingOnWrite,
+  refreshPublicPhotoRankingScores,
+} from './application/photo-ranking-score-maintenance.handler';
+export {
   recalculateVideoRankingOnWrite,
   refreshPublicVideoRankingScores,
 } from './application/video-ranking-score-maintenance.handler';


### PR DESCRIPTION
## Dependência

PR empilhado sobre o #59 (`agent/media-p0-photo-view-session-integrity`). Nenhum merge é realizado por este pacote.

## Escopo

Este pacote substitui as três fórmulas concorrentes de ranking de fotos por uma infraestrutura canônica baseada no mesmo `buildMediaEngagementScore` usado pelos vídeos.

## Fonte canônica

Foi criado `photo-ranking-score.ts`, responsável por combinar:

- reações;
- comentários;
- visualizações contabilizadas;
- visualizadores únicos;
- visualizações qualificadas;
- permanência visível acumulada;
- recência;
- qualidade e segurança já existentes no `scoreBreakdown`.

A saída preserva os campos públicos atuais:

- `score`;
- `engagementScore`;
- `viewScore`;
- `retentionScore`;
- `freshnessScore`;
- `scoreBreakdown`;
- `rankingVersion`;
- `rankingUpdatedAt`.

## Permanência de fotos

Cada visualização contabilizada passa a agregar:

- `qualifiedViewsCount`;
- `totalQualifiedVisibleMs`;
- `totalQualifiedTargetMs`;
- `averageQualifiedVisibleMs`.

A meta de retenção é de oito segundos por visualização. A amostra individual é limitada a trinta segundos, evitando que uma aba esquecida distorça o ranking.

O tempo mínimo de dois segundos definido no #59 não foi alterado. Ele continua sendo a barreira para contabilização; a meta de oito segundos atua somente na qualidade relativa da permanência.

## Visualizações

`recordPhotoViewCore` agora:

- preserva sessão, App Check, audiência e consumo único do #59;
- acumula permanência somente quando a janela antifraude permite nova contagem;
- usa a infraestrutura central para recalcular todos os componentes do ranking;
- mantém a atualização incremental do `viewScore` agregado do perfil;
- não duplica evidência quando a mesma pessoa retorna dentro de cinco minutos.

## Reações e comentários

Foram removidas as fórmulas locais de:

- `toggle-photo-reaction.handler.ts`;
- `manage-photo-comment.handler.ts`.

Ambos passam a usar `buildPhotoRankingUpdate`, preservando os contratos e respostas existentes. Assim, uma reação ou comentário não apaga mais `viewScore`, `retentionScore` ou `freshnessScore` calculados por outro fluxo.

## Manutenção e migração

Foi criado `photo-ranking-score-maintenance.handler.ts` com:

- `recalculatePhotoRankingOnWrite`;
- `refreshPublicPhotoRankingScores` a cada seis horas.

O trigger:

- corrige documentos legados ou parcialmente atualizados;
- reage a mudança de visualizações, audiência única, reações, capa, visibilidade e moderação;
- atualiza os agregados do perfil;
- remove do agregado fotos excluídas ou que deixaram de ser públicas e aprovadas;
- evita uma segunda atualização quando a escrita contém apenas campos derivados que ele próprio normalizou.

O scheduler revisa até 480 candidatas, combinando fotos de maior score e mais recentes em um único batch do Firestore. Nenhum índice composto novo é necessário.

## Recência

Assim como nos vídeos, a recência deixa de ficar congelada no último engajamento. O scheduler recalcula `freshnessScore` periodicamente, reduzindo de forma gradual a vantagem de publicações antigas sem apagar engajamento ou audiência acumulados.

## Supressões e substituições intencionais

Foram suprimidos:

- `calculateViewScore` específico de fotos;
- `calculateEngagementScore` duplicado nos handlers de reação e comentário;
- `calculateRankingScore` com pesos exclusivos e incompatíveis;
- tipos locais incompletos de `ScoreBreakdown`.

Esses trechos foram substituídos pelo helper canônico. Nenhum contador, validação de permissão, transação ou resposta pública foi removido.

## Compatibilidade

- nomes públicos das Functions preservados;
- payloads e respostas preservados;
- feeds continuam ordenando pelos mesmos campos `score`, `viewScore` e `publishedAt`;
- nenhum componente Angular foi alterado;
- nenhuma Firestore Rule foi afrouxada;
- ranking de vídeo não foi modificado;
- agregados de perfil continuam usando `refreshPublicProfileMediaMetrics`.

## Testes adicionados

- limite de trinta segundos por amostra;
- acumulação de permanência e meta;
- bloqueio de duplicação pela janela antifraude;
- combinação de audiência única, permanência, recência e engajamento;
- redução periódica da recência sem perda das demais evidências;
- equivalência de documentos canônicos.

## Validação concluída

- lint das Functions: aprovado;
- build TypeScript das Functions: aprovado;
- testes das Functions, incluindo ranking de fotos: aprovados;
- compilação dos handlers de visualização, reação e comentário: aprovada;
- compilação dos triggers e scheduler: aprovada;
- testes Angular: aprovados;
- build Angular seguro: aprovado;
- Firestore Rules: aprovadas;
- índices do Firestore: aprovados;
- Quality Gate agregado: aprovado.

Todos os jobs passaram no primeiro head, sem commit corretivo de código.

## Nota operacional

Durante a abertura do PR, um placeholder vazio foi criado por roteamento incorreto da ferramenta e removido imediatamente. Ele não aparece no diff final nem altera artefatos do projeto; permanece apenas como par de commits no histórico da branch.