### PR TITLE
feat(media): migrar ranking de fotos com backfill retomável

### DIFF
--- a/functions/src/media/application/media-callable-rate-limit.policy.test.ts
+++ b/functions/src/media/application/media-callable-rate-limit.policy.test.ts
@@ -27,6 +27,9 @@ describe('media-callable-rate-limit.policy', () => {
     const adminRecovery = resolveMediaCallableRateLimitRule(
       'ADMIN_PROCESSING_RECOVERY'
     );
+    const adminBackfill = resolveMediaCallableRateLimitRule(
+      'ADMIN_RANKING_BACKFILL'
+    );
 
     assert.ok(reaction.globalMaxPerWindow > reaction.resourceMaxPerWindow);
     assert.ok(report.windowMs > reaction.windowMs);
@@ -50,6 +53,13 @@ describe('media-callable-rate-limit.policy', () => {
     );
     assert.ok(
       adminRecovery.resourceMaxPerWindow < adminModeration.resourceMaxPerWindow
+    );
+    assert.equal(adminBackfill.windowMs, report.windowMs);
+    assert.ok(
+      adminBackfill.globalMaxPerWindow > adminBackfill.resourceMaxPerWindow
+    );
+    assert.ok(
+      adminBackfill.resourceMaxPerWindow > adminRecovery.resourceMaxPerWindow
     );
   });
 

--- a/functions/src/media/application/media-callable-rate-limit.policy.ts
+++ b/functions/src/media/application/media-callable-rate-limit.policy.ts
@@ -19,7 +19,8 @@ export type MediaCallableRateAction =
   | 'ADMIN_STATUS'
   | 'ADMIN_QUEUE'
   | 'ADMIN_MODERATION'
-  | 'ADMIN_PROCESSING_RECOVERY';
+  | 'ADMIN_PROCESSING_RECOVERY'
+  | 'ADMIN_RANKING_BACKFILL';
 
 export interface MediaCallableRateLimitRule {
   readonly windowMs: number;
@@ -180,6 +181,12 @@ const RULES: Readonly<Record<
     windowMs: TEN_MINUTES_MS,
     globalMaxPerWindow: 90,
     resourceMaxPerWindow: 9,
+    minIntervalMs: 1_000,
+  },
+  ADMIN_RANKING_BACKFILL: {
+    windowMs: ONE_HOUR_MS,
+    globalMaxPerWindow: 60,
+    resourceMaxPerWindow: 36,
     minIntervalMs: 1_000,
   },
 };

