### PR TITLE
refactor(video): model persisted lifecycle states

### DIFF
--- a/src/app/core/interfaces/media/i-video-item.ts
+++ b/src/app/core/interfaces/media/i-video-item.ts
@@ -1,10 +1,11 @@
 // src/app/core/interfaces/media/i-video-item.ts
 // -----------------------------------------------------------------------------
-// Contratos do domínio de vídeos privados.
+// Contratos do domínio técnico de vídeos do proprietário.
 //
-// Decisão de produto:
-// - vídeo começa como biblioteca privada do usuário;
-// - publicação cria cópia física e projeção pública separadas;
+// Decisão de arquitetura:
+// - o original e os derivados permanecem em namespaces privados do usuário;
+// - o registro inicia processamento e intenção obrigatória de publicação;
+// - a projeção pública utiliza contratos e paths separados;
 // - uid continua sendo o identificador canônico do usuário;
 // - paths privados nunca entram em contratos de exibição pública.
 // -----------------------------------------------------------------------------

--- a/src/app/core/services/media/video-lifecycle-state.policy.spec.ts
+++ b/src/app/core/services/media/video-lifecycle-state.policy.spec.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest';
+
+import { IVideoItem } from 'src/app/core/interfaces/media/i-video-item';
+import { IVideoPublicationConfig } from 'src/app/core/interfaces/media/i-video-publication-config';
+import { resolveVideoLifecyclePresentation } from './video-lifecycle-state.policy';
+
+const baseVideo: IVideoItem = {
+  id: 'video-1',
+  ownerUid: 'owner-1',
+  url: 'users/owner-1/uploads/videos/video-1.mp4',
+  status: 'uploaded',
+  createdAt: 1,
+};
+
+const basePublication: IVideoPublicationConfig = {
+  id: 'video-1',
+  videoId: 'video-1',
+  ownerUid: 'owner-1',
+  isPublished: false,
+  publishWhenReady: true,
+  visibility: 'PRIVATE',
+  orderIndex: 0,
+  moderationStatus: 'PRIVATE',
+};
+
+describe('video-lifecycle-state.policy', () => {
+  it.each([
+    ['uploaded', 'REGISTERED', 'Registrado'],
+    ['queued', 'QUEUED', 'Na fila'],
+    ['processing', 'PROCESSING', 'Processando'],
+  ] as const)(
+    'deriva o status persistido %s como %s',
+    (status, expectedState, expectedLabel) => {
+      const result = resolveVideoLifecyclePresentation(
+        { ...baseVideo, status },
+        basePublication
+      );
+
+      expect(result.state).toBe(expectedState);
+      expect(result.label).toBe(expectedLabel);
+      expect(result.tone).toBe('progress');
+      expect(result.terminal).toBe(false);
+    }
+  );
+
+  it('representa publicação em andamento quando o derivado está pronto', () => {
+    const result = resolveVideoLifecyclePresentation(
+      { ...baseVideo, status: 'ready' },
+      basePublication
+    );
+
+    expect(result).toMatchObject({
+      state: 'PUBLISHING',
+      label: 'Publicando',
+      tone: 'progress',
+      terminal: false,
+    });
+  });
+
+  it('prioriza moderação pendente sobre o status técnico pronto', () => {
+    const result = resolveVideoLifecyclePresentation(
+      { ...baseVideo, status: 'ready' },
+      {
+        ...basePublication,
+        isPublished: true,
+        moderationStatus: 'PENDING_REVIEW',
+      }
+    );
+
+    expect(result).toMatchObject({
+      state: 'PENDING_REVIEW',
+      label: 'Em análise',
+      tone: 'warning',
+    });
+  });
+
+  it('representa publicação aprovada como estado terminal', () => {
+    const result = resolveVideoLifecyclePresentation(
+      { ...baseVideo, status: 'ready' },
+      {
+        ...basePublication,
+        isPublished: true,
+        publishWhenReady: false,
+        visibility: 'PUBLIC',
+        moderationStatus: 'APPROVED',
+      }
+    );
+
+    expect(result).toMatchObject({
+      state: 'PUBLISHED',
+      label: 'Publicado',
+      tone: 'success',
+      terminal: true,
+    });
+  });
+
+  it('preserva mensagem técnica sanitizada em falha de processamento', () => {
+    const result = resolveVideoLifecyclePresentation(
+      {
+        ...baseVideo,
+        status: 'failed',
+        processingErrorMessage: '  Codec incompatível.  ',
+      },
+      basePublication
+    );
+
+    expect(result).toMatchObject({
+      state: 'FAILED',
+      label: 'Falha',
+      message: 'Codec incompatível.',
+      tone: 'error',
+      terminal: true,
+    });
+  });
+
+  it('preserva o motivo de rejeição informado pela moderação', () => {
+    const result = resolveVideoLifecyclePresentation(
+      { ...baseVideo, status: 'ready' },
+      {
+        ...basePublication,
+        moderationStatus: 'REJECTED',
+        moderationReason: 'Conteúdo fora das regras.',
+      }
+    );
+
+    expect(result).toMatchObject({
+      state: 'REJECTED',
+      label: 'Rejeitado',
+      message: 'Conteúdo fora das regras.',
+      tone: 'error',
+      terminal: true,
+    });
+  });
+
+  it.each([
+    ['FLAGGED', 'Sinalizado'],
+    ['HIDDEN', 'Oculto'],
+  ] as const)('representa moderação %s como bloqueio', (moderationStatus, label) => {
+    const result = resolveVideoLifecyclePresentation(
+      { ...baseVideo, status: 'ready' },
+      {
+        ...basePublication,
+        isPublished: true,
+        moderationStatus,
+      }
+    );
+
+    expect(result).toMatchObject({
+      state: 'BLOCKED',
+      label,
+      tone: 'error',
+      terminal: false,
+    });
+  });
+
+  it('identifica vídeo privado criado pelo fluxo legado', () => {
+    const result = resolveVideoLifecyclePresentation(
+      { ...baseVideo, status: 'ready' },
+      {
+        ...basePublication,
+        publishWhenReady: false,
+        isPublished: false,
+      }
+    );
+
+    expect(result).toMatchObject({
+      state: 'LEGACY_PRIVATE',
+      label: 'Vídeo antigo',
+      tone: 'warning',
+      terminal: false,
+    });
+  });
+});

