### PR TITLE
feat(admin): operar backfill do ranking de fotos

### DIFF
--- a/src/app/admin-dashboard/admin-dashboard-routing.module.ts
+++ b/src/app/admin-dashboard/admin-dashboard-routing.module.ts
@@ -7,6 +7,7 @@ import { ModerationReportsComponent } from './moderation-reports/moderation-repo
 import { OperationalOverviewComponent } from './operational-overview/operational-overview.component';
 import { VideoModerationComponent } from './video-moderation/video-moderation.component';
 import { AccountDeletionOperationsComponent } from './account-deletion-operations/account-deletion-operations.component';
+import { PhotoRankingBackfillComponent } from './photo-ranking-backfill/photo-ranking-backfill.component';
 import { adminCanActivateChild } from '../core/guards/access-guard/admin.guard';
 import { UserResolver } from './resolvers/user.resolver';
 
@@ -27,6 +28,7 @@ const routes: Routes = [
       },
       { path: 'denuncias', component: ModerationReportsComponent },
       { path: 'videos', component: VideoModerationComponent },
+      { path: 'ranking-fotos', component: PhotoRankingBackfillComponent },
     ],
   },
 ];

--- a/src/app/admin-dashboard/admin-dashboard.component.html
+++ b/src/app/admin-dashboard/admin-dashboard.component.html
@@ -9,6 +9,7 @@
       <a routerLink="users" routerLinkActive="is-active">Usuários</a>
       <a routerLink="denuncias" routerLinkActive="is-active">Denúncias</a>
       <a routerLink="videos" routerLinkActive="is-active">Vídeos</a>
+      <a routerLink="ranking-fotos" routerLinkActive="is-active">Ranking de fotos</a>
     </nav>
   </header>
 