--- a/functions/src/media/application/photo-ranking-backfill.handler.ts
+++ b/functions/src/media/application/photo-ranking-backfill.handler.ts
@@ -1,0 +1,568 @@
+import { randomUUID } from 'node:crypto';
+
+import { FieldPath } from 'firebase-admin/firestore';
+import * as logger from 'firebase-functions/logger';
+import type { CallableRequest } from 'firebase-functions/v2/https';
+import { HttpsError } from 'firebase-functions/v2/https';
+import { onSchedule } from 'firebase-functions/v2/scheduler';
+
+import { FUNCTIONS_REGION } from '../../config/functions-region';
+import { db, FieldValue } from '../../firebaseApp';
+import { assertAdminAuthorization } from './admin-authorization.policy';
+import {
+  PHOTO_RANKING_BACKFILL_COLLECTION,
+  PHOTO_RANKING_BACKFILL_ID,
+  PHOTO_RANKING_BACKFILL_LEASE_MS,
+  type PhotoRankingBackfillControlAction,
+  type PhotoRankingBackfillState,
+  buildInitialPhotoRankingBackfillState,
+  isPhotoRankingBackfillLeaseAvailable,
+  nextPhotoRankingBackfillFailureStatus,
+  normalizePhotoRankingBackfillAction,
+  normalizePhotoRankingBackfillOperationId,
+  normalizePhotoRankingBackfillPageSize,
+  normalizePhotoRankingBackfillState,
+} from './photo-ranking-backfill.policy';
+import {
+  buildPhotoRankingUpdate,
+  hasEquivalentPhotoRanking,
+  isRankablePhoto,
+  type PublicPhotoRankingDocument,
+} from './photo-ranking-score';
+import {
+  normalizeMediaScore,
+} from './media-engagement-score';
+
+interface ControlPhotoRankingBackfillRequest {
+  action?: PhotoRankingBackfillControlAction;
+  operationId?: string;
+  pageSize?: number;
+}
+
+interface PhotoRankingBackfillBatchResult {
+  acquired: boolean;
+  completed: boolean;
+  processed: number;
+  updated: number;
+  skipped: number;
+  cursorPath: string | null;
+  status: PhotoRankingBackfillState['status'];
+}
+
+interface PhotoRankingBackfillStatusResponse {
+  state: PhotoRankingBackfillState;
+  leaseActive: boolean;
+  checkedAt: number;
+}
+
+interface ControlPhotoRankingBackfillResponse {
+  action: PhotoRankingBackfillControlAction;
+  alreadyApplied: boolean;
+  state: PhotoRankingBackfillState;
+  batch: PhotoRankingBackfillBatchResult | null;
+}
+
+const ADMIN_PERMISSION_MESSAGE =
+  'Apenas administradores podem controlar o backfill de ranking de fotos.';
+const FAILURE_MESSAGE =
+  'O lote de migração não foi concluído. A execução será retomada com segurança.';
+
+function stateRef(): FirebaseFirestore.DocumentReference {
+  return db
+    .collection(PHOTO_RANKING_BACKFILL_COLLECTION)
+    .doc(PHOTO_RANKING_BACKFILL_ID);
+}
+
+function stateForResponse(
+  state: PhotoRankingBackfillState
+): PhotoRankingBackfillState {
+  return {
+    ...state,
+    leaseOwner: state.leaseOwner ? 'active' : null,
+  };
+}
+
+async function readBackfillState(
+  now = Date.now()
+): Promise<PhotoRankingBackfillState> {
+  const snapshot = await stateRef().get();
+
+  return snapshot.exists
+    ? normalizePhotoRankingBackfillState(snapshot.data(), now)
+    : buildInitialPhotoRankingBackfillState({
+      now,
+      status: 'IDLE',
+    });
+}
+
+async function acquireBackfillLease(input: {
+  runId: string;
+  now: number;
+}): Promise<PhotoRankingBackfillState | null> {
+  const ref = stateRef();
+
+  return db.runTransaction(async (transaction) => {
+    const snapshot = await transaction.get(ref);
+    const state = snapshot.exists
+      ? normalizePhotoRankingBackfillState(snapshot.data(), input.now)
+      : buildInitialPhotoRankingBackfillState({ now: input.now });
+
+    if (
+      state.status === 'PAUSED' ||
+      state.status === 'COMPLETED' ||
+      state.status === 'FAILED'
+    ) {
+      return null;
+    }
+
+    if (
+      !isPhotoRankingBackfillLeaseAvailable({
+        state,
+        now: input.now,
+        runId: input.runId,
+      })
+    ) {
+      return null;
+    }
+
+    const nextState: PhotoRankingBackfillState = {
+      ...state,
+      status: 'RUNNING',
+      startedAt: state.startedAt ?? input.now,
+      leaseOwner: input.runId,
+      leaseExpiresAt: input.now + PHOTO_RANKING_BACKFILL_LEASE_MS,
+      updatedAt: input.now,
+    };
+
+    transaction.set(ref, nextState);
+    return nextState;
+  });
+}
+
+function buildPhotoQuery(
+  cursorPath: string | null,
+  pageSize: number
+): FirebaseFirestore.Query {
+  let query: FirebaseFirestore.Query = db
+    .collectionGroup('public_photos')
+    .orderBy(FieldPath.documentId())
+    .limit(pageSize);
+
+  if (cursorPath) {
+    query = query.startAfter(cursorPath);
+  }
+
+  return query;
+}
+
+async function commitPhotoRankingPage(input: {
+  documents: FirebaseFirestore.QueryDocumentSnapshot[];
+  now: number;
+}): Promise<{
+  updated: number;
+  skipped: number;
+}> {
+  const batch = db.batch();
+  const profileViewScoreDeltas = new Map<string, number>();
+  let updated = 0;
+  let skipped = 0;
+
+  for (const document of input.documents) {
+    const data = document.data() as PublicPhotoRankingDocument;
+
+    if (!isRankablePhoto(data)) {
+      skipped += 1;
+      continue;
+    }
+
+    const update = buildPhotoRankingUpdate(data, input.now);
+
+    if (hasEquivalentPhotoRanking(data, update)) {
+      skipped += 1;
+      continue;
+    }
+
+    batch.set(document.ref, update, { merge: true });
+    updated += 1;
+
+    const ownerUid = document.ref.parent.parent?.id ?? '';
+    const viewScoreDelta = update.viewScore -
+      normalizeMediaScore(data.viewScore);
+
+    if (ownerUid && viewScoreDelta !== 0) {
+      profileViewScoreDeltas.set(
+        ownerUid,
+        (profileViewScoreDeltas.get(ownerUid) ?? 0) + viewScoreDelta
+      );
+    }
+  }
+
+  for (const [ownerUid, delta] of profileViewScoreDeltas) {
+    batch.set(
+      db.doc(`public_profiles/${ownerUid}`),
+      {
+        viewScore: FieldValue.increment(delta),
+        mediaMetricsUpdatedAt: FieldValue.serverTimestamp(),
+        updatedAt: FieldValue.serverTimestamp(),
+      },
+      { merge: true }
+    );
+  }
+
+  if (updated > 0) {
+    await batch.commit();
+  }
+
+  return { updated, skipped };
+}
+
+async function finalizeBackfillBatch(input: {
+  runId: string;
+  now: number;
+  processed: number;
+  updated: number;
+  skipped: number;
+  cursorPath: string | null;
+  completed: boolean;
+}): Promise<PhotoRankingBackfillState> {
+  const ref = stateRef();
+
+  return db.runTransaction(async (transaction) => {
+    const snapshot = await transaction.get(ref);
+    const state = normalizePhotoRankingBackfillState(
+      snapshot.data(),
+      input.now
+    );
+
+    if (state.leaseOwner !== input.runId) {
+      throw new HttpsError(
+        'aborted',
+        'O lease do backfill mudou antes da confirmação do lote.'
+      );
+    }
+
+    const paused = state.status === 'PAUSED';
+    const nextState: PhotoRankingBackfillState = {
+      ...state,
+      status: paused
+        ? 'PAUSED'
+        : input.completed
+          ? 'COMPLETED'
+          : 'RUNNING',
+      cursorPath: input.cursorPath ?? state.cursorPath,
+      processedCount: state.processedCount + input.processed,
+      updatedCount: state.updatedCount + input.updated,
+      skippedCount: state.skippedCount + input.skipped,
+      pagesCount: state.pagesCount + 1,
+      consecutiveFailures: 0,
+      leaseOwner: null,
+      leaseExpiresAt: 0,
+      updatedAt: input.now,
+      lastBatchAt: input.now,
+      completedAt: input.completed ? input.now : null,
+      lastErrorCode: null,
+      lastErrorMessage: null,
+    };
+
+    transaction.set(ref, nextState);
+    return nextState;
+  });
+}
+
+async function markBackfillBatchFailure(input: {
+  runId: string;
+  now: number;
+}): Promise<void> {
+  const ref = stateRef();
+
+  await db.runTransaction(async (transaction) => {
+    const snapshot = await transaction.get(ref);
+
+    if (!snapshot.exists) {
+      return;
+    }
+
+    const state = normalizePhotoRankingBackfillState(
+      snapshot.data(),
+      input.now
+    );
+
+    if (state.leaseOwner !== input.runId) {
+      return;
+    }
+
+    const consecutiveFailures = state.consecutiveFailures + 1;
+    const nextStatus = state.status === 'PAUSED'
+      ? 'PAUSED'
+      : nextPhotoRankingBackfillFailureStatus(consecutiveFailures);
+
+    transaction.set(ref, {
+      ...state,
+      status: nextStatus,
+      consecutiveFailures,
+      leaseOwner: null,
+      leaseExpiresAt: 0,
+      updatedAt: input.now,
+      lastErrorCode: 'BACKFILL_BATCH_FAILED',
+      lastErrorMessage: FAILURE_MESSAGE,
+    });
+  });
+}
+
+export async function executePhotoRankingBackfillBatch(): Promise<
+  PhotoRankingBackfillBatchResult
+> {
+  const runId = randomUUID();
+  const startedAt = Date.now();
+  const leasedState = await acquireBackfillLease({
+    runId,
+    now: startedAt,
+  });
+
+  if (!leasedState) {
+    const state = await readBackfillState(startedAt);
+    return {
+      acquired: false,
+      completed: state.status === 'COMPLETED',
+      processed: 0,
+      updated: 0,
+      skipped: 0,
+      cursorPath: state.cursorPath,
+      status: state.status,
+    };
+  }
+
+  try {
+    const snapshot = await buildPhotoQuery(
+      leasedState.cursorPath,
+      leasedState.pageSize
+    ).get();
+    const documents = snapshot.docs;
+    const processed = documents.length;
+    const cursorPath = documents.at(-1)?.ref.path ?? leasedState.cursorPath;
+    const completed = documents.length < leasedState.pageSize;
+    const result = await commitPhotoRankingPage({
+      documents,
+      now: startedAt,
+    });
+    const finalState = await finalizeBackfillBatch({
+      runId,
+      now: Date.now(),
+      processed,
+      updated: result.updated,
+      skipped: result.skipped,
+      cursorPath,
+      completed,
+    });
+
+    logger.info('[photoRankingBackfill] Lote concluído.', {
+      processed,
+      updated: result.updated,
+      skipped: result.skipped,
+      completed,
+      generation: finalState.generation,
+      pagesCount: finalState.pagesCount,
+    });
+
+    return {
+      acquired: true,
+      completed,
+      processed,
+      updated: result.updated,
+      skipped: result.skipped,
+      cursorPath: finalState.cursorPath,
+      status: finalState.status,
+    };
+  } catch (error) {
+    await markBackfillBatchFailure({ runId, now: Date.now() });
+
+    logger.error('[photoRankingBackfill] Falha ao executar lote.', {
+      error: error instanceof Error ? error.message : String(error ?? ''),
+    });
+
+    if (error instanceof HttpsError) {
+      throw error;
+    }
+
+    throw new HttpsError('internal', FAILURE_MESSAGE);
+  }
+}
+
+async function applyAdminControl(input: {
+  adminUid: string;
+  action: PhotoRankingBackfillControlAction;
+  operationId: string;
+  pageSize?: unknown;
+}): Promise<{
+  state: PhotoRankingBackfillState;
+  alreadyApplied: boolean;
+}> {
+  const ref = stateRef();
+  const adminLogRef = db.collection('admin_logs').doc();
+  const now = Date.now();
+
+  return db.runTransaction(async (transaction) => {
+    const snapshot = await transaction.get(ref);
+    const current = snapshot.exists
+      ? normalizePhotoRankingBackfillState(snapshot.data(), now)
+      : buildInitialPhotoRankingBackfillState({
+        now,
+        status: 'IDLE',
+      });
+
+    if (current.lastAdminOperationId === input.operationId) {
+      return { state: current, alreadyApplied: true };
+    }
+
+    if (
+      input.action === 'RESET' &&
+      !isPhotoRankingBackfillLeaseAvailable({
+        state: current,
+        now,
+        runId: input.operationId,
+      })
+    ) {
+      throw new HttpsError(
+        'failed-precondition',
+        'Há um lote em execução. Aguarde o término antes de reiniciar.'
+      );
+    }
+
+    if (
+      current.status === 'COMPLETED' &&
+      input.action !== 'RESET'
+    ) {
+      throw new HttpsError(
+        'failed-precondition',
+        'O backfill já foi concluído. Use RESET para executá-lo novamente.'
+      );
+    }
+
+    let nextState: PhotoRankingBackfillState;
+
+    if (input.action === 'RESET') {
+      nextState = {
+        ...buildInitialPhotoRankingBackfillState({
+          now,
+          pageSize: input.pageSize ?? current.pageSize,
+        }),
+        generation: current.generation + 1,
+      };
+    } else {
+      const pageSize = input.pageSize === undefined
+        ? current.pageSize
+        : normalizePhotoRankingBackfillPageSize(input.pageSize);
+      const nextStatus = input.action === 'PAUSE'
+        ? 'PAUSED'
+        : 'RUNNING';
+
+      nextState = {
+        ...current,
+        status: nextStatus,
+        pageSize,
+        startedAt: current.startedAt ?? now,
+        completedAt: null,
+        updatedAt: now,
+        lastErrorCode: null,
+        lastErrorMessage: null,
+        consecutiveFailures: input.action === 'PAUSE'
+          ? current.consecutiveFailures
+          : 0,
+      };
+    }
+
+    nextState.lastAdminOperationId = input.operationId;
+    nextState.lastAdminAction = input.action;
+    nextState.lastAdminBy = input.adminUid;
+
+    transaction.set(ref, nextState);
+    transaction.set(adminLogRef, {
+      adminUid: input.adminUid,
+      action: 'photoRankingBackfillControl',
+      details: {
+        operation: input.action,
+        operationId: input.operationId,
+        pageSize: nextState.pageSize,
+        generation: nextState.generation,
+        previousStatus: current.status,
+        nextStatus: nextState.status,
+      },
+      timestamp: FieldValue.serverTimestamp(),
+    });
+
+    return { state: nextState, alreadyApplied: false };
+  });
+}
+
+export async function getPhotoRankingBackfillStatusCore(
+  request: CallableRequest<Record<string, never>>
+): Promise<PhotoRankingBackfillStatusResponse> {
+  assertAdminAuthorization(request.auth, ADMIN_PERMISSION_MESSAGE);
+
+  const checkedAt = Date.now();
+  const state = await readBackfillState(checkedAt);
+
+  return {
+    state: stateForResponse(state),
+    leaseActive: !!state.leaseOwner && state.leaseExpiresAt > checkedAt,
+    checkedAt,
+  };
+}
+
+export async function controlPhotoRankingBackfillCore(
+  request: CallableRequest<ControlPhotoRankingBackfillRequest>
+): Promise<ControlPhotoRankingBackfillResponse> {
+  const adminUid = assertAdminAuthorization(
+    request.auth,
+    ADMIN_PERMISSION_MESSAGE
+  );
+  const action = normalizePhotoRankingBackfillAction(request.data?.action);
+  const operationId = normalizePhotoRankingBackfillOperationId(
+    request.data?.operationId
+  );
+
+  if (!action || !operationId) {
+    throw new HttpsError(
+      'invalid-argument',
+      'Ação ou identificador da operação inválido.'
+    );
+  }
+
+  const control = await applyAdminControl({
+    adminUid,
+    action,
+    operationId,
+    pageSize: request.data?.pageSize,
+  });
+
+  if (control.alreadyApplied || action !== 'RUN_PAGE') {
+    return {
+      action,
+      alreadyApplied: control.alreadyApplied,
+      state: stateForResponse(control.state),
+      batch: null,
+    };
+  }
+
+  const batch = await executePhotoRankingBackfillBatch();
+  const state = await readBackfillState();
+
+  return {
+    action,
+    alreadyApplied: false,
+    state: stateForResponse(state),
+    batch,
+  };
+}
+
+export const continuePhotoRankingBackfill = onSchedule(
+  {
+    schedule: 'every 10 minutes',
+    timeZone: 'America/Sao_Paulo',
+    region: FUNCTIONS_REGION,
+    maxInstances: 1,
+  },
+  async () => {
+    await executePhotoRankingBackfillBatch();
+  }
+);

