### PR TITLE
fix(media): integrar formatos e contrato do backfill

### DIFF
--- a/functions/src/media/application/photo-ranking-backfill.handler.ts
+++ b/functions/src/media/application/photo-ranking-backfill.handler.ts
@@ -14,14 +14,18 @@ import {
   PHOTO_RANKING_BACKFILL_ID,
   PHOTO_RANKING_BACKFILL_LEASE_MS,
   type PhotoRankingBackfillControlAction,
+  type PhotoRankingBackfillPublicState,
   type PhotoRankingBackfillState,
   buildInitialPhotoRankingBackfillState,
+  buildPhotoRankingBackfillPublicState,
   isPhotoRankingBackfillLeaseAvailable,
   nextPhotoRankingBackfillFailureStatus,
   normalizePhotoRankingBackfillAction,
   normalizePhotoRankingBackfillOperationId,
   normalizePhotoRankingBackfillPageSize,
   normalizePhotoRankingBackfillState,
+  resolvePhotoRankingBackfillControlStatus,
+  resolvePhotoRankingBackfillPostBatchStatus,
 } from './photo-ranking-backfill.policy';
 import {
   buildPhotoRankingUpdate,
@@ -37,7 +41,7 @@ interface ControlPhotoRankingBackfillRequest {
   pageSize?: number;
 }
 
-interface PhotoRankingBackfillBatchResult {
+interface InternalPhotoRankingBackfillBatchResult {
   acquired: boolean;
   completed: boolean;
   processed: number;
@@ -47,8 +51,17 @@ interface PhotoRankingBackfillBatchResult {
   status: PhotoRankingBackfillState['status'];
 }
 
+interface PhotoRankingBackfillBatchResult {
+  acquired: boolean;
+  completed: boolean;
+  processed: number;
+  updated: number;
+  skipped: number;
+  status: PhotoRankingBackfillState['status'];
+}
+
 interface PhotoRankingBackfillStatusResponse {
-  state: PhotoRankingBackfillState;
+  state: PhotoRankingBackfillPublicState;
   leaseActive: boolean;
   checkedAt: number;
 }
@@ -56,7 +69,7 @@ interface PhotoRankingBackfillStatusResponse {
 interface ControlPhotoRankingBackfillResponse {
   action: PhotoRankingBackfillControlAction;
   alreadyApplied: boolean;
-  state: PhotoRankingBackfillState;
+  state: PhotoRankingBackfillPublicState;
   batch: PhotoRankingBackfillBatchResult | null;
 }
 
@@ -73,10 +86,20 @@ function stateRef(): FirebaseFirestore.DocumentReference {
 
 function stateForResponse(
   state: PhotoRankingBackfillState
-): PhotoRankingBackfillState {
+): PhotoRankingBackfillPublicState {
+  return buildPhotoRankingBackfillPublicState(state);
+}
+
+function batchForResponse(
+  batch: InternalPhotoRankingBackfillBatchResult
+): PhotoRankingBackfillBatchResult {
   return {
-    ...state,
-    leaseOwner: state.leaseOwner ? 'active' : null,
+    acquired: batch.acquired,
+    completed: batch.completed,
+    processed: batch.processed,
+    updated: batch.updated,
+    skipped: batch.skipped,
+    status: batch.status,
   };
 }
 
@@ -93,6 +116,7 @@ async function readBackfillState(
 async function acquireBackfillLease(input: {
   runId: string;
   now: number;
+  allowPaused: boolean;
 }): Promise<PhotoRankingBackfillState | null> {
   const ref = stateRef();
 
@@ -103,9 +127,9 @@ async function acquireBackfillLease(input: {
       : buildInitialPhotoRankingBackfillState({ now: input.now });
 
     if (
-      state.status === 'PAUSED' ||
       state.status === 'COMPLETED' ||
-      state.status === 'FAILED'
+      state.status === 'FAILED' ||
+      (state.status === 'PAUSED' && !input.allowPaused)
     ) {
       return null;
     }
@@ -122,7 +146,9 @@ async function acquireBackfillLease(input: {
 
     const nextState: PhotoRankingBackfillState = {
       ...state,
-      status: 'RUNNING',
+      status: input.allowPaused && state.status === 'PAUSED'
+        ? 'PAUSED'
+        : 'RUNNING',
       startedAt: state.startedAt ?? input.now,
       leaseOwner: input.runId,
       leaseExpiresAt: input.now + PHOTO_RANKING_BACKFILL_LEASE_MS,
@@ -234,11 +260,10 @@ async function finalizeBackfillBatch(input: {
 
     const nextState: PhotoRankingBackfillState = {
       ...state,
-      status: state.status === 'PAUSED'
-        ? 'PAUSED'
-        : input.completed
-          ? 'COMPLETED'
-          : 'RUNNING',
+      status: resolvePhotoRankingBackfillPostBatchStatus({
+        currentStatus: state.status,
+        completed: input.completed,
+      }),
       cursorPath: input.cursorPath ?? state.cursorPath,
       processedCount: state.processedCount + input.processed,
       updatedCount: state.updatedCount + input.updated,
@@ -299,12 +324,16 @@ async function markBackfillBatchFailure(input: {
   });
 }
 
-export async function executePhotoRankingBackfillBatch(): Promise<
-  PhotoRankingBackfillBatchResult
-  > {
+export async function executePhotoRankingBackfillBatch(
+  options: { allowPaused?: boolean } = {}
+): Promise<InternalPhotoRankingBackfillBatchResult> {
   const runId = randomUUID();
   const startedAt = Date.now();
-  const leasedState = await acquireBackfillLease({ runId, now: startedAt });
+  const leasedState = await acquireBackfillLease({
+    runId,
+    now: startedAt,
+    allowPaused: options.allowPaused === true,
+  });
 
   if (!leasedState) {
     const state = await readBackfillState(startedAt);
@@ -418,6 +447,13 @@ async function applyAdminControl(input: {
       );
     }
 
+    if (current.status === 'FAILED' && input.action === 'RUN_PAGE') {
+      throw new HttpsError(
+        'failed-precondition',
+        'Retome a migração antes de executar um novo lote.'
+      );
+    }
+
     let nextState: PhotoRankingBackfillState;
 
     if (input.action === 'RESET') {
@@ -435,16 +471,19 @@ async function applyAdminControl(input: {
 
       nextState = {
         ...current,
-        status: input.action === 'PAUSE' ? 'PAUSED' : 'RUNNING',
+        status: resolvePhotoRankingBackfillControlStatus({
+          currentStatus: current.status,
+          action: input.action,
+        }),
         pageSize,
         startedAt: current.startedAt ?? now,
         completedAt: null,
         updatedAt: now,
         lastErrorCode: null,
         lastErrorMessage: null,
-        consecutiveFailures: input.action === 'PAUSE'
-          ? current.consecutiveFailures
-          : 0,
+        consecutiveFailures: input.action === 'START_OR_RESUME'
+          ? 0
+          : current.consecutiveFailures,
       };
     }
 
@@ -521,14 +560,16 @@ export async function controlPhotoRankingBackfillCore(
     };
   }
 
-  const batch = await executePhotoRankingBackfillBatch();
+  const batch = await executePhotoRankingBackfillBatch({
+    allowPaused: true,
+  });
   const state = await readBackfillState();
 
   return {
     action,
     alreadyApplied: false,
     state: stateForResponse(state),
-    batch,
+    batch: batchForResponse(batch),
   };
 }
 

--- a/functions/src/media/application/photo-ranking-backfill.policy.test.ts
+++ b/functions/src/media/application/photo-ranking-backfill.policy.test.ts
@@ -7,6 +7,7 @@ import {
   PHOTO_RANKING_BACKFILL_MAX_CONSECUTIVE_FAILURES,
   PHOTO_RANKING_BACKFILL_MIN_PAGE_SIZE,
   buildInitialPhotoRankingBackfillState,
+  buildPhotoRankingBackfillPublicState,
   isPhotoRankingBackfillLeaseAvailable,
   nextPhotoRankingBackfillFailureStatus,
   normalizePhotoRankingBackfillAction,
@@ -14,6 +15,8 @@ import {
   normalizePhotoRankingBackfillOperationId,
   normalizePhotoRankingBackfillPageSize,
   normalizePhotoRankingBackfillState,
+  resolvePhotoRankingBackfillControlStatus,
+  resolvePhotoRankingBackfillPostBatchStatus,
 } from './photo-ranking-backfill.policy';
 
 describe('photo-ranking-backfill.policy', () => {
@@ -92,6 +95,66 @@ describe('photo-ranking-backfill.policy', () => {
     assert.equal(state.cursorPath, null);
     assert.equal(state.processedCount, 0);
     assert.equal(state.generation, 1);
+  });
+
+  it('remove identificadores internos do estado devolvido ao navegador', () => {
+    const state = buildInitialPhotoRankingBackfillState({ now: 10_000 });
+    state.cursorPath = 'public_profiles/u/public_photos/p';
+    state.leaseOwner = 'lease-secret';
+    state.leaseExpiresAt = 30_000;
+    state.lastAdminOperationId = 'operation_123';
+    state.lastAdminBy = 'admin-secret';
+    state.lastAdminAction = 'RUN_PAGE';
+
+    const publicState = buildPhotoRankingBackfillPublicState(state);
+
+    assert.equal(publicState.lastAdminAction, 'RUN_PAGE');
+    assert.equal('cursorPath' in publicState, false);
+    assert.equal('leaseOwner' in publicState, false);
+    assert.equal('leaseExpiresAt' in publicState, false);
+    assert.equal('lastAdminOperationId' in publicState, false);
+    assert.equal('lastAdminBy' in publicState, false);
+  });
+
+  it('mantém lote manual pausado quando a execução não estava automática', () => {
+    assert.equal(
+      resolvePhotoRankingBackfillControlStatus({
+        currentStatus: 'PAUSED',
+        action: 'RUN_PAGE',
+      }),
+      'PAUSED'
+    );
+    assert.equal(
+      resolvePhotoRankingBackfillControlStatus({
+        currentStatus: 'IDLE',
+        action: 'RUN_PAGE',
+      }),
+      'PAUSED'
+    );
+    assert.equal(
+      resolvePhotoRankingBackfillControlStatus({
+        currentStatus: 'RUNNING',
+        action: 'RUN_PAGE',
+      }),
+      'RUNNING'
+    );
+  });
+
+  it('prioriza conclusão sobre uma pausa solicitada no último lote', () => {
+    assert.equal(
+      resolvePhotoRankingBackfillPostBatchStatus({
+        currentStatus: 'PAUSED',
+        completed: true,
+      }),
+      'COMPLETED'
+    );
+    assert.equal(
+      resolvePhotoRankingBackfillPostBatchStatus({
+        currentStatus: 'PAUSED',
+        completed: false,
+      }),
+      'PAUSED'
+    );
   });
 
   it('impede concorrência até o lease expirar', () => {

--- a/functions/src/media/application/photo-ranking-backfill.policy.ts
+++ b/functions/src/media/application/photo-ranking-backfill.policy.ts
@@ -47,6 +47,25 @@ export interface PhotoRankingBackfillState {
   generation: number;
 }
 
+export interface PhotoRankingBackfillPublicState {
+  version: number;
+  status: PhotoRankingBackfillStatus;
+  pageSize: number;
+  processedCount: number;
+  updatedCount: number;
+  skippedCount: number;
+  pagesCount: number;
+  consecutiveFailures: number;
+  startedAt: number | null;
+  updatedAt: number;
+  completedAt: number | null;
+  lastBatchAt: number | null;
+  lastErrorCode: string | null;
+  lastErrorMessage: string | null;
+  lastAdminAction: PhotoRankingBackfillControlAction | null;
+  generation: number;
+}
+
 function normalizeNonNegativeInteger(value: unknown): number {
   const numeric = Number(value ?? 0);
 
@@ -203,6 +222,55 @@ export function normalizePhotoRankingBackfillState(
     lastAdminBy: String(data.lastAdminBy ?? '').trim() || null,
     generation: Math.max(1, normalizeNonNegativeInteger(data.generation)),
   };
+}
+
+export function buildPhotoRankingBackfillPublicState(
+  state: PhotoRankingBackfillState
+): PhotoRankingBackfillPublicState {
+  return {
+    version: state.version,
+    status: state.status,
+    pageSize: state.pageSize,
+    processedCount: state.processedCount,
+    updatedCount: state.updatedCount,
+    skippedCount: state.skippedCount,
+    pagesCount: state.pagesCount,
+    consecutiveFailures: state.consecutiveFailures,
+    startedAt: state.startedAt,
+    updatedAt: state.updatedAt,
+    completedAt: state.completedAt,
+    lastBatchAt: state.lastBatchAt,
+    lastErrorCode: state.lastErrorCode,
+    lastErrorMessage: state.lastErrorMessage,
+    lastAdminAction: state.lastAdminAction,
+    generation: state.generation,
+  };
+}
+
+export function resolvePhotoRankingBackfillControlStatus(input: {
+  currentStatus: PhotoRankingBackfillStatus;
+  action: PhotoRankingBackfillControlAction;
+}): PhotoRankingBackfillStatus {
+  if (input.action === 'PAUSE') {
+    return 'PAUSED';
+  }
+
+  if (input.action === 'RUN_PAGE') {
+    return input.currentStatus === 'RUNNING' ? 'RUNNING' : 'PAUSED';
+  }
+
+  return 'RUNNING';
+}
+
+export function resolvePhotoRankingBackfillPostBatchStatus(input: {
+  currentStatus: PhotoRankingBackfillStatus;
+  completed: boolean;
+}): PhotoRankingBackfillStatus {
+  if (input.completed) {
+    return 'COMPLETED';
+  }
+
+  return input.currentStatus === 'PAUSED' ? 'PAUSED' : 'RUNNING';
 }
 
 export function isPhotoRankingBackfillLeaseAvailable(input: {

--- a/functions/src/media/application/register-private-video-upload-orchestrator.handler.ts
+++ b/functions/src/media/application/register-private-video-upload-orchestrator.handler.ts
@@ -17,6 +17,10 @@ import {
   extractOwnedPrivateVideoPathForId,
   extractOwnedPrivateVideoPosterPath,
 } from './video-storage-path';
+import {
+  isSupportedVideoUploadMimeType,
+  normalizeVideoUploadMimeType,
+} from './video-upload-format.policy';
 
 interface RegisterPrivateVideoUploadRequest
   extends VideoPublicationSettingsInput {
@@ -346,7 +350,8 @@ function resolveOwnedUploadAssets(
 /**
  * Registra o upload e só responde depois que a fila idempotente foi persistida.
  * O trigger Firestore continua como mecanismo de reconciliação e recuperação.
- * A elegibilidade é revalidada no backend antes do registro definitivo.
+ * A elegibilidade e o formato processável são revalidados no backend antes do
+ * registro definitivo.
  */
 export const registerPrivateVideoUpload = onCall<
   RegisterPrivateVideoUploadRequest
@@ -356,11 +361,22 @@ export const registerPrivateVideoUpload = onCall<
     const requesterUid = cleanId(request.auth?.uid);
     const ownerUid = cleanId(request.data?.ownerUid);
     const videoId = cleanId(request.data?.videoId);
+    const requestedMimeType = normalizeVideoUploadMimeType(
+      request.data?.mimeType
+    );
     const assets = ownerUid && videoId
       ? resolveOwnedUploadAssets(ownerUid, videoId, request.data)
       : null;
 
     if (requesterUid && requesterUid === ownerUid && assets) {
+      if (!isSupportedVideoUploadMimeType(requestedMimeType)) {
+        await cleanupDeniedUploadAssets(ownerUid, videoId, assets);
+        throw new HttpsError(
+          'failed-precondition',
+          'Envie um vídeo MP4, M4V, MOV ou WebM compatível.'
+        );
+      }
+
       try {
         await assertPrivateVideoUploadEligibility(ownerUid);
       } catch (error) {

--- a/functions/src/media/application/video-upload-format.policy.test.ts
+++ b/functions/src/media/application/video-upload-format.policy.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  SUPPORTED_VIDEO_UPLOAD_MIME_TYPES,
+  isSupportedVideoUploadMimeType,
+  normalizeVideoUploadMimeType,
+} from './video-upload-format.policy';
+
+describe('video-upload-format.policy', () => {
+  it('mantém somente formatos processáveis pelo pipeline', () => {
+    assert.deepEqual(SUPPORTED_VIDEO_UPLOAD_MIME_TYPES, [
+      'video/mp4',
+      'video/webm',
+      'video/quicktime',
+    ]);
+  });
+
+  it('normaliza e aceita os MIME types processáveis', () => {
+    assert.equal(normalizeVideoUploadMimeType(' VIDEO/MP4 '), 'video/mp4');
+    assert.equal(isSupportedVideoUploadMimeType('video/mp4'), true);
+    assert.equal(isSupportedVideoUploadMimeType('video/webm'), true);
+    assert.equal(isSupportedVideoUploadMimeType('video/quicktime'), true);
+  });
+
+  it('rejeita formatos apenas selecionáveis, mas não processáveis', () => {
+    assert.equal(isSupportedVideoUploadMimeType('video/x-matroska'), false);
+    assert.equal(isSupportedVideoUploadMimeType('video/x-msvideo'), false);
+    assert.equal(isSupportedVideoUploadMimeType('video/x-ms-wmv'), false);
+    assert.equal(isSupportedVideoUploadMimeType('video/mp2t'), false);
+    assert.equal(isSupportedVideoUploadMimeType('application/mxf'), false);
+  });
+});

--- a/functions/src/media/application/video-upload-format.policy.ts
+++ b/functions/src/media/application/video-upload-format.policy.ts
@@ -1,0 +1,19 @@
+export const SUPPORTED_VIDEO_UPLOAD_MIME_TYPES = Object.freeze([
+  'video/mp4',
+  'video/webm',
+  'video/quicktime',
+] as const);
+
+const SUPPORTED_VIDEO_UPLOAD_MIME_TYPE_SET = new Set<string>(
+  SUPPORTED_VIDEO_UPLOAD_MIME_TYPES
+);
+
+export function normalizeVideoUploadMimeType(value: unknown): string {
+  return String(value ?? '').trim().toLowerCase();
+}
+
+export function isSupportedVideoUploadMimeType(value: unknown): boolean {
+  return SUPPORTED_VIDEO_UPLOAD_MIME_TYPE_SET.has(
+    normalizeVideoUploadMimeType(value)
+  );
+}

--- a/functions/src/media/application/video-view-session.policy.test.ts
+++ b/functions/src/media/application/video-view-session.policy.test.ts
@@ -8,6 +8,7 @@ import './photo-audience-access.policy.test';
 import './photo-ranking-backfill.policy.test';
 import './photo-ranking-score.test';
 import './photo-view-session.policy.test';
+import './video-upload-format.policy.test';
 import {
   VIDEO_VIEW_SESSION_MIN_INTERVAL_MS,
   VIDEO_VIEW_SESSION_RATE_WINDOW_MS,

--- a/src/app/admin-dashboard/photo-ranking-backfill/photo-ranking-backfill.component.ts
+++ b/src/app/admin-dashboard/photo-ranking-backfill/photo-ranking-backfill.component.ts
@@ -210,7 +210,7 @@ export class PhotoRankingBackfillComponent {
   }
 
   canRunPage(status: AdminPhotoRankingBackfillStatus): boolean {
-    return status !== 'COMPLETED';
+    return status === 'IDLE' || status === 'RUNNING' || status === 'PAUSED';
   }
 
   statusLabel(status: AdminPhotoRankingBackfillStatus): string {
@@ -328,12 +328,17 @@ export class PhotoRankingBackfillComponent {
         return 'Pausa registrada. O lote ativo terminará antes da interrupção.';
       case 'RESET':
         return 'Nova geração criada. A migração recomeçará do primeiro documento.';
-      case 'RUN_PAGE':
+      case 'RUN_PAGE': {
         if (!result.batch?.acquired) {
           return 'Já existe um lote ativo. Nenhum processamento paralelo foi iniciado.';
         }
 
-        return `Lote concluído: ${result.batch.processed} foto(s) examinada(s), ${result.batch.updated} atualizada(s) e ${result.batch.skipped} ignorada(s).`;
+        const summary = `Lote concluído: ${result.batch.processed} foto(s) examinada(s), ${result.batch.updated} atualizada(s) e ${result.batch.skipped} ignorada(s).`;
+
+        return result.state.status === 'PAUSED'
+          ? `${summary} A migração permanece pausada.`
+          : summary;
+      }
     }
   }
 

--- a/src/app/core/services/media/video-upload-format.policy.spec.ts
+++ b/src/app/core/services/media/video-upload-format.policy.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   VIDEO_UPLOAD_ACCEPT,
+  VIDEO_UPLOAD_FORMAT_LABEL,
   isAcceptedVideoUploadFile,
   resolveVideoUploadFormat,
 } from './video-upload-format.policy';
@@ -12,12 +13,6 @@ describe('video-upload-format.policy', () => {
     ['video.m4v', 'video/x-m4v', 'm4v'],
     ['video.mov', 'video/quicktime', 'mov'],
     ['video.webm', 'video/webm', 'webm'],
-    ['video.mkv', 'video/x-matroska', 'mkv'],
-    ['video.avi', 'video/x-msvideo', 'avi'],
-    ['video.wmv', 'video/x-ms-wmv', 'wmv'],
-    ['video.mts', 'video/mp2t', 'mts'],
-    ['video.m2ts', '', 'm2ts'],
-    ['video.mxf', 'application/mxf', 'mxf'],
   ])('aceita %s com tipo %s', (name, type, extension) => {
     expect(resolveVideoUploadFormat({ name, type })).toEqual(
       expect.objectContaining({ extension })
@@ -25,27 +20,42 @@ describe('video-upload-format.policy', () => {
     expect(isAcceptedVideoUploadFile({ name, type })).toBe(true);
   });
 
-  it('aceita extensão conhecida quando o navegador não informa MIME type', () => {
-    expect(resolveVideoUploadFormat({ name: 'camera.MKV', type: '' })).toEqual(
+  it('aceita extensão processável quando o navegador não informa MIME type', () => {
+    expect(resolveVideoUploadFormat({ name: 'camera.WEBM', type: '' })).toEqual(
       expect.objectContaining({
-        extension: 'mkv',
-        mimeType: 'video/x-matroska',
-        browserPreviewLikely: false,
+        extension: 'webm',
+        mimeType: 'video/webm',
+        browserPreviewLikely: true,
       })
     );
   });
 
   it('rejeita divergência entre extensão e MIME type conhecidos', () => {
     expect(
-      resolveVideoUploadFormat({ name: 'arquivo.mp4', type: 'video/x-msvideo' })
+      resolveVideoUploadFormat({ name: 'arquivo.mp4', type: 'video/webm' })
     ).toBeNull();
   });
 
-  it('não anuncia formatos fora da política', () => {
-    expect(VIDEO_UPLOAD_ACCEPT).toContain('.mkv');
-    expect(VIDEO_UPLOAD_ACCEPT).toContain('.m2ts');
+  it.each([
+    ['arquivo.mkv', 'video/x-matroska'],
+    ['arquivo.avi', 'video/x-msvideo'],
+    ['arquivo.wmv', 'video/x-ms-wmv'],
+    ['arquivo.m2ts', 'video/mp2t'],
+    ['arquivo.mxf', 'application/mxf'],
+    ['arquivo.ogv', 'video/ogg'],
+  ])('rejeita formato não processável %s', (name, type) => {
+    expect(resolveVideoUploadFormat({ name, type })).toBeNull();
+    expect(isAcceptedVideoUploadFile({ name, type })).toBe(false);
+  });
+
+  it('anuncia somente os formatos realmente suportados', () => {
+    expect(VIDEO_UPLOAD_FORMAT_LABEL).toBe('MP4, M4V, MOV ou WebM');
+    expect(VIDEO_UPLOAD_ACCEPT).toContain('.mp4');
+    expect(VIDEO_UPLOAD_ACCEPT).toContain('.m4v');
+    expect(VIDEO_UPLOAD_ACCEPT).toContain('.mov');
+    expect(VIDEO_UPLOAD_ACCEPT).toContain('.webm');
+    expect(VIDEO_UPLOAD_ACCEPT).not.toContain('.mkv');
+    expect(VIDEO_UPLOAD_ACCEPT).not.toContain('.m2ts');
     expect(VIDEO_UPLOAD_ACCEPT).not.toContain('video/*');
-    expect(isAcceptedVideoUploadFile({ name: 'arquivo.ogv', type: 'video/ogg' }))
-      .toBe(false);
   });
 });

--- a/src/app/core/services/media/video-upload-format.policy.ts
+++ b/src/app/core/services/media/video-upload-format.policy.ts
@@ -4,6 +4,14 @@ export interface VideoUploadFormat {
   browserPreviewLikely: boolean;
 }
 
+/**
+ * Formatos aceitos de ponta a ponta pelo pipeline atual.
+ *
+ * Esta lista deve permanecer alinhada com:
+ * - storage.rules;
+ * - video-upload-format.policy.ts das Functions;
+ * - queue-video-processing.handler.ts.
+ */
 const FORMAT_BY_EXTENSION: Readonly<Record<string, VideoUploadFormat>> = {
   mp4: {
     extension: 'mp4',
@@ -25,41 +33,6 @@ const FORMAT_BY_EXTENSION: Readonly<Record<string, VideoUploadFormat>> = {
     mimeType: 'video/webm',
     browserPreviewLikely: true,
   },
-  mkv: {
-    extension: 'mkv',
-    mimeType: 'video/x-matroska',
-    browserPreviewLikely: false,
-  },
-  avi: {
-    extension: 'avi',
-    mimeType: 'video/x-msvideo',
-    browserPreviewLikely: false,
-  },
-  wmv: {
-    extension: 'wmv',
-    mimeType: 'video/x-ms-wmv',
-    browserPreviewLikely: false,
-  },
-  ts: {
-    extension: 'ts',
-    mimeType: 'video/mp2t',
-    browserPreviewLikely: false,
-  },
-  mts: {
-    extension: 'mts',
-    mimeType: 'video/mp2t',
-    browserPreviewLikely: false,
-  },
-  m2ts: {
-    extension: 'm2ts',
-    mimeType: 'video/mp2t',
-    browserPreviewLikely: false,
-  },
-  mxf: {
-    extension: 'mxf',
-    mimeType: 'application/mxf',
-    browserPreviewLikely: false,
-  },
 };
 
 const EXTENSION_BY_MIME_TYPE: Readonly<Record<string, string>> = {
@@ -67,14 +40,6 @@ const EXTENSION_BY_MIME_TYPE: Readonly<Record<string, string>> = {
   'video/x-m4v': 'm4v',
   'video/quicktime': 'mov',
   'video/webm': 'webm',
-  'video/x-matroska': 'mkv',
-  'video/x-msvideo': 'avi',
-  'video/avi': 'avi',
-  'video/msvideo': 'avi',
-  'video/x-ms-wmv': 'wmv',
-  'video/mp2t': 'ts',
-  'application/mxf': 'mxf',
-  'video/mxf': 'mxf',
 };
 
 export const VIDEO_UPLOAD_ACCEPT = [
@@ -82,8 +47,7 @@ export const VIDEO_UPLOAD_ACCEPT = [
   ...Object.keys(FORMAT_BY_EXTENSION).map((extension) => `.${extension}`),
 ].join(',');
 
-export const VIDEO_UPLOAD_FORMAT_LABEL =
-  'MP4, M4V, MOV, WebM, MKV, AVI, WMV, TS, MTS, M2TS ou MXF';
+export const VIDEO_UPLOAD_FORMAT_LABEL = 'MP4, M4V, MOV ou WebM';
 
 export function resolveVideoUploadFormat(
   candidate: Pick<File, 'name' | 'type'> | null | undefined

--- a/storage.rules
+++ b/storage.rules
@@ -23,8 +23,9 @@ service firebase.storage {
     function isVideoCreateOrUpdate() {
       return request.resource != null
         && (
-          request.resource.contentType.matches('video/.*')
-          || request.resource.contentType == 'application/mxf'
+          request.resource.contentType == 'video/mp4'
+          || request.resource.contentType == 'video/webm'
+          || request.resource.contentType == 'video/quicktime'
         )
         && request.resource.size <= 500 * 1024 * 1024;
     }
@@ -32,7 +33,8 @@ service firebase.storage {
     // ============================================================
     // Upload bruto e privado do usuário
     // - upload e rollback continuam sob controle do proprietário;
-    // - reprodução usa URL temporária emitida pelo backend.
+    // - reprodução usa URL temporária emitida pelo backend;
+    // - somente formatos processáveis pelo pipeline podem ser enviados.
     // ============================================================
 
     match /users/{uid}/uploads/images/{fileName} {


### PR DESCRIPTION
## Dependência

PR empilhado sobre o #62 (`agent/media-p1-photo-ranking-admin-panel`). Nenhum merge é realizado por este pacote.

## Motivo da revisão

A revisão da pilha #49–#62 identificou que #49 e #50 foram abertos paralelamente sobre `main`. O restante da pilha herdou #50, mas não herdou automaticamente todas as correções do #49.

A proteção contra autoengajamento foi posteriormente reimplementada no #51 e permanece presente. A restrição dos formatos de upload, porém, ficou fora do topo da pilha.

Também foram identificadas duas inconsistências no backfill de fotos:

- campos internos eram descartados pelo Angular, mas ainda atravessavam a resposta da callable;
- `RUN_PAGE` transformava uma migração pausada em execução automática.

## Formatos de vídeo

O upload foi alinhado de ponta a ponta aos formatos que o pipeline realmente processa:

- MP4 e M4V, persistidos como `video/mp4`;
- MOV, com `video/quicktime`;
- WebM, com `video/webm`.

Foram removidos da seleção Angular e bloqueados no Storage:

- MKV;
- AVI;
- WMV;
- TS, MTS e M2TS;
- MXF;
- outros formatos não reconhecidos.

O orquestrador de registro agora exige um MIME processável antes de registrar o vídeo. Em caso de divergência, o upload privado e a capa são removidos pelo fluxo recuperável já existente.

Foi criada uma política backend tipada para os MIME types processáveis, com testes próprios.

## Contrato seguro do backfill

O estado persistido continua contendo todos os campos necessários à coordenação e auditoria, mas o DTO público agora é construído campo a campo.

Deixaram de atravessar a callable:

- `cursorPath`;
- `leaseOwner`;
- `leaseExpiresAt`;
- `lastAdminOperationId`;
- `lastAdminBy`;
- cursor interno do resultado do lote.

O navegador recebe apenas estado operacional, métricas, horários, geração, última ação e erro sanitizado.

## Lote manual

`RUN_PAGE` agora respeita o modo anterior:

- se a migração estava `RUNNING`, continua automática;
- se estava `IDLE` ou `PAUSED`, processa somente um lote e permanece `PAUSED`;
- se o lote concluir o cursor, o estado passa para `COMPLETED`;
- em `FAILED`, o administrador precisa primeiro usar `START_OR_RESUME`.

O painel não apresenta mais o botão de lote manual em estado `FAILED` e informa quando o lote terminou mantendo a migração pausada.

## Supressões e substituições

Foram suprimidos do frontend os formatos MKV, AVI, WMV, TS/MTS/M2TS e MXF. O motivo é concreto: eles podiam ser selecionados e enviados, mas a fila de processamento não os aceitava, gerando falha posterior e experiência enganosa.

Nas Storage Rules, a expressão ampla `video/.*` e a exceção `application/mxf` foram substituídas por três MIME types explícitos. Isso fecha a mesma inconsistência na primeira barreira de upload.

No DTO público do backfill, a cópia integral do estado com mascaramento apenas do lease foi substituída por projeção explícita de campos seguros. Nenhum campo foi removido do documento interno do Firestore.

Nenhum nome público de callable, método, componente ou rota foi alterado.

## Testes adicionados

- conjunto exato de MIME types processáveis;
- rejeição de formatos que antes eram apenas selecionáveis;
- alinhamento do `accept` e do rótulo Angular;
- projeção pública sem cursor, lease ou identidade administrativa;
- lote manual preservando pausa;
- conclusão prevalecendo sobre pausa.

## Validação concluída

- lint das Functions: aprovado;
- build TypeScript das Functions: aprovado;
- testes das Functions e das novas políticas: aprovados;
- testes Angular: aprovados;
- build Angular seguro: aprovado;
- Angular CI Validation: aprovado;
- configuração do Emulator: aprovada;
- Firestore Rules: aprovadas;
- índices do Firestore: aprovados;
- Quality Gate agregado: aprovado.

Os dois pipelines passaram integralmente no primeiro head do PR, sem commit corretivo posterior.