--- a/src/app/core/services/media/video-lifecycle-state.policy.spec.ts
+++ b/src/app/core/services/media/video-lifecycle-state.policy.spec.ts
@@ -79,6 +79,26 @@ describe('video-lifecycle-state.policy', () => {
     });
   });
 
+  it('não confunde o path bruto de fallback com saída processada', () => {
+    const result = resolveVideoLifecyclePresentation(
+      {
+        ...baseVideo,
+        status: 'ready',
+        mimeType: 'video/mp4',
+        processedMimeType: 'video/mp4',
+        processedStoragePath:
+          'users/owner-1/uploads/videos/video-1-source.mp4',
+      },
+      basePublication
+    );
+
+    expect(result).toMatchObject({
+      state: 'REGISTERED',
+      label: 'Registrado',
+      tone: 'progress',
+    });
+  });
+
   it('não classifica como legado enquanto a publicação ainda não foi hidratada', () => {
     const result = resolveVideoLifecyclePresentation(readyVideo, null);
 

--- a/src/app/core/services/media/video-lifecycle-state.policy.spec.ts
+++ b/src/app/core/services/media/video-lifecycle-state.policy.spec.ts
@@ -133,7 +133,6 @@ describe('video-lifecycle-state.policy', () => {
         ...basePublication,
         isPublished: true,
         publishWhenReady: false,
-        visibility: 'PUBLIC',
         moderationStatus: 'APPROVED',
       }
     );

--- a/src/app/core/services/media/video-lifecycle-state.policy.spec.ts
+++ b/src/app/core/services/media/video-lifecycle-state.policy.spec.ts
@@ -12,6 +12,15 @@ const baseVideo: IVideoItem = {
   createdAt: 1,
 };
 
+const readyVideo: IVideoItem = {
+  ...baseVideo,
+  status: 'ready',
+  mimeType: 'video/mp4',
+  processedMimeType: 'video/mp4',
+  processedStoragePath:
+    'users/owner-1/processed/videos/video-1/job-1/playback.mp4',
+};
+
 const basePublication: IVideoPublicationConfig = {
   id: 'video-1',
   videoId: 'video-1',
@@ -45,7 +54,7 @@ describe('video-lifecycle-state.policy', () => {
 
   it('representa publicação em andamento quando o derivado está pronto', () => {
     const result = resolveVideoLifecyclePresentation(
-      { ...baseVideo, status: 'ready' },
+      readyVideo,
       basePublication
     );
 
@@ -57,11 +66,21 @@ describe('video-lifecycle-state.policy', () => {
     });
   });
 
-  it('não classifica como legado enquanto a publicação ainda não foi hidratada', () => {
+  it('não avança para publicação sem um derivado compatível', () => {
     const result = resolveVideoLifecyclePresentation(
-      { ...baseVideo, status: 'ready' },
-      null
+      { ...baseVideo, status: 'ready', mimeType: 'video/mp4' },
+      basePublication
     );
+
+    expect(result).toMatchObject({
+      state: 'REGISTERED',
+      label: 'Registrado',
+      tone: 'progress',
+    });
+  });
+
+  it('não classifica como legado enquanto a publicação ainda não foi hidratada', () => {
+    const result = resolveVideoLifecyclePresentation(readyVideo, null);
 
     expect(result).toMatchObject({
       state: 'REGISTERED',
@@ -72,7 +91,7 @@ describe('video-lifecycle-state.policy', () => {
 
   it('prioriza moderação pendente sobre o status técnico pronto', () => {
     const result = resolveVideoLifecyclePresentation(
-      { ...baseVideo, status: 'ready' },
+      readyVideo,
       {
         ...basePublication,
         isPublished: true,
@@ -89,7 +108,7 @@ describe('video-lifecycle-state.policy', () => {
 
   it('representa publicação aprovada como estado terminal', () => {
     const result = resolveVideoLifecyclePresentation(
-      { ...baseVideo, status: 'ready' },
+      readyVideo,
       {
         ...basePublication,
         isPublished: true,
@@ -128,7 +147,7 @@ describe('video-lifecycle-state.policy', () => {
 
   it('preserva o motivo de rejeição informado pela moderação', () => {
     const result = resolveVideoLifecyclePresentation(
-      { ...baseVideo, status: 'ready' },
+      readyVideo,
       {
         ...basePublication,
         moderationStatus: 'REJECTED',
@@ -150,7 +169,7 @@ describe('video-lifecycle-state.policy', () => {
     ['HIDDEN', 'Oculto'],
   ] as const)('representa moderação %s como bloqueio', (moderationStatus, label) => {
     const result = resolveVideoLifecyclePresentation(
-      { ...baseVideo, status: 'ready' },
+      readyVideo,
       {
         ...basePublication,
         isPublished: true,
@@ -168,7 +187,7 @@ describe('video-lifecycle-state.policy', () => {
 
   it('identifica vídeo privado criado pelo fluxo legado', () => {
     const result = resolveVideoLifecyclePresentation(
-      { ...baseVideo, status: 'ready' },
+      readyVideo,
       {
         ...basePublication,
         publishWhenReady: false,

--- a/src/app/core/services/media/video-lifecycle-state.policy.spec.ts
+++ b/src/app/core/services/media/video-lifecycle-state.policy.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import { IVideoItem } from 'src/app/core/interfaces/media/i-video-item';
-import { IVideoPublicationConfig } from 'src/app/core/interfaces/media/i-video-publication-config';
+import type { IVideoItem } from 'src/app/core/interfaces/media/i-video-item';
+import type { IVideoPublicationConfig } from 'src/app/core/interfaces/media/i-video-publication-config';
 import { resolveVideoLifecyclePresentation } from './video-lifecycle-state.policy';
 
 const baseVideo: IVideoItem = {
@@ -54,6 +54,19 @@ describe('video-lifecycle-state.policy', () => {
       label: 'Publicando',
       tone: 'progress',
       terminal: false,
+    });
+  });
+
+  it('não classifica como legado enquanto a publicação ainda não foi hidratada', () => {
+    const result = resolveVideoLifecyclePresentation(
+      { ...baseVideo, status: 'ready' },
+      null
+    );
+
+    expect(result).toMatchObject({
+      state: 'REGISTERED',
+      label: 'Registrado',
+      tone: 'progress',
     });
   });
 

--- a/src/app/core/services/media/video-lifecycle-state.policy.ts
+++ b/src/app/core/services/media/video-lifecycle-state.policy.ts
@@ -1,5 +1,5 @@
-import { IVideoItem } from 'src/app/core/interfaces/media/i-video-item';
-import { IVideoPublicationConfig } from 'src/app/core/interfaces/media/i-video-publication-config';
+import type { IVideoItem } from 'src/app/core/interfaces/media/i-video-item';
+import type { IVideoPublicationConfig } from 'src/app/core/interfaces/media/i-video-publication-config';
 
 export type VideoLifecycleState =
   | 'REGISTERED'
@@ -14,18 +14,17 @@ export type VideoLifecycleState =
   | 'LEGACY_PRIVATE';
 
 export type VideoLifecycleTone =
-  | 'neutral'
   | 'progress'
   | 'success'
   | 'warning'
   | 'error';
 
 export interface VideoLifecyclePresentation {
-  state: VideoLifecycleState;
-  label: string;
-  message: string;
-  tone: VideoLifecycleTone;
-  terminal: boolean;
+  readonly state: VideoLifecycleState;
+  readonly label: string;
+  readonly message: string;
+  readonly tone: VideoLifecycleTone;
+  readonly terminal: boolean;
 }
 
 const PRESENTATIONS: Readonly<
@@ -86,10 +85,7 @@ const PRESENTATIONS: Readonly<
 };
 
 export function resolveVideoLifecyclePresentation(
-  video: Pick<
-    IVideoItem,
-    'status' | 'processingStage' | 'processingErrorMessage'
-  >,
+  video: Pick<IVideoItem, 'status' | 'processingErrorMessage'>,
   publication: Pick<
     IVideoPublicationConfig,
     | 'isPublished'
@@ -170,8 +166,10 @@ export function resolveVideoLifecyclePresentation(
 
   if (
     video.status === 'ready' &&
-    publication?.isPublished !== true &&
-    publication?.publishWhenReady !== true
+    publication !== null &&
+    publication !== undefined &&
+    publication.isPublished !== true &&
+    publication.publishWhenReady !== true
   ) {
     return PRESENTATIONS.LEGACY_PRIVATE;
   }

--- a/src/app/core/services/media/video-lifecycle-state.policy.ts
+++ b/src/app/core/services/media/video-lifecycle-state.policy.ts
@@ -28,6 +28,8 @@ export interface VideoLifecyclePresentation {
 }
 
 const PUBLIC_PLAYBACK_TYPES = new Set(['video/mp4', 'video/webm']);
+const PROCESSED_VIDEO_PATH_PATTERN =
+  /^users\/[A-Za-z0-9_-]{1,128}\/processed\/videos\/[A-Za-z0-9_-]{1,128}\/.+/;
 
 const PRESENTATIONS: Readonly<
   Record<
@@ -196,12 +198,17 @@ function hasCompatibleProcessedPlayback(
     'processedStoragePath' | 'processedMimeType' | 'mimeType'
   >
 ): boolean {
-  const storagePath = String(video.processedStoragePath ?? '').trim();
+  const storagePath = String(video.processedStoragePath ?? '')
+    .trim()
+    .replace(/^\/+/, '');
   const mimeType = String(video.processedMimeType ?? video.mimeType ?? '')
     .trim()
     .toLowerCase();
 
-  return !!storagePath && PUBLIC_PLAYBACK_TYPES.has(mimeType);
+  return (
+    PROCESSED_VIDEO_PATH_PATTERN.test(storagePath) &&
+    PUBLIC_PLAYBACK_TYPES.has(mimeType)
+  );
 }
 
 function cleanMessage(value: string | null | undefined): string {

--- a/src/app/core/services/media/video-lifecycle-state.policy.ts
+++ b/src/app/core/services/media/video-lifecycle-state.policy.ts
@@ -27,6 +27,8 @@ export interface VideoLifecyclePresentation {
   readonly terminal: boolean;
 }
 
+const PUBLIC_PLAYBACK_TYPES = new Set(['video/mp4', 'video/webm']);
+
 const PRESENTATIONS: Readonly<
   Record<
     Exclude<VideoLifecycleState, 'FAILED' | 'REJECTED' | 'BLOCKED'>,
@@ -85,7 +87,14 @@ const PRESENTATIONS: Readonly<
 };
 
 export function resolveVideoLifecyclePresentation(
-  video: Pick<IVideoItem, 'status' | 'processingErrorMessage'>,
+  video: Pick<
+    IVideoItem,
+    | 'status'
+    | 'processingErrorMessage'
+    | 'processedStoragePath'
+    | 'processedMimeType'
+    | 'mimeType'
+  >,
   publication: Pick<
     IVideoPublicationConfig,
     | 'isPublished'
@@ -156,8 +165,11 @@ export function resolveVideoLifecyclePresentation(
     return PRESENTATIONS.PROCESSING;
   }
 
+  const hasProcessedPlayback = hasCompatibleProcessedPlayback(video);
+
   if (
     video.status === 'ready' &&
+    hasProcessedPlayback &&
     publication?.isPublished !== true &&
     publication?.publishWhenReady === true
   ) {
@@ -166,6 +178,7 @@ export function resolveVideoLifecyclePresentation(
 
   if (
     video.status === 'ready' &&
+    hasProcessedPlayback &&
     publication !== null &&
     publication !== undefined &&
     publication.isPublished !== true &&
@@ -175,6 +188,20 @@ export function resolveVideoLifecyclePresentation(
   }
 
   return PRESENTATIONS.REGISTERED;
+}
+
+function hasCompatibleProcessedPlayback(
+  video: Pick<
+    IVideoItem,
+    'processedStoragePath' | 'processedMimeType' | 'mimeType'
+  >
+): boolean {
+  const storagePath = String(video.processedStoragePath ?? '').trim();
+  const mimeType = String(video.processedMimeType ?? video.mimeType ?? '')
+    .trim()
+    .toLowerCase();
+
+  return !!storagePath && PUBLIC_PLAYBACK_TYPES.has(mimeType);
 }
 
 function cleanMessage(value: string | null | undefined): string {

--- a/src/app/core/services/media/video-lifecycle-state.policy.ts
+++ b/src/app/core/services/media/video-lifecycle-state.policy.ts
@@ -1,0 +1,184 @@
+import { IVideoItem } from 'src/app/core/interfaces/media/i-video-item';
+import { IVideoPublicationConfig } from 'src/app/core/interfaces/media/i-video-publication-config';
+
+export type VideoLifecycleState =
+  | 'REGISTERED'
+  | 'QUEUED'
+  | 'PROCESSING'
+  | 'PUBLISHING'
+  | 'PENDING_REVIEW'
+  | 'PUBLISHED'
+  | 'REJECTED'
+  | 'BLOCKED'
+  | 'FAILED'
+  | 'LEGACY_PRIVATE';
+
+export type VideoLifecycleTone =
+  | 'neutral'
+  | 'progress'
+  | 'success'
+  | 'warning'
+  | 'error';
+
+export interface VideoLifecyclePresentation {
+  state: VideoLifecycleState;
+  label: string;
+  message: string;
+  tone: VideoLifecycleTone;
+  terminal: boolean;
+}
+
+const PRESENTATIONS: Readonly<
+  Record<
+    Exclude<VideoLifecycleState, 'FAILED' | 'REJECTED' | 'BLOCKED'>,
+    VideoLifecyclePresentation
+  >
+> = {
+  REGISTERED: {
+    state: 'REGISTERED',
+    label: 'Registrado',
+    message: 'O upload foi registrado e aguarda entrada na fila de processamento.',
+    tone: 'progress',
+    terminal: false,
+  },
+  QUEUED: {
+    state: 'QUEUED',
+    label: 'Na fila',
+    message: 'O vídeo está na fila de processamento.',
+    tone: 'progress',
+    terminal: false,
+  },
+  PROCESSING: {
+    state: 'PROCESSING',
+    label: 'Processando',
+    message: 'A versão compatível do vídeo está sendo preparada.',
+    tone: 'progress',
+    terminal: false,
+  },
+  PUBLISHING: {
+    state: 'PUBLISHING',
+    label: 'Publicando',
+    message: 'O processamento terminou e a publicação está sendo concluída.',
+    tone: 'progress',
+    terminal: false,
+  },
+  PENDING_REVIEW: {
+    state: 'PENDING_REVIEW',
+    label: 'Em análise',
+    message: 'O vídeo foi processado e aguarda moderação antes de aparecer no perfil.',
+    tone: 'warning',
+    terminal: false,
+  },
+  PUBLISHED: {
+    state: 'PUBLISHED',
+    label: 'Publicado',
+    message: 'O vídeo está disponível no perfil.',
+    tone: 'success',
+    terminal: true,
+  },
+  LEGACY_PRIVATE: {
+    state: 'LEGACY_PRIVATE',
+    label: 'Vídeo antigo',
+    message: 'Este vídeo pertence ao fluxo antigo. Publique-o para concluir a migração ou exclua-o.',
+    tone: 'warning',
+    terminal: false,
+  },
+};
+
+export function resolveVideoLifecyclePresentation(
+  video: Pick<
+    IVideoItem,
+    'status' | 'processingStage' | 'processingErrorMessage'
+  >,
+  publication: Pick<
+    IVideoPublicationConfig,
+    | 'isPublished'
+    | 'publishWhenReady'
+    | 'moderationStatus'
+    | 'moderationReason'
+  > | null | undefined
+): VideoLifecyclePresentation {
+  if (video.status === 'failed') {
+    return {
+      state: 'FAILED',
+      label: 'Falha',
+      message:
+        cleanMessage(video.processingErrorMessage) ||
+        'Não foi possível processar este arquivo. Exclua-o e envie uma nova versão.',
+      tone: 'error',
+      terminal: true,
+    };
+  }
+
+  if (publication?.moderationStatus === 'REJECTED') {
+    return {
+      state: 'REJECTED',
+      label: 'Rejeitado',
+      message:
+        cleanMessage(publication.moderationReason) ||
+        'A moderação rejeitou esta versão. Exclua o arquivo e envie uma nova versão.',
+      tone: 'error',
+      terminal: true,
+    };
+  }
+
+  if (
+    publication?.moderationStatus === 'FLAGGED' ||
+    publication?.moderationStatus === 'HIDDEN'
+  ) {
+    return {
+      state: 'BLOCKED',
+      label: publication.moderationStatus === 'FLAGGED' ? 'Sinalizado' : 'Oculto',
+      message:
+        cleanMessage(publication.moderationReason) ||
+        'O vídeo está indisponível enquanto a revisão de segurança é concluída.',
+      tone: 'error',
+      terminal: false,
+    };
+  }
+
+  if (
+    publication?.isPublished === true &&
+    publication.moderationStatus === 'APPROVED'
+  ) {
+    return PRESENTATIONS.PUBLISHED;
+  }
+
+  if (publication?.moderationStatus === 'PENDING_REVIEW') {
+    return PRESENTATIONS.PENDING_REVIEW;
+  }
+
+  if (video.status === 'uploaded') {
+    return PRESENTATIONS.REGISTERED;
+  }
+
+  if (video.status === 'queued') {
+    return PRESENTATIONS.QUEUED;
+  }
+
+  if (video.status === 'processing') {
+    return PRESENTATIONS.PROCESSING;
+  }
+
+  if (
+    video.status === 'ready' &&
+    publication?.isPublished !== true &&
+    publication?.publishWhenReady === true
+  ) {
+    return PRESENTATIONS.PUBLISHING;
+  }
+
+  if (
+    video.status === 'ready' &&
+    publication?.isPublished !== true &&
+    publication?.publishWhenReady !== true
+  ) {
+    return PRESENTATIONS.LEGACY_PRIVATE;
+  }
+
+  return PRESENTATIONS.REGISTERED;
+}
+
+function cleanMessage(value: string | null | undefined): string {
+  return String(value ?? '').trim().slice(0, 500);
+}

--- a/src/app/media/videos/profile-videos/profile-videos.component.html
+++ b/src/app/media/videos/profile-videos/profile-videos.component.html
@@ -11,6 +11,7 @@
 @let selectedFileName = (selectedFileName$ | async);
 @let selectedFileSize = (selectedFileSize$ | async);
 @let canUpload = (canUpload$ | async) === true;
+@let lastUploadedLifecycle = (lastUploadedLifecycle$ | async);
 
 <section class="profile-videos" aria-label="Vídeos">
   @if (isOwner$ | async) {
@@ -193,7 +194,11 @@
         </div>
       }
 
-      @if (uploadPhase !== 'IDLE' && uploadPhase !== 'READY') {
+      @if (
+        uploadPhase === 'PREPARING' ||
+        uploadPhase === 'UPLOADING' ||
+        uploadPhase === 'SAVING'
+      ) {
         <div class="profile-videos__progress" aria-live="polite">
           <div class="profile-videos__progress-copy">
             <strong>{{ uploadStep }}</strong>
@@ -210,6 +215,11 @@
             <span [style.width.%]="uploadProgress"></span>
           </div>
         </div>
+      } @else if (uploadPhase === 'REGISTERED') {
+        <p class="profile-videos__upload-status" role="status" aria-live="polite">
+          <strong>{{ lastUploadedLifecycle?.label || 'Registrado' }}</strong>
+          — {{ lastUploadedLifecycle?.message || uploadStep }}
+        </p>
       } @else if (uploadPhase === 'READY') {
         <p class="profile-videos__upload-status" role="status" aria-live="polite">
           {{ uploadStep }}
@@ -238,7 +248,7 @@
       }
 
       <div class="profile-videos__upload-actions">
-        @if (uploadPhase === 'DONE') {
+        @if (uploadPhase === 'REGISTERED') {
           <button
             type="button"
             class="app-action app-action--primary"
@@ -289,11 +299,11 @@
                   <strong>{{ displayVideoTitle(item) }}</strong>
                   <span
                     class="profile-videos__publication-chip"
-                    [class.profile-videos__publication-chip--published]="item.publication?.moderationStatus === 'APPROVED'"
-                    [class.profile-videos__publication-chip--pending]="isPendingPublication(item)"
-                    [class.profile-videos__publication-chip--rejected]="item.publication?.moderationStatus === 'REJECTED' || item.video.status === 'failed'"
+                    [class.profile-videos__publication-chip--published]="item.lifecycle.tone === 'success'"
+                    [class.profile-videos__publication-chip--pending]="item.lifecycle.tone === 'progress' || item.lifecycle.tone === 'warning'"
+                    [class.profile-videos__publication-chip--rejected]="item.lifecycle.tone === 'error'"
                   >
-                    {{ publicationLabel(item) }}
+                    {{ item.lifecycle.label }}
                   </span>
                 </div>
 
@@ -372,29 +382,14 @@
                   </form>
                 }
 
-                @if (item.video.status === 'queued' || item.video.status === 'processing') {
-                  <p class="profile-videos__helper" role="status">
-                    Preparando o vídeo para publicação automática.
-                  </p>
-                } @else if (item.video.status === 'failed') {
-                  <p class="profile-videos__helper profile-videos__helper--error" role="alert">
-                    {{ item.video.processingErrorMessage || 'Não foi possível processar este arquivo. Exclua-o e envie uma nova versão.' }}
-                  </p>
-                } @else if (item.publication?.moderationStatus === 'REJECTED') {
-                  <p class="profile-videos__helper profile-videos__helper--error" role="alert">
-                    A moderação rejeitou esta versão. {{ item.publication?.moderationReason || 'Exclua o arquivo e envie uma nova versão antes de tentar publicar novamente.' }}
-                  </p>
-                } @else if (
-                  !item.publication?.isPublished &&
-                  item.publication?.publishWhenReady !== true &&
-                  item.video.status === 'ready'
-                ) {
-                  <p class="profile-videos__helper" role="status">
-                    Este vídeo foi salvo no fluxo antigo. Publique-o para concluir a migração ou exclua-o.
-                  </p>
-                } @else if (!isPublicPlaybackCompatible(item.video)) {
-                  <p class="profile-videos__helper" role="status">
-                    A versão compatível ainda não foi confirmada.
+                @if (item.lifecycle.state !== 'PUBLISHED') {
+                  <p
+                    class="profile-videos__helper"
+                    [class.profile-videos__helper--error]="item.lifecycle.tone === 'error'"
+                    [attr.role]="item.lifecycle.tone === 'error' ? 'alert' : 'status'"
+                    [attr.aria-live]="item.lifecycle.tone === 'error' ? 'assertive' : 'polite'"
+                  >
+                    {{ item.lifecycle.message }}
                   </p>
                 }
 

--- a/src/app/media/videos/profile-videos/profile-videos.component.ts
+++ b/src/app/media/videos/profile-videos/profile-videos.component.ts
@@ -1,6 +1,6 @@
 // src/app/media/videos/profile-videos/profile-videos.component.ts
 // -----------------------------------------------------------------------------
-// Biblioteca privada, upload recuperável e publicação controlada de vídeos.
+// Upload recuperável e acompanhamento reativo do ciclo de vida dos vídeos.
 // -----------------------------------------------------------------------------
 
 import { CommonModule } from '@angular/common';
@@ -48,6 +48,10 @@ import {
   MediaPolicyDenyReason,
   MediaPolicyService,
 } from 'src/app/core/services/media/media-policy.service';
+import {
+  resolveVideoLifecyclePresentation,
+  VideoLifecyclePresentation,
+} from 'src/app/core/services/media/video-lifecycle-state.policy';
 import { VideoLibraryService } from 'src/app/core/services/media/video-library.service';
 import { VideoMetadataPreparationService } from 'src/app/core/services/media/video-metadata-preparation.service';
 import { VideoPublicationService } from 'src/app/core/services/media/video-publication.service';
@@ -65,6 +69,7 @@ import {
 interface ProfileVideoViewItem {
   video: IVideoItem;
   publication: IVideoPublicationConfig | null;
+  lifecycle: VideoLifecyclePresentation;
 }
 
 interface VideoUploadFailureFeedback {
@@ -74,14 +79,14 @@ interface VideoUploadFailureFeedback {
   retryable: boolean;
 }
 
-type VideoBusyAction = 'publish' | 'unpublish' | 'delete' | 'save';
+type VideoBusyAction = 'publish' | 'delete' | 'save';
 type VideoUploadUiPhase =
   | 'IDLE'
   | 'READY'
   | 'PREPARING'
   | 'UPLOADING'
   | 'SAVING'
-  | 'DONE';
+  | 'REGISTERED';
 
 const MAX_VIDEO_SIZE_BYTES = 500 * 1024 * 1024;
 const PUBLIC_PLAYBACK_TYPES = new Set(['video/mp4', 'video/webm']);
@@ -182,9 +187,11 @@ export class ProfileVideosComponent {
     new BehaviorSubject<VideoUploadFailureFeedback | null>(null);
   readonly uploadFailure$ = this.uploadFailureSubject.asObservable();
 
+  private readonly lastUploadedVideoIdSubject =
+    new BehaviorSubject<string | null>(null);
+
   private uploadSubscription: Subscription | null = null;
   private cancelRequestedByUser = false;
-  private uploadPublishWhenReady = true;
 
   readonly viewer$: Observable<IMediaPolicyViewerSnapshot | null | undefined> =
     this.currentUserStore.user$.pipe(
@@ -292,13 +299,36 @@ export class ProfileVideosComponent {
             ])
           );
 
-          return videos.map((video) => ({
-            video,
-            publication: publicationByVideoId.get(video.id) ?? null,
-          }));
+          return videos.map((video) => {
+            const publication = publicationByVideoId.get(video.id) ?? null;
+
+            return {
+              video,
+              publication,
+              lifecycle: resolveVideoLifecyclePresentation(video, publication),
+            };
+          });
         })
       );
     }),
+    shareReplay({ bufferSize: 1, refCount: true })
+  );
+
+  readonly lastUploadedLifecycle$: Observable<
+    VideoLifecyclePresentation | null
+  > = combineLatest([
+    this.lastUploadedVideoIdSubject,
+    this.viewItems$,
+  ]).pipe(
+    map(([videoId, items]) =>
+      videoId
+        ? items.find((item) => item.video.id === videoId)?.lifecycle ?? null
+        : null
+    ),
+    distinctUntilChanged((previous, current) =>
+      previous?.state === current?.state &&
+      previous?.message === current?.message
+    ),
     shareReplay({ bufferSize: 1, refCount: true })
   );
 
@@ -340,6 +370,7 @@ export class ProfileVideosComponent {
       return;
     }
 
+    this.lastUploadedVideoIdSubject.next(null);
     this.uploadFailureSubject.next(null);
     this.revokePreviewUrl();
     this.revokePosterUrl();
@@ -394,7 +425,7 @@ export class ProfileVideosComponent {
     });
   }
 
-  startUpload(publishWhenReady = true): void {
+  startUpload(): void {
     if (this.uploadSubscription) {
       return;
     }
@@ -409,7 +440,6 @@ export class ProfileVideosComponent {
 
     this.uploadFailureSubject.next(null);
     this.cancelRequestedByUser = false;
-    this.uploadPublishWhenReady = publishWhenReady;
     let subscription: Subscription | null = null;
 
     const upload$ = combineLatest([
@@ -435,7 +465,7 @@ export class ProfileVideosComponent {
           return EMPTY;
         }
 
-        const publication = this.uploadPublicationSettings(publishWhenReady);
+        const publication = this.uploadPublicationSettings();
         this.uploadPhaseSubject.next('PREPARING');
         this.uploadProgressSubject.next(0);
         this.uploadStepSubject.next('Validando vídeo e capa.');
@@ -454,7 +484,7 @@ export class ProfileVideosComponent {
 
         if (
           this.cancelRequestedByUser &&
-          this.uploadPhaseSubject.value !== 'DONE'
+          this.uploadPhaseSubject.value !== 'REGISTERED'
         ) {
           this.uploadPhaseSubject.next('READY');
           this.uploadProgressSubject.next(0);
@@ -490,7 +520,7 @@ export class ProfileVideosComponent {
       return;
     }
 
-    this.startUpload(this.uploadPublishWhenReady);
+    this.startUpload();
   }
 
   cancelUpload(): void {
@@ -508,6 +538,7 @@ export class ProfileVideosComponent {
       return;
     }
 
+    this.lastUploadedVideoIdSubject.next(null);
     this.uploadFailureSubject.next(null);
     this.revokePreviewUrl();
     this.revokePosterUrl();
@@ -648,32 +679,6 @@ export class ProfileVideosComponent {
     });
   }
 
-  unpublishVideo(item: ProfileVideoViewItem): void {
-    if (!item.publication?.isPublished || this.isBusy(item.video.id)) {
-      return;
-    }
-
-    this.setBusyAction(item.video.id, 'unpublish');
-
-    this.ownerUid$.pipe(
-      take(1),
-      switchMap((ownerUid) =>
-        this.videoPublication.unpublishVideo$(ownerUid, item.video.id)
-      ),
-      finalize(() => this.clearBusyAction(item.video.id)),
-      takeUntilDestroyed(this.destroyRef)
-    ).subscribe({
-      next: () => {
-        this.errorNotification.showSuccess('Vídeo removido da área pública.');
-      },
-      error: () => {
-        this.errorNotification.showError(
-          'Não foi possível remover a publicação do vídeo.'
-        );
-      },
-    });
-  }
-
   requestDelete(item: ProfileVideoViewItem): void {
     if (this.isBusy(item.video.id)) {
       return;
@@ -752,7 +757,7 @@ export class ProfileVideosComponent {
     return (
       !!this.uploadSubscription &&
       phase !== 'SAVING' &&
-      phase !== 'DONE'
+      phase !== 'REGISTERED'
     );
   }
 
@@ -760,55 +765,6 @@ export class ProfileVideosComponent {
     return ['PREPARING', 'UPLOADING', 'SAVING'].includes(
       this.uploadPhaseSubject.value
     );
-  }
-
-  publicationLabel(item: ProfileVideoViewItem): string {
-    if (item.video.status === 'failed') {
-      return 'Falha';
-    }
-
-    if (!item.publication?.isPublished && item.publication?.publishWhenReady) {
-      return item.video.status === 'ready' ? 'Publicando' : 'Preparando';
-    }
-
-    if (!item.publication?.isPublished) {
-      return 'Privado';
-    }
-
-    if (item.publication.moderationStatus === 'APPROVED') {
-      return 'Publicado';
-    }
-
-    if (item.publication.moderationStatus === 'PENDING_REVIEW') {
-      return 'Em análise';
-    }
-
-    return 'Indisponível';
-  }
-
-  isPendingPublication(item: ProfileVideoViewItem): boolean {
-    return item.publication?.publishWhenReady === true ||
-      item.publication?.moderationStatus === 'PENDING_REVIEW';
-  }
-
-  processingLabel(video: IVideoItem): string {
-    if (video.status === 'queued') {
-      return 'Na fila';
-    }
-
-    if (video.status === 'processing') {
-      return 'Processando';
-    }
-
-    if (video.status === 'failed') {
-      return 'Falha no processamento';
-    }
-
-    if (video.status === 'ready') {
-      return 'Pronto';
-    }
-
-    return 'Aguardando processamento';
   }
 
   displayVideoTitle(item: ProfileVideoViewItem): string {
@@ -859,9 +815,8 @@ export class ProfileVideosComponent {
     return `${minutes}:${String(seconds).padStart(2, '0')}`;
   }
 
-  private uploadPublicationSettings(
-    publishWhenReady: boolean
-  ): IVideoPublicationSettingsInput & { publishWhenReady: boolean } {
+  private uploadPublicationSettings():
+    IVideoPublicationSettingsInput & { publishWhenReady: true } {
     const raw = this.uploadPublicationForm.getRawValue();
 
     return {
@@ -870,7 +825,7 @@ export class ProfileVideosComponent {
       reactionsEnabled: raw.reactionsEnabled,
       commentsEnabled: raw.commentsEnabled,
       ratingsEnabled: raw.ratingsEnabled,
-      publishWhenReady,
+      publishWhenReady: true,
     };
   }
 
@@ -893,13 +848,12 @@ export class ProfileVideosComponent {
       return;
     }
 
+    this.lastUploadedVideoIdSubject.next(event.result.id);
     this.uploadFailureSubject.next(null);
-    this.uploadPhaseSubject.next('DONE');
+    this.uploadPhaseSubject.next('REGISTERED');
     this.uploadProgressSubject.next(100);
     this.uploadStepSubject.next(
-      this.uploadPublishWhenReady
-        ? 'Vídeo recebido. A publicação continuará automaticamente.'
-        : 'Vídeo recebido e salvo sem publicação.'
+      'Upload registrado. O processamento e a publicação continuam automaticamente.'
     );
     this.revokePreviewUrl();
     this.revokePosterUrl();
@@ -907,9 +861,7 @@ export class ProfileVideosComponent {
     this.selectedPosterBlobSubject.next(null);
     this.previewUrlSubject.next(null);
     this.errorNotification.showSuccess(
-      this.uploadPublishWhenReady
-        ? 'Envio concluído. O vídeo seguirá para processamento e publicação.'
-        : 'Vídeo salvo sem publicação.'
+      'Upload registrado. Acompanhe abaixo o processamento e a publicação.'
     );
   }
 
@@ -933,11 +885,7 @@ export class ProfileVideosComponent {
     }
 
     this.uploadPhaseSubject.next('SAVING');
-    this.uploadStepSubject.next(
-      this.uploadPublishWhenReady
-        ? 'Registrando publicação.'
-        : 'Registrando vídeo.'
-    );
+    this.uploadStepSubject.next('Registrando o vídeo e a intenção de publicação.');
   }
 
   private describeUploadFailure(error: unknown): VideoUploadFailureFeedback {


### PR DESCRIPTION
## Dependência

Este é um PR empilhado sobre o **#68**. A base é `agent/enforce-video-auto-publication`; depois que o #68 for integrado, este PR poderá ser redirecionado para `main` sem carregar alterações duplicadas.

## O que mudou

- substitui o estado visual artificial `DONE` por `REGISTERED`;
- mantém o ID do último vídeo registrado e acompanha seu estado reativamente pelos observables existentes;
- deriva um ciclo de vida único a partir de `video.status`, disponibilidade do derivado, `publishWhenReady`, `isPublished` e `moderationStatus`;
- representa explicitamente: Registrado, Na fila, Processando, Publicando, Em análise, Publicado, Rejeitado, Sinalizado/Oculto, Falha e Vídeo antigo;
- só apresenta `PUBLISHING` quando existem path e MIME processados compatíveis com reprodução pública;
- exige que o path pertença ao namespace `users/{uid}/processed/videos/{videoId}/...`, impedindo que o fallback bruto em `uploads/videos/` seja tratado como derivado concluído;
- centraliza rótulos, mensagens, severidade e terminalidade em `video-lifecycle-state.policy.ts`;
- torna cards e feedback do último upload acessíveis com `role`, `aria-live` e severidade coerentes;
- remove da tela o método morto `unpublishVideo`, já bloqueado pelo backend no PR #68;
- atualiza a documentação do contrato privado para refletir processamento e publicação obrigatória.

## Arquitetura

Nenhum novo status foi persistido no Firestore. A política é uma projeção pura dos documentos já existentes, evitando duas fontes de verdade e mantendo a reatividade por `combineLatest`, `map`, `distinctUntilChanged` e `shareReplay`.

O último upload continua atualizando após o fim da transferência: o painel recebe as mudanças do documento e passa por fila, processamento, moderação e publicação sem polling manual.

## Compatibilidade

Vídeos privados legados continuam identificados como `LEGACY_PRIVATE` somente quando:

- existe configuração de publicação confirmando `publishWhenReady !== true`;
- o vídeo está tecnicamente pronto;
- existe derivado no namespace processado com MIME reproduzível.

A ausência transitória da publicação ou do derivado durante a hidratação não é classificada incorretamente como legado ou publicação em andamento. O path bruto usado temporariamente pelo serviço de acesso privado também não promove o estado visual.

## Testes

A nova política possui cobertura para:

- upload registrado, fila e processamento;
- publicação em andamento com derivado compatível;
- bloqueio do avanço visual quando o derivado ainda não existe;
- rejeição explícita do path bruto `uploads/videos/` como saída processada;
- snapshot de publicação ainda não hidratado;
- moderação pendente;
- publicação aprovada;
- falha técnica com mensagem sanitizada;
- rejeição com motivo;
- conteúdo sinalizado ou oculto;
- vídeo privado legado.

A execução local continua indisponível por falha de resolução DNS do executor. O PR permanece em rascunho para validação integral pelos workflows do GitHub.

## Supressões intencionais

- removido `ProfileVideosComponent.unpublishVideo()`, pois não havia mais chamada no template e o endpoint está bloqueado no backend;
- removidos `publicationLabel()`, `isPendingPublication()` e `processingLabel()`, substituídos pela política central de ciclo de vida;
- removida a variável `uploadPublishWhenReady`, pois novos uploads sempre publicam automaticamente.

Nenhuma lógica de exclusão, edição, upload recuperável ou migração de vídeos legados foi ocultada ou reduzida.