--- a/functions/src/media/application/photo-ranking-backfill.handler.ts
+++ b/functions/src/media/application/photo-ranking-backfill.handler.ts
@@ -29,9 +29,7 @@ import {
   isRankablePhoto,
   type PublicPhotoRankingDocument,
 } from './photo-ranking-score';
-import {
-  normalizeMediaScore,
-} from './media-engagement-score';
+import { normalizeMediaScore } from './media-engagement-score';
 
 interface ControlPhotoRankingBackfillRequest {
   action?: PhotoRankingBackfillControlAction;
@@ -89,10 +87,7 @@ async function readBackfillState(
 
   return snapshot.exists
     ? normalizePhotoRankingBackfillState(snapshot.data(), now)
-    : buildInitialPhotoRankingBackfillState({
-      now,
-      status: 'IDLE',
-    });
+    : buildInitialPhotoRankingBackfillState({ now, status: 'IDLE' });
 }
 
 async function acquireBackfillLease(input: {
@@ -158,12 +153,9 @@ function buildPhotoQuery(
 async function commitPhotoRankingPage(input: {
   documents: FirebaseFirestore.QueryDocumentSnapshot[];
   now: number;
-}): Promise<{
-  updated: number;
-  skipped: number;
-}> {
+}): Promise<{ updated: number; skipped: number }> {
   const batch = db.batch();
-  const profileViewScoreDeltas = new Map<string, number>();
+  const profileDeltas = new Map<string, number>();
   let updated = 0;
   let skipped = 0;
 
@@ -186,18 +178,17 @@ async function commitPhotoRankingPage(input: {
     updated += 1;
 
     const ownerUid = document.ref.parent.parent?.id ?? '';
-    const viewScoreDelta = update.viewScore -
-      normalizeMediaScore(data.viewScore);
+    const delta = update.viewScore - normalizeMediaScore(data.viewScore);
 
-    if (ownerUid && viewScoreDelta !== 0) {
-      profileViewScoreDeltas.set(
+    if (ownerUid && delta !== 0) {
+      profileDeltas.set(
         ownerUid,
-        (profileViewScoreDeltas.get(ownerUid) ?? 0) + viewScoreDelta
+        (profileDeltas.get(ownerUid) ?? 0) + delta
       );
     }
   }
 
-  for (const [ownerUid, delta] of profileViewScoreDeltas) {
+  for (const [ownerUid, delta] of profileDeltas) {
     batch.set(
       db.doc(`public_profiles/${ownerUid}`),
       {
@@ -241,10 +232,9 @@ async function finalizeBackfillBatch(input: {
       );
     }
 
-    const paused = state.status === 'PAUSED';
     const nextState: PhotoRankingBackfillState = {
       ...state,
-      status: paused
+      status: state.status === 'PAUSED'
         ? 'PAUSED'
         : input.completed
           ? 'COMPLETED'
@@ -292,13 +282,13 @@ async function markBackfillBatchFailure(input: {
     }
 
     const consecutiveFailures = state.consecutiveFailures + 1;
-    const nextStatus = state.status === 'PAUSED'
+    const status = state.status === 'PAUSED'
       ? 'PAUSED'
       : nextPhotoRankingBackfillFailureStatus(consecutiveFailures);
 
     transaction.set(ref, {
       ...state,
-      status: nextStatus,
+      status,
       consecutiveFailures,
       leaseOwner: null,
       leaseExpiresAt: 0,
@@ -311,13 +301,10 @@ async function markBackfillBatchFailure(input: {
 
 export async function executePhotoRankingBackfillBatch(): Promise<
   PhotoRankingBackfillBatchResult
-> {
+  > {
   const runId = randomUUID();
   const startedAt = Date.now();
-  const leasedState = await acquireBackfillLease({
-    runId,
-    now: startedAt,
-  });
+  const leasedState = await acquireBackfillLease({ runId, now: startedAt });
 
   if (!leasedState) {
     const state = await readBackfillState(startedAt);
@@ -375,7 +362,6 @@ export async function executePhotoRankingBackfillBatch(): Promise<
     };
   } catch (error) {
     await markBackfillBatchFailure({ runId, now: Date.now() });
-
     logger.error('[photoRankingBackfill] Falha ao executar lote.', {
       error: error instanceof Error ? error.message : String(error ?? ''),
     });
@@ -405,10 +391,7 @@ async function applyAdminControl(input: {
     const snapshot = await transaction.get(ref);
     const current = snapshot.exists
       ? normalizePhotoRankingBackfillState(snapshot.data(), now)
-      : buildInitialPhotoRankingBackfillState({
-        now,
-        status: 'IDLE',
-      });
+      : buildInitialPhotoRankingBackfillState({ now, status: 'IDLE' });
 
     if (current.lastAdminOperationId === input.operationId) {
       return { state: current, alreadyApplied: true };
@@ -428,10 +411,7 @@ async function applyAdminControl(input: {
       );
     }
 
-    if (
-      current.status === 'COMPLETED' &&
-      input.action !== 'RESET'
-    ) {
+    if (current.status === 'COMPLETED' && input.action !== 'RESET') {
       throw new HttpsError(
         'failed-precondition',
         'O backfill já foi concluído. Use RESET para executá-lo novamente.'
@@ -452,13 +432,10 @@ async function applyAdminControl(input: {
       const pageSize = input.pageSize === undefined
         ? current.pageSize
         : normalizePhotoRankingBackfillPageSize(input.pageSize);
-      const nextStatus = input.action === 'PAUSE'
-        ? 'PAUSED'
-        : 'RUNNING';
 
       nextState = {
         ...current,
-        status: nextStatus,
+        status: input.action === 'PAUSE' ? 'PAUSED' : 'RUNNING',
         pageSize,
         startedAt: current.startedAt ?? now,
         completedAt: null,

--- a/functions/src/media/application/photo-ranking-backfill.policy.test.ts
+++ b/functions/src/media/application/photo-ranking-backfill.policy.test.ts
@@ -1,0 +1,129 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  PHOTO_RANKING_BACKFILL_DEFAULT_PAGE_SIZE,
+  PHOTO_RANKING_BACKFILL_MAX_PAGE_SIZE,
+  PHOTO_RANKING_BACKFILL_MAX_CONSECUTIVE_FAILURES,
+  PHOTO_RANKING_BACKFILL_MIN_PAGE_SIZE,
+  buildInitialPhotoRankingBackfillState,
+  isPhotoRankingBackfillLeaseAvailable,
+  nextPhotoRankingBackfillFailureStatus,
+  normalizePhotoRankingBackfillAction,
+  normalizePhotoRankingBackfillCursorPath,
+  normalizePhotoRankingBackfillOperationId,
+  normalizePhotoRankingBackfillPageSize,
+  normalizePhotoRankingBackfillState,
+} from './photo-ranking-backfill.policy';
+
+describe('photo-ranking-backfill.policy', () => {
+  it('limita o tamanho das páginas', () => {
+    assert.equal(
+      normalizePhotoRankingBackfillPageSize(undefined),
+      PHOTO_RANKING_BACKFILL_DEFAULT_PAGE_SIZE
+    );
+    assert.equal(
+      normalizePhotoRankingBackfillPageSize(1),
+      PHOTO_RANKING_BACKFILL_MIN_PAGE_SIZE
+    );
+    assert.equal(
+      normalizePhotoRankingBackfillPageSize(999),
+      PHOTO_RANKING_BACKFILL_MAX_PAGE_SIZE
+    );
+  });
+
+  it('aceita somente cursores de fotos públicas', () => {
+    assert.equal(
+      normalizePhotoRankingBackfillCursorPath(
+        'public_profiles/user-1/public_photos/photo_2'
+      ),
+      'public_profiles/user-1/public_photos/photo_2'
+    );
+    assert.equal(
+      normalizePhotoRankingBackfillCursorPath(
+        'users/user-1/photos/photo-2'
+      ),
+      null
+    );
+    assert.equal(
+      normalizePhotoRankingBackfillCursorPath('../public_photos/photo-2'),
+      null
+    );
+  });
+
+  it('normaliza ações e operações administrativas', () => {
+    assert.equal(normalizePhotoRankingBackfillAction('run_page'), 'RUN_PAGE');
+    assert.equal(normalizePhotoRankingBackfillAction('delete'), null);
+    assert.equal(
+      normalizePhotoRankingBackfillOperationId('operation_123'),
+      'operation_123'
+    );
+    assert.equal(normalizePhotoRankingBackfillOperationId('curto'), '');
+  });
+
+  it('inicializa execução retomável com contadores zerados', () => {
+    const state = buildInitialPhotoRankingBackfillState({
+      now: 1_800_000_000_000,
+      pageSize: 150,
+    });
+
+    assert.equal(state.status, 'RUNNING');
+    assert.equal(state.pageSize, 150);
+    assert.equal(state.cursorPath, null);
+    assert.equal(state.processedCount, 0);
+    assert.equal(state.generation, 1);
+    assert.equal(state.startedAt, 1_800_000_000_000);
+  });
+
+  it('recupera estado legado sem confiar em valores inválidos', () => {
+    const state = normalizePhotoRankingBackfillState(
+      {
+        status: 'INVALID',
+        pageSize: 999,
+        cursorPath: 'users/u/photos/p',
+        processedCount: -10,
+        generation: 0,
+      },
+      1_800_000_000_000
+    );
+
+    assert.equal(state.status, 'RUNNING');
+    assert.equal(state.pageSize, PHOTO_RANKING_BACKFILL_MAX_PAGE_SIZE);
+    assert.equal(state.cursorPath, null);
+    assert.equal(state.processedCount, 0);
+    assert.equal(state.generation, 1);
+  });
+
+  it('impede concorrência até o lease expirar', () => {
+    const state = buildInitialPhotoRankingBackfillState({ now: 10_000 });
+    state.leaseOwner = 'run-a';
+    state.leaseExpiresAt = 20_000;
+
+    assert.equal(
+      isPhotoRankingBackfillLeaseAvailable({
+        state,
+        now: 15_000,
+        runId: 'run-b',
+      }),
+      false
+    );
+    assert.equal(
+      isPhotoRankingBackfillLeaseAvailable({
+        state,
+        now: 20_000,
+        runId: 'run-b',
+      }),
+      true
+    );
+  });
+
+  it('interrompe a retomada automática após falhas consecutivas', () => {
+    assert.equal(nextPhotoRankingBackfillFailureStatus(1), 'RUNNING');
+    assert.equal(
+      nextPhotoRankingBackfillFailureStatus(
+        PHOTO_RANKING_BACKFILL_MAX_CONSECUTIVE_FAILURES
+      ),
+      'FAILED'
+    );
+  });
+});

--- a/functions/src/media/application/photo-ranking-backfill.policy.ts
+++ b/functions/src/media/application/photo-ranking-backfill.policy.ts
@@ -1,0 +1,227 @@
+import { MEDIA_RANKING_VERSION } from './media-engagement-score';
+
+export const PHOTO_RANKING_BACKFILL_ID =
+  `photo-ranking-v${MEDIA_RANKING_VERSION}`;
+export const PHOTO_RANKING_BACKFILL_COLLECTION =
+  'media_ranking_backfills';
+export const PHOTO_RANKING_BACKFILL_DEFAULT_PAGE_SIZE = 120;
+export const PHOTO_RANKING_BACKFILL_MIN_PAGE_SIZE = 20;
+export const PHOTO_RANKING_BACKFILL_MAX_PAGE_SIZE = 180;
+export const PHOTO_RANKING_BACKFILL_LEASE_MS = 4 * 60 * 1000;
+export const PHOTO_RANKING_BACKFILL_MAX_CONSECUTIVE_FAILURES = 5;
+
+export type PhotoRankingBackfillStatus =
+  | 'IDLE'
+  | 'RUNNING'
+  | 'PAUSED'
+  | 'COMPLETED'
+  | 'FAILED';
+
+export type PhotoRankingBackfillControlAction =
+  | 'START_OR_RESUME'
+  | 'PAUSE'
+  | 'RUN_PAGE'
+  | 'RESET';
+
+export interface PhotoRankingBackfillState {
+  version: number;
+  status: PhotoRankingBackfillStatus;
+  pageSize: number;
+  cursorPath: string | null;
+  processedCount: number;
+  updatedCount: number;
+  skippedCount: number;
+  pagesCount: number;
+  consecutiveFailures: number;
+  leaseOwner: string | null;
+  leaseExpiresAt: number;
+  startedAt: number | null;
+  updatedAt: number;
+  completedAt: number | null;
+  lastBatchAt: number | null;
+  lastErrorCode: string | null;
+  lastErrorMessage: string | null;
+  lastAdminOperationId: string | null;
+  lastAdminAction: PhotoRankingBackfillControlAction | null;
+  lastAdminBy: string | null;
+  generation: number;
+}
+
+function normalizeNonNegativeInteger(value: unknown): number {
+  const numeric = Number(value ?? 0);
+
+  return Number.isFinite(numeric) && numeric >= 0
+    ? Math.trunc(numeric)
+    : 0;
+}
+
+function normalizeNullableTimestamp(value: unknown): number | null {
+  const normalized = normalizeNonNegativeInteger(value);
+  return normalized > 0 ? normalized : null;
+}
+
+export function normalizePhotoRankingBackfillPageSize(
+  value: unknown
+): number {
+  const numeric = Number(value ?? PHOTO_RANKING_BACKFILL_DEFAULT_PAGE_SIZE);
+
+  if (!Number.isFinite(numeric)) {
+    return PHOTO_RANKING_BACKFILL_DEFAULT_PAGE_SIZE;
+  }
+
+  return Math.max(
+    PHOTO_RANKING_BACKFILL_MIN_PAGE_SIZE,
+    Math.min(PHOTO_RANKING_BACKFILL_MAX_PAGE_SIZE, Math.trunc(numeric))
+  );
+}
+
+export function normalizePhotoRankingBackfillCursorPath(
+  value: unknown
+): string | null {
+  const path = String(value ?? '').trim();
+
+  if (!path) {
+    return null;
+  }
+
+  return /^public_profiles\/[A-Za-z0-9_-]{1,128}\/public_photos\/[A-Za-z0-9_-]{1,128}$/.test(
+    path
+  )
+    ? path
+    : null;
+}
+
+export function normalizePhotoRankingBackfillOperationId(
+  value: unknown
+): string {
+  const operationId = String(value ?? '').trim();
+  return /^[A-Za-z0-9_-]{8,128}$/.test(operationId)
+    ? operationId
+    : '';
+}
+
+export function normalizePhotoRankingBackfillAction(
+  value: unknown
+): PhotoRankingBackfillControlAction | null {
+  const action = String(value ?? '').trim().toUpperCase();
+
+  if (
+    action === 'START_OR_RESUME' ||
+    action === 'PAUSE' ||
+    action === 'RUN_PAGE' ||
+    action === 'RESET'
+  ) {
+    return action;
+  }
+
+  return null;
+}
+
+export function buildInitialPhotoRankingBackfillState(input: {
+  now: number;
+  pageSize?: unknown;
+  status?: PhotoRankingBackfillStatus;
+}): PhotoRankingBackfillState {
+  const now = normalizeNonNegativeInteger(input.now);
+  const status = input.status ?? 'RUNNING';
+
+  return {
+    version: MEDIA_RANKING_VERSION,
+    status,
+    pageSize: normalizePhotoRankingBackfillPageSize(input.pageSize),
+    cursorPath: null,
+    processedCount: 0,
+    updatedCount: 0,
+    skippedCount: 0,
+    pagesCount: 0,
+    consecutiveFailures: 0,
+    leaseOwner: null,
+    leaseExpiresAt: 0,
+    startedAt: status === 'RUNNING' ? now : null,
+    updatedAt: now,
+    completedAt: null,
+    lastBatchAt: null,
+    lastErrorCode: null,
+    lastErrorMessage: null,
+    lastAdminOperationId: null,
+    lastAdminAction: null,
+    lastAdminBy: null,
+    generation: 1,
+  };
+}
+
+export function normalizePhotoRankingBackfillState(
+  value: unknown,
+  now: number
+): PhotoRankingBackfillState {
+  if (typeof value !== 'object' || value === null) {
+    return buildInitialPhotoRankingBackfillState({ now });
+  }
+
+  const data = value as Partial<PhotoRankingBackfillState>;
+  const status = String(data.status ?? '').trim().toUpperCase();
+  const normalizedStatus: PhotoRankingBackfillStatus =
+    status === 'IDLE' ||
+    status === 'RUNNING' ||
+    status === 'PAUSED' ||
+    status === 'COMPLETED' ||
+    status === 'FAILED'
+      ? status
+      : 'RUNNING';
+
+  return {
+    version: normalizeNonNegativeInteger(data.version) ||
+      MEDIA_RANKING_VERSION,
+    status: normalizedStatus,
+    pageSize: normalizePhotoRankingBackfillPageSize(data.pageSize),
+    cursorPath: normalizePhotoRankingBackfillCursorPath(data.cursorPath),
+    processedCount: normalizeNonNegativeInteger(data.processedCount),
+    updatedCount: normalizeNonNegativeInteger(data.updatedCount),
+    skippedCount: normalizeNonNegativeInteger(data.skippedCount),
+    pagesCount: normalizeNonNegativeInteger(data.pagesCount),
+    consecutiveFailures: normalizeNonNegativeInteger(
+      data.consecutiveFailures
+    ),
+    leaseOwner: String(data.leaseOwner ?? '').trim() || null,
+    leaseExpiresAt: normalizeNonNegativeInteger(data.leaseExpiresAt),
+    startedAt: normalizeNullableTimestamp(data.startedAt),
+    updatedAt: normalizeNonNegativeInteger(data.updatedAt) ||
+      normalizeNonNegativeInteger(now),
+    completedAt: normalizeNullableTimestamp(data.completedAt),
+    lastBatchAt: normalizeNullableTimestamp(data.lastBatchAt),
+    lastErrorCode: String(data.lastErrorCode ?? '').trim().slice(0, 100) ||
+      null,
+    lastErrorMessage: String(data.lastErrorMessage ?? '')
+      .trim()
+      .slice(0, 300) || null,
+    lastAdminOperationId: normalizePhotoRankingBackfillOperationId(
+      data.lastAdminOperationId
+    ) || null,
+    lastAdminAction: normalizePhotoRankingBackfillAction(
+      data.lastAdminAction
+    ),
+    lastAdminBy: String(data.lastAdminBy ?? '').trim() || null,
+    generation: Math.max(1, normalizeNonNegativeInteger(data.generation)),
+  };
+}
+
+export function isPhotoRankingBackfillLeaseAvailable(input: {
+  state: PhotoRankingBackfillState;
+  now: number;
+  runId: string;
+}): boolean {
+  const now = normalizeNonNegativeInteger(input.now);
+
+  return !input.state.leaseOwner ||
+    input.state.leaseOwner === input.runId ||
+    input.state.leaseExpiresAt <= now;
+}
+
+export function nextPhotoRankingBackfillFailureStatus(
+  consecutiveFailures: unknown
+): PhotoRankingBackfillStatus {
+  return normalizeNonNegativeInteger(consecutiveFailures) >=
+    PHOTO_RANKING_BACKFILL_MAX_CONSECUTIVE_FAILURES
+    ? 'FAILED'
+    : 'RUNNING';
+}

--- a/functions/src/media/application/protected-admin-media-callables.handler.ts
+++ b/functions/src/media/application/protected-admin-media-callables.handler.ts
@@ -20,6 +20,10 @@ import {
 import {
   assertMediaCallableRateLimit,
 } from './media-callable-rate-limit.service';
+import {
+  controlPhotoRankingBackfillCore,
+  getPhotoRankingBackfillStatusCore,
+} from './photo-ranking-backfill.handler';
 
 interface ListVideoModerationQueueRequest {
   limit?: number;
@@ -42,6 +46,12 @@ interface RecoverVideoProcessingJobRequest {
   action?: 'RETRY_FAILED' | 'RECHECK_STALE' | 'CANCEL_ACTIVE';
   reason?: string;
   operationId?: string;
+}
+
+interface ControlPhotoRankingBackfillRequest {
+  action?: 'START_OR_RESUME' | 'PAUSE' | 'RUN_PAGE' | 'RESET';
+  operationId?: string;
+  pageSize?: number;
 }
 
 const DEFAULT_MODERATION_QUEUE_LIMIT = 40;
@@ -77,13 +87,28 @@ function mediaResourceKey(
     `${cleanId(mediaId) || 'invalid-media'}`;
 }
 
+function photoRankingBackfillCost(action: unknown): number {
+  const normalized = String(action ?? '').trim().toUpperCase();
+
+  if (normalized === 'RUN_PAGE') {
+    return 12;
+  }
+
+  if (normalized === 'RESET') {
+    return 6;
+  }
+
+  return 2;
+}
+
 async function applyAdminRateLimit(input: {
   actorUid: string;
   action:
     | 'ADMIN_STATUS'
     | 'ADMIN_QUEUE'
     | 'ADMIN_MODERATION'
-    | 'ADMIN_PROCESSING_RECOVERY';
+    | 'ADMIN_PROCESSING_RECOVERY'
+    | 'ADMIN_RANKING_BACKFILL';
   resourceKey: string;
   cost?: number;
 }): Promise<void> {
@@ -207,5 +232,46 @@ export const recoverVideoProcessingJob = onCall<
     });
 
     return recoverVideoProcessingJobCore.run(request);
+  }
+);
+
+export const getPhotoRankingBackfillStatus = onCall<
+  Record<string, never>
+>(
+  ADMIN_BROWSER_CALLABLE_OPTIONS,
+  async (request) => {
+    const adminUid = assertAdminAuthorization(
+      request.auth,
+      'Apenas administradores podem consultar o backfill de fotos.'
+    );
+
+    await applyAdminRateLimit({
+      actorUid: adminUid,
+      action: 'ADMIN_STATUS',
+      resourceKey: 'photo-ranking-backfill-status',
+    });
+
+    return getPhotoRankingBackfillStatusCore(request);
+  }
+);
+
+export const controlPhotoRankingBackfill = onCall<
+  ControlPhotoRankingBackfillRequest
+>(
+  ADMIN_BROWSER_CALLABLE_OPTIONS,
+  async (request) => {
+    const adminUid = assertAdminAuthorization(
+      request.auth,
+      'Apenas administradores podem controlar o backfill de fotos.'
+    );
+
+    await applyAdminRateLimit({
+      actorUid: adminUid,
+      action: 'ADMIN_RANKING_BACKFILL',
+      resourceKey: 'photo-ranking-backfill-control',
+      cost: photoRankingBackfillCost(request.data?.action),
+    });
+
+    return controlPhotoRankingBackfillCore(request);
   }
 );

--- a/functions/src/media/application/video-view-session.policy.test.ts
+++ b/functions/src/media/application/video-view-session.policy.test.ts
@@ -5,6 +5,7 @@ import './admin-authorization.policy.test';
 import './media-callable-rate-limit.policy.test';
 import './media-mutation-idempotency.policy.test';
 import './photo-audience-access.policy.test';
+import './photo-ranking-backfill.policy.test';
 import './photo-ranking-score.test';
 import './photo-view-session.policy.test';
 import {

--- a/functions/src/media/index.ts
+++ b/functions/src/media/index.ts
@@ -32,6 +32,8 @@ export {
 } from './application/protected-media-lifecycle-callables.handler';
 
 export {
+  controlPhotoRankingBackfill,
+  getPhotoRankingBackfillStatus,
   getVideoProcessingOperationalStatus,
   listVideoModerationQueue,
   listVideoProcessingRecoveryJobs,
@@ -111,6 +113,9 @@ export {
   recordVideoView,
 } from './application/record-video-view-orchestrator.handler';
 
+export {
+  continuePhotoRankingBackfill,
+} from './application/photo-ranking-backfill.handler';
 export {
   recalculatePhotoRankingOnWrite,
   refreshPublicPhotoRankingScores,


### PR DESCRIPTION
## Dependência

PR empilhado sobre o #60 (`agent/media-p0-photo-ranking-retention`). Nenhum merge é realizado por este pacote.

## Escopo

Este pacote cria um backfill completo, paginado, retomável e idempotente para migrar fotos antigas ao ranking canônico introduzido no #60.

## Execução paginada

O backfill percorre `public_photos` em ordem determinística pelo caminho completo do documento.

Cada lote:

- processa entre 20 e 180 documentos;
- usa 120 documentos por padrão;
- persiste o último caminho processado;
- recalcula somente fotos `PUBLIC` e `APPROVED`;
- ignora documentos já equivalentes à versão canônica;
- atualiza as fotos em um único batch;
- ajusta o `viewScore` agregado do perfil pelo delta real;
- avança o cursor somente depois do commit.

Se a execução cair depois do batch e antes do avanço do cursor, o lote pode ser repetido: as fotos já equivalentes são ignoradas e o delta do perfil não é aplicado novamente.

## Estado retomável

O progresso é armazenado em coleção backend-only com:

- versão do ranking;
- status `IDLE`, `RUNNING`, `PAUSED`, `COMPLETED` ou `FAILED`;
- cursor;
- tamanho da página;
- documentos processados, atualizados e ignorados;
- páginas concluídas;
- geração da migração;
- falhas consecutivas;
- horários de início, último lote e conclusão;
- último erro sanitizado.

O identificador interno do lease não é devolvido ao cliente.

## Concorrência e recuperação

Cada lote adquire um lease transacional de quatro minutos.

- scheduler e execução administrativa não processam simultaneamente;
- leases expirados podem ser retomados;
- o cursor só avança após confirmação do lote;
- falhas liberam o lease;
- a retomada automática continua após erros transitórios;
- após cinco falhas consecutivas, o estado passa para `FAILED` e exige retomada administrativa.

## Scheduler

`continuePhotoRankingBackfill` executa a cada dez minutos com `maxInstances: 1`.

Na ausência de estado anterior, o scheduler inicia automaticamente a migração. Estados `PAUSED`, `COMPLETED` e `FAILED` não consomem páginas.

## Controle administrativo protegido

Foram adicionadas as callables:

- `getPhotoRankingBackfillStatus`;
- `controlPhotoRankingBackfill`.

As ações disponíveis são:

- `START_OR_RESUME`;
- `PAUSE`;
- `RUN_PAGE`;
- `RESET`.

A borda pública exige autenticação administrativa, App Check e rate limiting. O core repete a autorização como defesa em profundidade.

Operações mutáveis exigem `operationId` e ficam idempotentes. Cada ação é registrada em `admin_logs` sem expor o lease ou erros internos.

## Rate limiting

Foi criada a categoria `ADMIN_RANKING_BACKFILL`:

- janela de uma hora;
- 60 unidades globais;
- 36 unidades por recurso;
- intervalo mínimo de um segundo;
- `RUN_PAGE` custa 12 unidades;
- `RESET` custa 6;
- pausa e retomada custam 2.

A consulta de status reutiliza `ADMIN_STATUS`.

## Supressões e ocultações

Nenhum código funcional existente foi removido.

O `runId` real do lease foi ocultado da resposta administrativa e substituído pelo indicador `active`. O motivo é impedir que identificadores internos de coordenação sejam reutilizados ou registrados no navegador.

O erro persistido no documento de progresso também foi reduzido a código e mensagem estáveis. O erro técnico completo permanece apenas nos logs das Functions.

## Compatibilidade

- ranking em tempo real do #60 permanece ativo;
- scheduler de recência continua inalterado;
- nomes públicos existentes não foram modificados;
- nenhuma alteração Angular é necessária;
- nenhuma Firestore Rule foi afrouxada;
- nenhum índice composto novo é necessário;
- o backfill não escreve documentos de visualizadores;
- o ranking de vídeos não foi alterado.

## Testes adicionados

- limites mínimo, padrão e máximo das páginas;
- validação do cursor;
- validação de ação e `operationId`;
- inicialização e recuperação de estado legado;
- exclusão mútua pelo lease;
- interrupção após falhas consecutivas;
- política de rate limiting administrativo.

## Validação concluída

- lint das Functions: aprovado;
- build TypeScript das Functions: aprovado;
- testes das Functions e da política do backfill: aprovados;
- paginação por collection group e cursor persistido: compilada;
- scheduler e callables protegidas: compilados;
- testes Angular: aprovados;
- build Angular seguro: aprovado;
- Firestore Rules: aprovadas;
- índices do Firestore: aprovados;
- Quality Gate agregado: aprovado.

O primeiro run foi interrompido somente por uma regra de indentação do ESLint na assinatura multilinha. A formatação foi corrigida em um commit isolado; o segundo Quality Gate passou integralmente, sem correção funcional.