--- a/src/app/admin-dashboard/photo-ranking-backfill/photo-ranking-backfill.component.css
+++ b/src/app/admin-dashboard/photo-ranking-backfill/photo-ranking-backfill.component.css
@@ -1,0 +1,449 @@
+:host {
+  display: block;
+  min-width: 0;
+}
+
+.backfill-page {
+  display: grid;
+  gap: 1rem;
+  min-width: 0;
+  padding-bottom: 1rem;
+  color: var(--text-color, #111827);
+}
+
+.backfill-page__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.backfill-page__eyebrow {
+  margin: 0 0 0.25rem;
+  color: var(--primary-color, #d64d4d);
+  font-size: 0.72rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.backfill-page h2,
+.backfill-page h3,
+.backfill-page p,
+.backfill-page dl,
+.backfill-page dd {
+  margin: 0;
+}
+
+.backfill-page h2 {
+  font-size: clamp(1.35rem, 1.2rem + 0.8vw, 2rem);
+  font-weight: 900;
+  line-height: 1.08;
+  letter-spacing: -0.03em;
+}
+
+.backfill-page h3 {
+  font-size: 1rem;
+  font-weight: 850;
+  line-height: 1.25;
+}
+
+.backfill-page__description,
+.backfill-card__heading p,
+.backfill-state p,
+.backfill-status p,
+.reset-confirmation p {
+  margin-top: 0.35rem;
+  color: color-mix(in oklab, var(--text-color, #111827) 68%, transparent);
+  font-size: 0.86rem;
+  line-height: 1.55;
+}
+
+.button {
+  min-height: 42px;
+  padding: 0.65rem 0.9rem;
+  border: 1px solid transparent;
+  border-radius: 0.75rem;
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 800;
+  line-height: 1.15;
+  cursor: pointer;
+}
+
+.button:focus-visible,
+.page-size-field input:focus-visible {
+  outline: 3px solid color-mix(in oklab, var(--primary-color, #d64d4d) 34%, transparent);
+  outline-offset: 2px;
+}
+
+.button:disabled {
+  cursor: not-allowed;
+  opacity: 0.56;
+}
+
+.button--primary,
+.button--danger {
+  background: var(--primary-color, #d64d4d);
+  color: #fff;
+}
+
+.button--secondary {
+  border-color: var(--surface-border, rgba(0, 0, 0, 0.14));
+  background: var(--surface-card, #fff);
+  color: var(--text-color, #111827);
+}
+
+.button--danger-ghost {
+  border-color: color-mix(in oklab, #b42318 38%, transparent);
+  background: color-mix(in oklab, #b42318 6%, transparent);
+  color: #b42318;
+}
+
+.button--danger {
+  background: #b42318;
+}
+
+.backfill-state,
+.backfill-status,
+.backfill-card,
+.metric-card,
+.backfill-notice,
+.reset-confirmation {
+  border: 1px solid var(--surface-border, rgba(0, 0, 0, 0.12));
+  border-radius: 1rem;
+  background: var(--surface-card, #fff);
+  box-shadow: 0 12px 30px color-mix(in oklab, #000 5%, transparent);
+}
+
+.backfill-state {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  min-height: 120px;
+  padding: 1rem;
+}
+
+.backfill-state--loading {
+  justify-content: flex-start;
+}
+
+.backfill-state--error {
+  border-color: color-mix(in oklab, #b42318 34%, transparent);
+}
+
+.backfill-spinner {
+  width: 1.4rem;
+  height: 1.4rem;
+  flex: 0 0 auto;
+  border: 3px solid color-mix(in oklab, var(--primary-color, #d64d4d) 18%, transparent);
+  border-top-color: var(--primary-color, #d64d4d);
+  border-radius: 50%;
+  animation: backfill-spin 0.8s linear infinite;
+}
+
+.backfill-status {
+  display: grid;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.status-badge {
+  display: inline-flex;
+  min-height: 30px;
+  align-items: center;
+  padding: 0 0.7rem;
+  border-radius: 999px;
+  background: color-mix(in oklab, #667085 10%, transparent);
+  color: #475467;
+  font-size: 0.75rem;
+  font-weight: 850;
+}
+
+.status-badge[data-tone='success'] {
+  background: color-mix(in oklab, #067647 10%, transparent);
+  color: #067647;
+}
+
+.status-badge[data-tone='info'] {
+  background: color-mix(in oklab, #175cd3 10%, transparent);
+  color: #175cd3;
+}
+
+.status-badge[data-tone='warning'] {
+  background: color-mix(in oklab, #b54708 10%, transparent);
+  color: #b54708;
+}
+
+.status-badge[data-tone='danger'] {
+  background: color-mix(in oklab, #b42318 10%, transparent);
+  color: #b42318;
+}
+
+.backfill-status__meta,
+.detail-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.7rem;
+}
+
+.backfill-status__meta div,
+.detail-list div {
+  min-width: 0;
+  padding: 0.7rem;
+  border-radius: 0.8rem;
+  background: color-mix(in oklab, var(--surface-ground, #f5f6f8) 78%, transparent);
+}
+
+.backfill-status__meta dt,
+.detail-list dt {
+  color: color-mix(in oklab, var(--text-color, #111827) 58%, transparent);
+  font-size: 0.7rem;
+  font-weight: 750;
+}
+
+.backfill-status__meta dd,
+.detail-list dd {
+  margin-top: 0.25rem;
+  overflow-wrap: anywhere;
+  font-size: 0.84rem;
+  font-weight: 800;
+}
+
+.metric-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.metric-card {
+  min-width: 0;
+  padding: 0.9rem;
+}
+
+.metric-card span,
+.metric-card small {
+  display: block;
+}
+
+.metric-card span {
+  color: color-mix(in oklab, var(--text-color, #111827) 66%, transparent);
+  font-size: 0.73rem;
+  font-weight: 760;
+}
+
+.metric-card strong {
+  display: block;
+  margin: 0.3rem 0;
+  font-size: clamp(1.4rem, 1.1rem + 1vw, 2rem);
+  line-height: 1;
+}
+
+.metric-card small {
+  color: color-mix(in oklab, var(--text-color, #111827) 55%, transparent);
+  font-size: 0.68rem;
+  line-height: 1.4;
+}
+
+.backfill-card {
+  display: grid;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.backfill-card--compact {
+  gap: 0.75rem;
+}
+
+.backfill-card__heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.backfill-card__heading > strong {
+  flex: 0 0 auto;
+  color: var(--primary-color, #d64d4d);
+  font-size: 1.2rem;
+}
+
+.backfill-card__heading--controls {
+  align-items: flex-end;
+}
+
+.backfill-progress {
+  width: 100%;
+  height: 0.65rem;
+  overflow: hidden;
+  border: 0;
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--text-color, #111827) 9%, transparent);
+}
+
+.backfill-progress::-webkit-progress-bar {
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--text-color, #111827) 9%, transparent);
+}
+
+.backfill-progress::-webkit-progress-value {
+  border-radius: 999px;
+  background: var(--primary-color, #d64d4d);
+}
+
+.backfill-progress::-moz-progress-bar {
+  border-radius: 999px;
+  background: var(--primary-color, #d64d4d);
+}
+
+.backfill-notice {
+  padding: 0.85rem 1rem;
+  font-size: 0.82rem;
+  line-height: 1.5;
+}
+
+.backfill-notice--warning {
+  border-color: color-mix(in oklab, #b54708 32%, transparent);
+  background: color-mix(in oklab, #b54708 6%, var(--surface-card, #fff));
+  color: #7a2e0e;
+}
+
+.backfill-notice--danger {
+  border-color: color-mix(in oklab, #b42318 32%, transparent);
+  background: color-mix(in oklab, #b42318 6%, var(--surface-card, #fff));
+  color: #7a271a;
+}
+
+.backfill-notice p {
+  margin-top: 0.25rem;
+}
+
+.backfill-notice small {
+  display: block;
+  margin-top: 0.35rem;
+  font-weight: 700;
+}
+
+.page-size-field {
+  display: grid;
+  gap: 0.3rem;
+  min-width: 150px;
+  color: color-mix(in oklab, var(--text-color, #111827) 70%, transparent);
+  font-size: 0.72rem;
+  font-weight: 760;
+}
+
+.page-size-field input {
+  width: 100%;
+  min-height: 42px;
+  padding: 0 0.7rem;
+  border: 1px solid var(--surface-border, rgba(0, 0, 0, 0.16));
+  border-radius: 0.7rem;
+  background: var(--surface-card, #fff);
+  color: var(--text-color, #111827);
+  font: inherit;
+  font-size: 0.9rem;
+}
+
+.page-size-field small {
+  color: color-mix(in oklab, var(--text-color, #111827) 52%, transparent);
+  font-size: 0.65rem;
+  font-weight: 600;
+}
+
+.action-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.65rem;
+}
+
+.backfill-inline-help {
+  color: color-mix(in oklab, var(--text-color, #111827) 62%, transparent);
+  font-size: 0.76rem;
+  line-height: 1.45;
+}
+
+.reset-confirmation {
+  display: grid;
+  gap: 0.8rem;
+  padding: 0.9rem;
+  border-color: color-mix(in oklab, #b42318 35%, transparent);
+  background: color-mix(in oklab, #b42318 5%, var(--surface-card, #fff));
+}
+
+.reset-confirmation__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.6rem;
+}
+
+@keyframes backfill-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (min-width: 760px) {
+  .backfill-status {
+    grid-template-columns: minmax(0, 1fr) minmax(360px, 0.8fr);
+    align-items: center;
+  }
+
+  .metric-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 620px) {
+  .backfill-page__header,
+  .backfill-card__heading,
+  .backfill-card__heading--controls,
+  .backfill-state {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .backfill-page__header .button,
+  .backfill-state .button,
+  .action-grid .button,
+  .reset-confirmation__actions .button {
+    width: 100%;
+  }
+
+  .metric-grid,
+  .action-grid,
+  .backfill-status__meta,
+  .detail-list {
+    grid-template-columns: 1fr;
+  }
+
+  .page-size-field {
+    width: 100%;
+  }
+
+  .reset-confirmation__actions {
+    flex-direction: column-reverse;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .backfill-spinner {
+    animation: none;
+  }
+}
+
+:host-context(html.high-contrast) .backfill-state,
+:host-context(html.high-contrast) .backfill-status,
+:host-context(html.high-contrast) .backfill-card,
+:host-context(html.high-contrast) .metric-card,
+:host-context(html.high-contrast) .backfill-notice,
+:host-context(html.high-contrast) .reset-confirmation,
+:host-context(html.high-contrast) .button,
+:host-context(html.high-contrast) .page-size-field input {
+  border-color: currentColor !important;
+  background: var(--background-color) !important;
+  color: var(--text-color) !important;
+  box-shadow: none !important;
+}

--- a/src/app/admin-dashboard/photo-ranking-backfill/photo-ranking-backfill.component.html
+++ b/src/app/admin-dashboard/photo-ranking-backfill/photo-ranking-backfill.component.html
@@ -1,0 +1,308 @@
+<section class="backfill-page" aria-labelledby="backfill-title">
+  <header class="backfill-page__header">
+    <div>
+      <p class="backfill-page__eyebrow">Operação de mídia</p>
+      <h2 id="backfill-title">Ranking de fotos</h2>
+      <p class="backfill-page__description">
+        Acompanhe e controle a migração das fotos antigas para o ranking canônico.
+      </p>
+    </div>
+
+    <button
+      class="button button--secondary"
+      type="button"
+      [disabled]="isBusy() || statusCooldown().active"
+      (click)="refresh()"
+    >
+      {{ statusCooldown().active
+        ? 'Atualizar em ' + statusCooldown().remainingSeconds + 's'
+        : 'Atualizar status' }}
+    </button>
+  </header>
+
+  <p
+    *ngIf="cooldownMessage()"
+    class="backfill-notice backfill-notice--warning"
+    role="status"
+    aria-live="polite"
+  >
+    {{ cooldownMessage() }}
+  </p>
+
+  <ng-container *ngIf="panelState() as panel">
+    <div
+      *ngIf="panel.status === 'loading'"
+      class="backfill-state backfill-state--loading"
+      role="status"
+      aria-live="polite"
+    >
+      <span class="backfill-spinner" aria-hidden="true"></span>
+      <div>
+        <strong>Carregando a migração</strong>
+        <p>Consultando o estado seguro do backfill.</p>
+      </div>
+    </div>
+
+    <div
+      *ngIf="panel.status === 'error'"
+      class="backfill-state backfill-state--error"
+      role="alert"
+    >
+      <div>
+        <strong>Não foi possível carregar o status</strong>
+        <p>O erro foi encaminhado ao tratamento global. Tente atualizar novamente.</p>
+      </div>
+      <button
+        class="button button--secondary"
+        type="button"
+        [disabled]="statusCooldown().active"
+        (click)="refresh()"
+      >
+        Tentar novamente
+      </button>
+    </div>
+
+    <ng-container *ngIf="panel.status === 'ready' && panel.data as data">
+      <div class="backfill-status" aria-live="polite">
+        <div>
+          <span
+            class="status-badge"
+            [attr.data-tone]="statusTone(data.state.status)"
+          >
+            {{ statusLabel(data.state.status) }}
+          </span>
+          <p>{{ statusDescription(data.state.status) }}</p>
+        </div>
+
+        <dl class="backfill-status__meta">
+          <div>
+            <dt>Versão</dt>
+            <dd>{{ data.state.version }}</dd>
+          </div>
+          <div>
+            <dt>Geração</dt>
+            <dd>{{ data.state.generation }}</dd>
+          </div>
+          <div>
+            <dt>Lote ativo</dt>
+            <dd>{{ data.leaseActive ? 'Sim' : 'Não' }}</dd>
+          </div>
+          <div>
+            <dt>Última atividade</dt>
+            <dd>{{ lastActivityAt(data) | date:'dd/MM/yyyy HH:mm' }}</dd>
+          </div>
+        </dl>
+      </div>
+
+      <div class="metric-grid" aria-label="Métricas da migração">
+        <article class="metric-card">
+          <span>Fotos examinadas</span>
+          <strong>{{ data.state.processedCount | number:'1.0-0' }}</strong>
+          <small>Documentos percorridos pelo cursor</small>
+        </article>
+
+        <article class="metric-card">
+          <span>Fotos atualizadas</span>
+          <strong>{{ data.state.updatedCount | number:'1.0-0' }}</strong>
+          <small>Documentos que precisaram do ranking canônico</small>
+        </article>
+
+        <article class="metric-card">
+          <span>Fotos ignoradas</span>
+          <strong>{{ data.state.skippedCount | number:'1.0-0' }}</strong>
+          <small>Já corretas ou fora do conjunto elegível</small>
+        </article>
+
+        <article class="metric-card">
+          <span>Lotes concluídos</span>
+          <strong>{{ data.state.pagesCount | number:'1.0-0' }}</strong>
+          <small>{{ data.state.pageSize }} documentos por lote</small>
+        </article>
+      </div>
+
+      <section class="backfill-card" aria-labelledby="quality-title">
+        <div class="backfill-card__heading">
+          <div>
+            <h3 id="quality-title">Resultado dos documentos examinados</h3>
+            <p>
+              Esta barra mostra a proporção que exigiu atualização. Ela não representa
+              o percentual total da migração, pois o backfill não expõe a quantidade
+              global de fotos antes de percorrer a coleção.
+            </p>
+          </div>
+          <strong>{{ updateRate(data) }}%</strong>
+        </div>
+
+        <progress
+          class="backfill-progress"
+          [value]="data.state.updatedCount"
+          [max]="data.state.processedCount || 1"
+        >
+          {{ updateRate(data) }}%
+        </progress>
+      </section>
+
+      <section
+        *ngIf="data.state.lastErrorMessage"
+        class="backfill-notice backfill-notice--danger"
+        role="alert"
+        aria-labelledby="backfill-error-title"
+      >
+        <div>
+          <strong id="backfill-error-title">Última falha registrada</strong>
+          <p>{{ data.state.lastErrorMessage }}</p>
+          <small *ngIf="data.state.lastErrorCode">
+            Código: {{ data.state.lastErrorCode }}
+          </small>
+        </div>
+      </section>
+
+      <section class="backfill-card" aria-labelledby="controls-title">
+        <div class="backfill-card__heading backfill-card__heading--controls">
+          <div>
+            <h3 id="controls-title">Controle da migração</h3>
+            <p>
+              As ações são protegidas por App Check, autorização administrativa,
+              idempotência e limite de chamadas.
+            </p>
+          </div>
+
+          <label class="page-size-field">
+            <span>Fotos por lote</span>
+            <input
+              type="number"
+              min="20"
+              max="180"
+              step="10"
+              [value]="pageSize()"
+              [disabled]="isBusy()"
+              aria-describedby="page-size-help"
+              (input)="onPageSizeInput($event)"
+            />
+            <small id="page-size-help">Entre 20 e 180. Padrão: 120.</small>
+          </label>
+        </div>
+
+        <div class="action-grid">
+          <button
+            *ngIf="canStartOrResume(data.state.status)"
+            class="button button--primary"
+            type="button"
+            [disabled]="isBusy() || actionCooldown().active"
+            (click)="startOrResume()"
+          >
+            {{ busyAction() === 'START_OR_RESUME' ? 'Retomando...' : 'Iniciar ou retomar' }}
+          </button>
+
+          <button
+            *ngIf="canPause(data.state.status)"
+            class="button button--secondary"
+            type="button"
+            [disabled]="isBusy() || actionCooldown().active"
+            (click)="pause()"
+          >
+            {{ busyAction() === 'PAUSE' ? 'Pausando...' : 'Pausar após o lote atual' }}
+          </button>
+
+          <button
+            *ngIf="canRunPage(data.state.status)"
+            class="button button--secondary"
+            type="button"
+            [disabled]="isBusy() || actionCooldown().active || data.leaseActive"
+            (click)="runPage()"
+          >
+            {{ busyAction() === 'RUN_PAGE' ? 'Executando lote...' : 'Executar próximo lote agora' }}
+          </button>
+
+          <button
+            class="button button--danger-ghost"
+            type="button"
+            [disabled]="isBusy() || actionCooldown().active || data.leaseActive"
+            (click)="beginReset()"
+          >
+            Reiniciar migração
+          </button>
+        </div>
+
+        <p
+          *ngIf="data.leaseActive"
+          class="backfill-inline-help"
+          role="status"
+        >
+          Um lote está em andamento. Novas execuções ficam bloqueadas até a liberação
+          do lease.
+        </p>
+
+        <div
+          *ngIf="resetConfirmation()"
+          class="reset-confirmation"
+          role="alertdialog"
+          aria-modal="false"
+          aria-labelledby="reset-title"
+          aria-describedby="reset-description"
+        >
+          <div>
+            <strong id="reset-title">Reiniciar desde o primeiro documento?</strong>
+            <p id="reset-description">
+              Uma nova geração será criada. Os scores corretos continuam preservados,
+              mas todas as fotos serão verificadas novamente.
+            </p>
+          </div>
+
+          <div class="reset-confirmation__actions">
+            <button
+              class="button button--secondary"
+              type="button"
+              [disabled]="isBusy()"
+              (click)="cancelReset()"
+            >
+              Cancelar
+            </button>
+            <button
+              class="button button--danger"
+              type="button"
+              [disabled]="isBusy()"
+              (click)="confirmReset()"
+            >
+              {{ busyAction() === 'RESET' ? 'Reiniciando...' : 'Confirmar reinício' }}
+            </button>
+          </div>
+        </div>
+      </section>
+
+      <section class="backfill-card backfill-card--compact" aria-labelledby="details-title">
+        <h3 id="details-title">Detalhes operacionais</h3>
+        <dl class="detail-list">
+          <div>
+            <dt>Falhas consecutivas</dt>
+            <dd>{{ data.state.consecutiveFailures }}</dd>
+          </div>
+          <div>
+            <dt>Início</dt>
+            <dd>
+              {{ data.state.startedAt
+                ? (data.state.startedAt | date:'dd/MM/yyyy HH:mm')
+                : 'Não iniciado' }}
+            </dd>
+          </div>
+          <div>
+            <dt>Último lote</dt>
+            <dd>
+              {{ data.state.lastBatchAt
+                ? (data.state.lastBatchAt | date:'dd/MM/yyyy HH:mm')
+                : 'Nenhum lote concluído' }}
+            </dd>
+          </div>
+          <div>
+            <dt>Conclusão</dt>
+            <dd>
+              {{ data.state.completedAt
+                ? (data.state.completedAt | date:'dd/MM/yyyy HH:mm')
+                : 'Em aberto' }}
+            </dd>
+          </div>
+        </dl>
+      </section>
+    </ng-container>
+  </ng-container>
+</section>

--- a/src/app/admin-dashboard/photo-ranking-backfill/photo-ranking-backfill.component.ts
+++ b/src/app/admin-dashboard/photo-ranking-backfill/photo-ranking-backfill.component.ts
@@ -1,0 +1,348 @@
+import { CommonModule } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { BehaviorSubject, Observable, merge, of, timer } from 'rxjs';
+import {
+  catchError,
+  finalize,
+  map,
+  shareReplay,
+  startWith,
+  switchMap,
+  tap,
+} from 'rxjs/operators';
+
+import {
+  ICallableCooldownState,
+} from 'src/app/core/services/error-handler/callable-cooldown.policy';
+import {
+  CallableCooldownService,
+} from 'src/app/core/services/error-handler/callable-cooldown.service';
+import { ErrorNotificationService } from 'src/app/core/services/error-handler/error-notification.service';
+import {
+  AdminPhotoRankingBackfillAction,
+  AdminPhotoRankingBackfillStatus,
+  AdminPhotoRankingBackfillService,
+  IAdminPhotoRankingBackfillControlResult,
+  IAdminPhotoRankingBackfillStatusResponse,
+} from 'src/app/core/services/media/admin-photo-ranking-backfill.service';
+
+type PanelLoadStatus = 'loading' | 'ready' | 'error';
+
+interface PhotoRankingBackfillPanelState {
+  status: PanelLoadStatus;
+  data: IAdminPhotoRankingBackfillStatusResponse | null;
+}
+
+const STATUS_REFRESH_INTERVAL_MS = 30_000;
+const DEFAULT_PAGE_SIZE = 120;
+const MIN_PAGE_SIZE = 20;
+const MAX_PAGE_SIZE = 180;
+const COOLDOWN_SCOPE = {
+  status: 'admin-photo-ranking-backfill-status',
+  action: 'admin-photo-ranking-backfill-action',
+} as const;
+
+function inactiveCooldown(scope: string): ICallableCooldownState {
+  return {
+    scope,
+    active: false,
+    expiresAt: 0,
+    remainingMs: 0,
+    remainingSeconds: 0,
+  };
+}
+
+@Component({
+  selector: 'app-photo-ranking-backfill',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './photo-ranking-backfill.component.html',
+  styleUrls: ['./photo-ranking-backfill.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PhotoRankingBackfillComponent {
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly backfill = inject(AdminPhotoRankingBackfillService);
+  private readonly notifications = inject(ErrorNotificationService);
+  private readonly cooldowns = inject(CallableCooldownService);
+  private readonly refreshSubject = new BehaviorSubject<number>(0);
+
+  readonly busyAction = signal<AdminPhotoRankingBackfillAction | null>(null);
+  readonly resetConfirmation = signal(false);
+  readonly pageSize = signal(DEFAULT_PAGE_SIZE);
+  private readonly pageSizeTouched = signal(false);
+
+  readonly statusCooldown = toSignal(
+    this.cooldowns.state$(COOLDOWN_SCOPE.status),
+    { initialValue: inactiveCooldown(COOLDOWN_SCOPE.status) }
+  );
+  readonly actionCooldown = toSignal(
+    this.cooldowns.state$(COOLDOWN_SCOPE.action),
+    { initialValue: inactiveCooldown(COOLDOWN_SCOPE.action) }
+  );
+
+  readonly cooldownMessage = computed(() => {
+    const active = [this.statusCooldown(), this.actionCooldown()]
+      .filter((state) => state.active);
+
+    if (!active.length) {
+      return '';
+    }
+
+    const remainingSeconds = Math.max(
+      ...active.map((state) => state.remainingSeconds)
+    );
+
+    return `Proteção contra excesso de chamadas ativa. Tente novamente em ${remainingSeconds} segundo(s).`;
+  });
+
+  readonly panelState$: Observable<PhotoRankingBackfillPanelState> = merge(
+    this.refreshSubject,
+    timer(STATUS_REFRESH_INTERVAL_MS, STATUS_REFRESH_INTERVAL_MS)
+  ).pipe(
+    switchMap(() =>
+      this.backfill.getStatus$().pipe(
+        tap((data) => {
+          if (!this.pageSizeTouched()) {
+            this.pageSize.set(data.state.pageSize);
+          }
+        }),
+        map((data) => ({
+          status: 'ready',
+          data,
+        } as PhotoRankingBackfillPanelState)),
+        startWith({
+          status: 'loading',
+          data: null,
+        } as PhotoRankingBackfillPanelState),
+        catchError((error) => {
+          this.cooldowns.captureResourceExhausted(
+            error,
+            COOLDOWN_SCOPE.status,
+            3_000
+          );
+
+          return of({
+            status: 'error',
+            data: null,
+          } as PhotoRankingBackfillPanelState);
+        })
+      )
+    ),
+    shareReplay({ bufferSize: 1, refCount: true })
+  );
+
+  readonly panelState = toSignal(this.panelState$, {
+    initialValue: {
+      status: 'loading',
+      data: null,
+    } as PhotoRankingBackfillPanelState,
+  });
+
+  readonly isBusy = computed(() => this.busyAction() !== null);
+
+  refresh(): void {
+    if (this.cooldowns.notifyIfActive(COOLDOWN_SCOPE.status)) {
+      return;
+    }
+
+    this.refreshSubject.next(this.refreshSubject.value + 1);
+  }
+
+  onPageSizeInput(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const numeric = Number(input.value);
+    const normalized = Number.isFinite(numeric)
+      ? Math.max(MIN_PAGE_SIZE, Math.min(MAX_PAGE_SIZE, Math.trunc(numeric)))
+      : DEFAULT_PAGE_SIZE;
+
+    this.pageSize.set(normalized);
+    this.pageSizeTouched.set(true);
+  }
+
+  startOrResume(): void {
+    this.executeAction('START_OR_RESUME');
+  }
+
+  pause(): void {
+    this.executeAction('PAUSE');
+  }
+
+  runPage(): void {
+    this.executeAction('RUN_PAGE');
+  }
+
+  beginReset(): void {
+    if (this.isBusy() || this.actionCooldown().active) {
+      this.cooldowns.notifyIfActive(COOLDOWN_SCOPE.action);
+      return;
+    }
+
+    this.resetConfirmation.set(true);
+  }
+
+  cancelReset(): void {
+    this.resetConfirmation.set(false);
+  }
+
+  confirmReset(): void {
+    if (!this.resetConfirmation()) {
+      return;
+    }
+
+    this.executeAction('RESET');
+  }
+
+  canStartOrResume(status: AdminPhotoRankingBackfillStatus): boolean {
+    return status === 'IDLE' || status === 'PAUSED' || status === 'FAILED';
+  }
+
+  canPause(status: AdminPhotoRankingBackfillStatus): boolean {
+    return status === 'RUNNING';
+  }
+
+  canRunPage(status: AdminPhotoRankingBackfillStatus): boolean {
+    return status !== 'COMPLETED';
+  }
+
+  statusLabel(status: AdminPhotoRankingBackfillStatus): string {
+    switch (status) {
+      case 'IDLE':
+        return 'Não iniciado';
+      case 'RUNNING':
+        return 'Em execução';
+      case 'PAUSED':
+        return 'Pausado';
+      case 'COMPLETED':
+        return 'Concluído';
+      case 'FAILED':
+        return 'Interrompido por falhas';
+    }
+  }
+
+  statusDescription(status: AdminPhotoRankingBackfillStatus): string {
+    switch (status) {
+      case 'IDLE':
+        return 'A migração ainda não processou nenhum lote.';
+      case 'RUNNING':
+        return 'O scheduler continuará processando páginas automaticamente.';
+      case 'PAUSED':
+        return 'O cursor foi preservado e a execução automática está suspensa.';
+      case 'COMPLETED':
+        return 'Todas as fotos alcançadas pelo cursor foram verificadas.';
+      case 'FAILED':
+        return 'Cinco falhas consecutivas bloquearam a retomada automática.';
+    }
+  }
+
+  statusTone(status: AdminPhotoRankingBackfillStatus): string {
+    switch (status) {
+      case 'RUNNING':
+        return 'info';
+      case 'COMPLETED':
+        return 'success';
+      case 'PAUSED':
+      case 'IDLE':
+        return 'warning';
+      case 'FAILED':
+        return 'danger';
+    }
+  }
+
+  updateRate(data: IAdminPhotoRankingBackfillStatusResponse): number {
+    const processed = data.state.processedCount;
+    return processed > 0
+      ? Math.round((data.state.updatedCount / processed) * 100)
+      : 0;
+  }
+
+  lastActivityAt(data: IAdminPhotoRankingBackfillStatusResponse): number {
+    return data.state.lastBatchAt ?? data.state.updatedAt ?? data.checkedAt;
+  }
+
+  private executeAction(action: AdminPhotoRankingBackfillAction): void {
+    if (
+      this.isBusy() ||
+      this.cooldowns.notifyIfActive(COOLDOWN_SCOPE.action)
+    ) {
+      return;
+    }
+
+    this.busyAction.set(action);
+
+    this.backfill.control$({
+      action,
+      operationId: this.createOperationId(action),
+      pageSize: this.pageSize(),
+    }).pipe(
+      finalize(() => this.busyAction.set(null)),
+      takeUntilDestroyed(this.destroyRef)
+    ).subscribe({
+      next: (result) => {
+        this.resetConfirmation.set(false);
+        this.pageSize.set(result.state.pageSize);
+        this.pageSizeTouched.set(false);
+        this.notifications.showSuccess(this.successMessage(result));
+        this.refreshSubject.next(this.refreshSubject.value + 1);
+      },
+      error: (error) => {
+        if (
+          !this.cooldowns.captureResourceExhausted(
+            error,
+            COOLDOWN_SCOPE.action,
+            5_000
+          ) &&
+          !this.cooldowns.wasHandled(error)
+        ) {
+          this.notifications.showError(
+            'Não foi possível concluir a ação no backfill de ranking.'
+          );
+        } else if (!this.cooldowns.wasHandled(error)) {
+          this.notifications.showError(
+            'Não foi possível concluir a ação no backfill de ranking.'
+          );
+        }
+      },
+    });
+  }
+
+  private successMessage(
+    result: IAdminPhotoRankingBackfillControlResult
+  ): string {
+    if (result.alreadyApplied) {
+      return 'Esta operação já havia sido aplicada anteriormente.';
+    }
+
+    switch (result.action) {
+      case 'START_OR_RESUME':
+        return 'Migração retomada. O scheduler continuará pelos próximos lotes.';
+      case 'PAUSE':
+        return 'Pausa registrada. O lote ativo terminará antes da interrupção.';
+      case 'RESET':
+        return 'Nova geração criada. A migração recomeçará do primeiro documento.';
+      case 'RUN_PAGE':
+        if (!result.batch?.acquired) {
+          return 'Já existe um lote ativo. Nenhum processamento paralelo foi iniciado.';
+        }
+
+        return `Lote concluído: ${result.batch.processed} foto(s) examinada(s), ${result.batch.updated} atualizada(s) e ${result.batch.skipped} ignorada(s).`;
+    }
+  }
+
+  private createOperationId(action: AdminPhotoRankingBackfillAction): string {
+    const randomId = globalThis.crypto?.randomUUID?.() ??
+      `${Date.now()}_${Math.random().toString(36).slice(2)}`;
+
+    return `photo_rank_${action.toLowerCase()}_${randomId}`
+      .replace(/[^A-Za-z0-9_-]/g, '_')
+      .slice(0, 128);
+  }
+}

--- a/src/app/core/services/media/admin-photo-ranking-backfill.service.spec.ts
+++ b/src/app/core/services/media/admin-photo-ranking-backfill.service.spec.ts
@@ -40,10 +40,10 @@ describe('AdminPhotoRankingBackfillService normalização', () => {
       generation: 1,
     });
 
-    expect('cursorPath' in state).toBeFalse();
-    expect('leaseOwner' in state).toBeFalse();
-    expect('lastAdminOperationId' in state).toBeFalse();
-    expect('lastAdminBy' in state).toBeFalse();
+    expect('cursorPath' in state).toBe(false);
+    expect('leaseOwner' in state).toBe(false);
+    expect('lastAdminOperationId' in state).toBe(false);
+    expect('lastAdminBy' in state).toBe(false);
   });
 
   it('preserva apenas status, métricas e erro sanitizado', () => {
@@ -70,7 +70,7 @@ describe('AdminPhotoRankingBackfillService normalização', () => {
       checkedAt: 2100,
     });
 
-    expect(response.leaseActive).toBeTrue();
+    expect(response.leaseActive).toBe(true);
     expect(response.checkedAt).toBe(2100);
     expect(response.state.status).toBe('FAILED');
     expect(response.state.processedCount).toBe(500);
@@ -82,7 +82,7 @@ describe('AdminPhotoRankingBackfillService normalização', () => {
   it('aplica valores seguros a respostas ausentes', () => {
     const response = normalizeAdminPhotoRankingBackfillStatusResponse(null);
 
-    expect(response.leaseActive).toBeFalse();
+    expect(response.leaseActive).toBe(false);
     expect(response.checkedAt).toBe(0);
     expect(response.state.status).toBe('IDLE');
     expect(response.state.pageSize).toBe(120);

--- a/src/app/core/services/media/admin-photo-ranking-backfill.service.spec.ts
+++ b/src/app/core/services/media/admin-photo-ranking-backfill.service.spec.ts
@@ -1,0 +1,91 @@
+import {
+  normalizeAdminPhotoRankingBackfillState,
+  normalizeAdminPhotoRankingBackfillStatusResponse,
+} from './admin-photo-ranking-backfill.service';
+
+describe('AdminPhotoRankingBackfillService normalização', () => {
+  it('normaliza estado inválido sem expor campos internos', () => {
+    const state = normalizeAdminPhotoRankingBackfillState({
+      version: '4',
+      status: 'running',
+      pageSize: 999,
+      processedCount: '120',
+      updatedCount: -1,
+      skippedCount: 30.9,
+      pagesCount: 1,
+      consecutiveFailures: '2',
+      cursorPath: 'public_profiles/user/public_photos/photo',
+      leaseOwner: 'segredo-interno',
+      lastAdminOperationId: 'operacao-interna',
+      lastAdminBy: 'admin-interno',
+      generation: 0,
+    });
+
+    expect(state).toEqual({
+      version: 4,
+      status: 'RUNNING',
+      pageSize: 180,
+      processedCount: 120,
+      updatedCount: 0,
+      skippedCount: 30,
+      pagesCount: 1,
+      consecutiveFailures: 2,
+      startedAt: null,
+      updatedAt: 0,
+      completedAt: null,
+      lastBatchAt: null,
+      lastErrorCode: null,
+      lastErrorMessage: null,
+      lastAdminAction: null,
+      generation: 1,
+    });
+
+    expect('cursorPath' in state).toBeFalse();
+    expect('leaseOwner' in state).toBeFalse();
+    expect('lastAdminOperationId' in state).toBeFalse();
+    expect('lastAdminBy' in state).toBeFalse();
+  });
+
+  it('preserva apenas status, métricas e erro sanitizado', () => {
+    const response = normalizeAdminPhotoRankingBackfillStatusResponse({
+      state: {
+        version: 4,
+        status: 'FAILED',
+        pageSize: 120,
+        processedCount: 500,
+        updatedCount: 200,
+        skippedCount: 300,
+        pagesCount: 5,
+        consecutiveFailures: 5,
+        startedAt: 1000,
+        updatedAt: 2000,
+        completedAt: null,
+        lastBatchAt: 1900,
+        lastErrorCode: 'BACKFILL_BATCH_FAILED',
+        lastErrorMessage: 'Falha sanitizada.',
+        lastAdminAction: 'START_OR_RESUME',
+        generation: 2,
+      },
+      leaseActive: true,
+      checkedAt: 2100,
+    });
+
+    expect(response.leaseActive).toBeTrue();
+    expect(response.checkedAt).toBe(2100);
+    expect(response.state.status).toBe('FAILED');
+    expect(response.state.processedCount).toBe(500);
+    expect(response.state.lastErrorCode).toBe('BACKFILL_BATCH_FAILED');
+    expect(response.state.lastErrorMessage).toBe('Falha sanitizada.');
+    expect(response.state.generation).toBe(2);
+  });
+
+  it('aplica valores seguros a respostas ausentes', () => {
+    const response = normalizeAdminPhotoRankingBackfillStatusResponse(null);
+
+    expect(response.leaseActive).toBeFalse();
+    expect(response.checkedAt).toBe(0);
+    expect(response.state.status).toBe('IDLE');
+    expect(response.state.pageSize).toBe(120);
+    expect(response.state.generation).toBe(1);
+  });
+});

--- a/src/app/core/services/media/admin-photo-ranking-backfill.service.ts
+++ b/src/app/core/services/media/admin-photo-ranking-backfill.service.ts
@@ -1,0 +1,332 @@
+import { Injectable, inject } from '@angular/core';
+import { Functions, httpsCallable } from '@angular/fire/functions';
+import { Observable, defer, from, throwError } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+
+import { GlobalErrorHandlerService } from '../error-handler/global-error-handler.service';
+
+export type AdminPhotoRankingBackfillStatus =
+  | 'IDLE'
+  | 'RUNNING'
+  | 'PAUSED'
+  | 'COMPLETED'
+  | 'FAILED';
+
+export type AdminPhotoRankingBackfillAction =
+  | 'START_OR_RESUME'
+  | 'PAUSE'
+  | 'RUN_PAGE'
+  | 'RESET';
+
+export interface IAdminPhotoRankingBackfillState {
+  version: number;
+  status: AdminPhotoRankingBackfillStatus;
+  pageSize: number;
+  processedCount: number;
+  updatedCount: number;
+  skippedCount: number;
+  pagesCount: number;
+  consecutiveFailures: number;
+  startedAt: number | null;
+  updatedAt: number;
+  completedAt: number | null;
+  lastBatchAt: number | null;
+  lastErrorCode: string | null;
+  lastErrorMessage: string | null;
+  lastAdminAction: AdminPhotoRankingBackfillAction | null;
+  generation: number;
+}
+
+export interface IAdminPhotoRankingBackfillStatusResponse {
+  state: IAdminPhotoRankingBackfillState;
+  leaseActive: boolean;
+  checkedAt: number;
+}
+
+export interface IAdminPhotoRankingBackfillBatchResult {
+  acquired: boolean;
+  completed: boolean;
+  processed: number;
+  updated: number;
+  skipped: number;
+  status: AdminPhotoRankingBackfillStatus;
+}
+
+export interface IAdminPhotoRankingBackfillControlResult {
+  action: AdminPhotoRankingBackfillAction;
+  alreadyApplied: boolean;
+  state: IAdminPhotoRankingBackfillState;
+  batch: IAdminPhotoRankingBackfillBatchResult | null;
+}
+
+interface RawBackfillState {
+  version?: unknown;
+  status?: unknown;
+  pageSize?: unknown;
+  processedCount?: unknown;
+  updatedCount?: unknown;
+  skippedCount?: unknown;
+  pagesCount?: unknown;
+  consecutiveFailures?: unknown;
+  startedAt?: unknown;
+  updatedAt?: unknown;
+  completedAt?: unknown;
+  lastBatchAt?: unknown;
+  lastErrorCode?: unknown;
+  lastErrorMessage?: unknown;
+  lastAdminAction?: unknown;
+  generation?: unknown;
+}
+
+interface RawStatusResponse {
+  state?: RawBackfillState;
+  leaseActive?: unknown;
+  checkedAt?: unknown;
+}
+
+interface RawBatchResult {
+  acquired?: unknown;
+  completed?: unknown;
+  processed?: unknown;
+  updated?: unknown;
+  skipped?: unknown;
+  status?: unknown;
+}
+
+interface RawControlResponse {
+  action?: unknown;
+  alreadyApplied?: unknown;
+  state?: RawBackfillState;
+  batch?: RawBatchResult | null;
+}
+
+interface ControlRequest {
+  action: AdminPhotoRankingBackfillAction;
+  operationId: string;
+  pageSize: number;
+}
+
+const DEFAULT_PAGE_SIZE = 120;
+const MIN_PAGE_SIZE = 20;
+const MAX_PAGE_SIZE = 180;
+
+function normalizeNonNegativeInteger(value: unknown): number {
+  const numeric = Number(value ?? 0);
+  return Number.isFinite(numeric) && numeric >= 0 ? Math.trunc(numeric) : 0;
+}
+
+function normalizeNullableTimestamp(value: unknown): number | null {
+  const timestamp = normalizeNonNegativeInteger(value);
+  return timestamp > 0 ? timestamp : null;
+}
+
+function normalizePageSize(value: unknown): number {
+  const numeric = Number(value ?? DEFAULT_PAGE_SIZE);
+
+  if (!Number.isFinite(numeric)) {
+    return DEFAULT_PAGE_SIZE;
+  }
+
+  return Math.max(MIN_PAGE_SIZE, Math.min(MAX_PAGE_SIZE, Math.trunc(numeric)));
+}
+
+function normalizeStatus(value: unknown): AdminPhotoRankingBackfillStatus {
+  const status = String(value ?? '').trim().toUpperCase();
+
+  if (
+    status === 'IDLE' ||
+    status === 'RUNNING' ||
+    status === 'PAUSED' ||
+    status === 'COMPLETED' ||
+    status === 'FAILED'
+  ) {
+    return status;
+  }
+
+  return 'IDLE';
+}
+
+function normalizeAction(value: unknown): AdminPhotoRankingBackfillAction | null {
+  const action = String(value ?? '').trim().toUpperCase();
+
+  if (
+    action === 'START_OR_RESUME' ||
+    action === 'PAUSE' ||
+    action === 'RUN_PAGE' ||
+    action === 'RESET'
+  ) {
+    return action;
+  }
+
+  return null;
+}
+
+function normalizeOptionalText(value: unknown, maxLength: number): string | null {
+  const text = String(value ?? '').trim().slice(0, maxLength);
+  return text || null;
+}
+
+export function normalizeAdminPhotoRankingBackfillState(
+  value: unknown
+): IAdminPhotoRankingBackfillState {
+  const state = typeof value === 'object' && value !== null
+    ? value as RawBackfillState
+    : {};
+
+  return {
+    version: normalizeNonNegativeInteger(state.version),
+    status: normalizeStatus(state.status),
+    pageSize: normalizePageSize(state.pageSize),
+    processedCount: normalizeNonNegativeInteger(state.processedCount),
+    updatedCount: normalizeNonNegativeInteger(state.updatedCount),
+    skippedCount: normalizeNonNegativeInteger(state.skippedCount),
+    pagesCount: normalizeNonNegativeInteger(state.pagesCount),
+    consecutiveFailures: normalizeNonNegativeInteger(
+      state.consecutiveFailures
+    ),
+    startedAt: normalizeNullableTimestamp(state.startedAt),
+    updatedAt: normalizeNonNegativeInteger(state.updatedAt),
+    completedAt: normalizeNullableTimestamp(state.completedAt),
+    lastBatchAt: normalizeNullableTimestamp(state.lastBatchAt),
+    lastErrorCode: normalizeOptionalText(state.lastErrorCode, 100),
+    lastErrorMessage: normalizeOptionalText(state.lastErrorMessage, 300),
+    lastAdminAction: normalizeAction(state.lastAdminAction),
+    generation: Math.max(1, normalizeNonNegativeInteger(state.generation)),
+  };
+}
+
+export function normalizeAdminPhotoRankingBackfillStatusResponse(
+  value: unknown
+): IAdminPhotoRankingBackfillStatusResponse {
+  const response = typeof value === 'object' && value !== null
+    ? value as RawStatusResponse
+    : {};
+
+  return {
+    state: normalizeAdminPhotoRankingBackfillState(response.state),
+    leaseActive: response.leaseActive === true,
+    checkedAt: normalizeNonNegativeInteger(response.checkedAt),
+  };
+}
+
+function normalizeBatchResult(
+  value: RawBatchResult | null | undefined
+): IAdminPhotoRankingBackfillBatchResult | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  return {
+    acquired: value.acquired === true,
+    completed: value.completed === true,
+    processed: normalizeNonNegativeInteger(value.processed),
+    updated: normalizeNonNegativeInteger(value.updated),
+    skipped: normalizeNonNegativeInteger(value.skipped),
+    status: normalizeStatus(value.status),
+  };
+}
+
+@Injectable({ providedIn: 'root' })
+export class AdminPhotoRankingBackfillService {
+  private readonly functions = inject(Functions);
+  private readonly globalErrorHandler = inject(GlobalErrorHandlerService);
+
+  getStatus$(): Observable<IAdminPhotoRankingBackfillStatusResponse> {
+    return defer(() => {
+      const callable = httpsCallable<
+        Record<string, never>,
+        RawStatusResponse
+      >(this.functions, 'getPhotoRankingBackfillStatus');
+
+      return from(callable({}));
+    }).pipe(
+      map((response) =>
+        normalizeAdminPhotoRankingBackfillStatusResponse(response.data)
+      ),
+      catchError((error) => {
+        this.reportError(error, 'getStatus$', {});
+        return throwError(() => error);
+      })
+    );
+  }
+
+  control$(command: {
+    action: AdminPhotoRankingBackfillAction;
+    operationId: string;
+    pageSize: number;
+  }): Observable<IAdminPhotoRankingBackfillControlResult> {
+    const payload: ControlRequest = {
+      action: command.action,
+      operationId: this.normalizeOperationId(command.operationId),
+      pageSize: normalizePageSize(command.pageSize),
+    };
+
+    if (!payload.operationId) {
+      return throwError(
+        () => new Error('Identificador da operação administrativa inválido.')
+      );
+    }
+
+    return defer(() => {
+      const callable = httpsCallable<ControlRequest, RawControlResponse>(
+        this.functions,
+        'controlPhotoRankingBackfill'
+      );
+
+      return from(callable(payload));
+    }).pipe(
+      map((response) => {
+        const action = normalizeAction(response.data?.action);
+
+        if (!action) {
+          throw new Error('Resposta inválida do controle de backfill.');
+        }
+
+        return {
+          action,
+          alreadyApplied: response.data?.alreadyApplied === true,
+          state: normalizeAdminPhotoRankingBackfillState(
+            response.data?.state
+          ),
+          batch: normalizeBatchResult(response.data?.batch),
+        };
+      }),
+      catchError((error) => {
+        this.reportError(error, 'control$', {
+          action: payload.action,
+          pageSize: payload.pageSize,
+        });
+        return throwError(() => error);
+      })
+    );
+  }
+
+  private normalizeOperationId(value: unknown): string {
+    const operationId = String(value ?? '').trim();
+    return /^[A-Za-z0-9_-]{8,128}$/.test(operationId) ? operationId : '';
+  }
+
+  private reportError(
+    error: unknown,
+    operation: string,
+    context: Record<string, unknown>
+  ): void {
+    try {
+      const normalized = error instanceof Error
+        ? error
+        : new Error('Falha no painel de migração do ranking de fotos.');
+
+      (normalized as any).original = error;
+      (normalized as any).context = {
+        scope: 'AdminPhotoRankingBackfillService',
+        operation,
+        ...context,
+      };
+      (normalized as any).skipUserNotification = true;
+
+      this.globalErrorHandler.handleError(normalized);
+    } catch {
+      // O painel não deve falhar caso a telemetria esteja indisponível.
+    }
+  }
+}


### PR DESCRIPTION
## Dependência

PR empilhado sobre o #61 (`agent/media-p0-photo-ranking-backfill`). Nenhum merge é realizado por este pacote.

## Escopo

Este pacote adiciona uma interface Angular administrativa para observar e controlar o backfill retomável do ranking de fotos.

A nova rota é:

- `/admin-dashboard/ranking-fotos`

Ela permanece protegida pelos guards administrativos já aplicados ao `AdminDashboardComponent` e às rotas filhas.

## Serviço Angular

Foi criado `AdminPhotoRankingBackfillService`, que encapsula as callables:

- `getPhotoRankingBackfillStatus`;
- `controlPhotoRankingBackfill`.

O serviço:

- usa `Observable`, `defer`, `from`, `map` e `catchError`;
- normaliza todos os campos recebidos;
- limita `pageSize` entre 20 e 180;
- valida `operationId`;
- encaminha falhas ao `GlobalErrorHandlerService` com contexto de debug;
- mantém a notificação visual sob responsabilidade do componente e do cooldown central.

## Ocultações intencionais

Embora o backend preserve dados internos para operação e auditoria, o DTO do navegador suprime:

- `cursorPath`;
- `leaseOwner`;
- `lastAdminOperationId`;
- `lastAdminBy`;
- o cursor retornado por um lote manual.

Esses campos não são necessários para operar a tela e poderiam expor detalhes internos de coordenação. O painel recebe somente status, métricas, geração, horários, ação anterior e erro sanitizado.

Nenhum campo foi removido do backend ou renomeado publicamente.

## Atualização reativa

O painel:

- carrega o estado por Observable;
- atualiza automaticamente a cada 30 segundos;
- permite atualização manual;
- usa `shareReplay` para evitar chamadas duplicadas;
- converte o estado para signal apenas na borda visual;
- cancela ações com `takeUntilDestroyed`;
- usa `ChangeDetectionStrategy.OnPush`.

## Métricas exibidas

- estado atual da migração;
- versão e geração;
- lote ativo;
- fotos examinadas;
- fotos atualizadas;
- fotos ignoradas;
- lotes concluídos;
- tamanho da página;
- falhas consecutivas;
- início, último lote e conclusão;
- último erro sanitizado.

A barra visual mostra somente a proporção de documentos examinados que exigiram atualização. O texto explicita que ela não representa o percentual total da migração, pois o backend não faz uma contagem global antecipada.

## Controles

O administrador pode:

- iniciar ou retomar;
- pausar após o lote atual;
- executar o próximo lote imediatamente;
- reiniciar a migração em uma nova geração;
- ajustar o tamanho do lote entre 20 e 180.

O reinício exige confirmação explícita. Ações ficam bloqueadas durante execução local, lease ativo ou cooldown.

## Cooldown e feedback

O painel reutiliza `CallableCooldownService` criado no #58.

- consulta de status e ações usam escopos separados;
- `resource-exhausted` mostra o tempo restante;
- botões permanecem desabilitados durante o cooldown;
- mensagens de sucesso diferenciam pausa, retomada, reset, lote executado e operação já aplicada;
- erros não relacionados ao rate limiting recebem mensagem segura ao administrador.

## Acessibilidade e mobile

- estrutura semântica com títulos e regiões;
- `aria-live` para status e cooldown;
- `role="alert"` para falhas;
- `alertdialog` para confirmação de reset;
- foco visível;
- botões com texto completo;
- `progress` nativo;
- layout em uma coluna em telas pequenas;
- navegação administrativa horizontal rolável já preservada;
- suporte a contraste elevado e `prefers-reduced-motion`.

## Supressões e substituições

Nenhum código funcional existente foi suprimido.

Foram apenas adicionados:

- um link à navegação administrativa;
- uma rota filha;
- o serviço e a tela do backfill;
- testes do DTO seguro.

As demais rotas, telas, guards, serviços e ações administrativas permanecem inalterados.

## Testes adicionados

- normalização de números e status;
- limite de `pageSize`;
- valores seguros para resposta ausente;
- preservação de erro sanitizado;
- verificação explícita de que cursor, lease, operationId e identidade administrativa não entram no DTO visual.

## Validação concluída

- testes Angular: aprovados;
- compilação do template e do componente standalone: aprovada;
- build Angular seguro: aprovado;
- Angular CI Validation: aprovado;
- configuração do Emulator: aprovada;
- lint, build e testes das Functions herdadas: aprovados;
- Firestore Rules: aprovadas;
- índices do Firestore: aprovados;
- Quality Gate agregado: aprovado.

O primeiro run compilou a aplicação, mas interrompeu a suíte porque o novo teste usava matchers Jasmine (`toBeTrue`/`toBeFalse`) em um projeto configurado com Vitest. Os matchers foram substituídos por `toBe(true/false)` em um commit isolado. O segundo Quality Gate e o Angular CI passaram integralmente, sem alteração funcional no painel.