### PR TITLE
feat(video): reserve upload quota before transfer

### DIFF
--- a/functions/src/media/application/private-video-upload-eligibility.service.ts
+++ b/functions/src/media/application/private-video-upload-eligibility.service.ts
@@ -1,0 +1,124 @@
+import { HttpsError } from 'firebase-functions/v2/https';
+
+import { assertInteractionAccessData } from '../../account_lifecycle/interaction-access.policy';
+import { auth, db } from '../../firebaseApp';
+
+interface PrivateVideoUploadAuthSnapshot {
+  disabled?: boolean;
+  emailVerified?: boolean;
+}
+
+interface PrivateVideoUploadAccountSnapshot {
+  uid?: unknown;
+  profileCompleted?: unknown;
+  accountLocked?: unknown;
+  loginAllowed?: unknown;
+  accountStatus?: unknown;
+  suspended?: unknown;
+  interactionBlocked?: unknown;
+  ageReverification?: {
+    status?: unknown;
+  } | null;
+}
+
+function authErrorCode(error: unknown): string {
+  if (!error || typeof error !== 'object') {
+    return '';
+  }
+
+  const candidate = error as {
+    code?: unknown;
+    errorInfo?: { code?: unknown };
+  };
+
+  return String(candidate.errorInfo?.code ?? candidate.code ?? '')
+    .trim()
+    .toLowerCase();
+}
+
+export function assertPrivateVideoUploadEligibilityData(
+  authUser: PrivateVideoUploadAuthSnapshot | null | undefined,
+  user: PrivateVideoUploadAccountSnapshot | null | undefined,
+  expectedUid: string
+): void {
+  if (!authUser || !user) {
+    throw new HttpsError(
+      'failed-precondition',
+      'Seu perfil não está disponível para enviar vídeos.'
+    );
+  }
+
+  const documentUid = String(user.uid ?? expectedUid).trim();
+
+  if (documentUid && documentUid !== expectedUid) {
+    throw new HttpsError(
+      'permission-denied',
+      'O perfil informado não corresponde à conta autenticada.'
+    );
+  }
+
+  if (
+    authUser.disabled === true ||
+    user.accountLocked === true ||
+    user.loginAllowed === false
+  ) {
+    throw new HttpsError(
+      'permission-denied',
+      'Sua conta não está disponível para enviar vídeos.'
+    );
+  }
+
+  assertInteractionAccessData(user);
+
+  if (authUser.emailVerified !== true) {
+    throw new HttpsError(
+      'failed-precondition',
+      'Verifique seu e-mail antes de enviar vídeos.'
+    );
+  }
+
+  if (user.profileCompleted !== true) {
+    throw new HttpsError(
+      'failed-precondition',
+      'Complete seu perfil antes de enviar vídeos.'
+    );
+  }
+}
+
+export async function assertPrivateVideoUploadEligibility(
+  ownerUid: string
+): Promise<Record<string, unknown>> {
+  try {
+    const [authUser, userSnapshot] = await Promise.all([
+      auth.getUser(ownerUid),
+      db.doc(`users/${ownerUid}`).get(),
+    ]);
+    const user = userSnapshot.exists
+      ? userSnapshot.data() as Record<string, unknown>
+      : null;
+
+    assertPrivateVideoUploadEligibilityData(
+      {
+        disabled: authUser.disabled,
+        emailVerified: authUser.emailVerified,
+      },
+      user as PrivateVideoUploadAccountSnapshot | null,
+      ownerUid
+    );
+
+    return user ?? {};
+  } catch (error) {
+    if (error instanceof HttpsError) {
+      throw error;
+    }
+
+    if (authErrorCode(error) === 'auth/user-not-found') {
+      throw new HttpsError(
+        'failed-precondition',
+        'Sua conta não está disponível para enviar vídeos.'
+      );
+    }
+
+    throw error;
+  }
+}

--- a/functions/src/media/application/private-video-upload-quota.policy.test.ts
+++ b/functions/src/media/application/private-video-upload-quota.policy.test.ts
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  calculatePrivateVideoReservationBytes,
+  estimateRegisteredVideoReservedBytes,
+  evaluatePrivateVideoQuota,
+  getPrivateVideoQuotaLimit,
+  resolvePrivateVideoQuotaPlan,
+} from './private-video-upload-quota.policy';
+
+const MIB = 1024 * 1024;
+const GIB = 1024 * MIB;
+
+describe('private-video-upload-quota.policy', () => {
+  it('mantém conta sem projeção financeira no plano free', () => {
+    assert.equal(
+      resolvePrivateVideoQuotaPlan({ role: 'premium' }, 1_000),
+      'free'
+    );
+  });
+
+  it('reconhece projeção paga ativa e vigente', () => {
+    assert.equal(
+      resolvePrivateVideoQuotaPlan(
+        {
+          tier: 'premium',
+          billingProjectionVersion: 1,
+          isSubscriber: true,
+          subscriptionStatus: 'active',
+          subscriptionScope: 'platform_subscription',
+          subscriptionStartedAt: 500,
+          subscriptionEndsAt: 2_000,
+        },
+        1_000
+      ),
+      'premium'
+    );
+  });
+
+  it('não reconhece assinatura vencida', () => {
+    assert.equal(
+      resolvePrivateVideoQuotaPlan(
+        {
+          tier: 'vip',
+          billingProjectionVersion: 1,
+          isSubscriber: true,
+          subscriptionStatus: 'active',
+          subscriptionScope: 'platform_subscription',
+          subscriptionStartedAt: 500,
+          subscriptionEndsAt: 900,
+        },
+        1_000
+      ),
+      'free'
+    );
+  });
+
+  it('reserva original, margem do derivado e capa', () => {
+    assert.equal(
+      calculatePrivateVideoReservationBytes(300 * MIB, 2 * MIB),
+      602 * MIB
+    );
+  });
+
+  it('usa quota persistida quando disponível', () => {
+    assert.equal(
+      estimateRegisteredVideoReservedBytes({ quotaReservedBytes: 1234 }),
+      1234
+    );
+  });
+
+  it('estima vídeos legados sem quota persistida', () => {
+    assert.equal(
+      estimateRegisteredVideoReservedBytes({
+        sourceSizeBytes: 100,
+        processedSizeBytes: 80,
+        posterSizeBytes: 5,
+      }),
+      205
+    );
+  });
+
+  it('bloqueia quantidade acima do plano', () => {
+    const decision = evaluatePrivateVideoQuota(
+      'free',
+      { currentItems: 1, currentReservedBytes: 100 },
+      200
+    );
+
+    assert.equal(decision.allowed, false);
+    assert.equal(decision.reason, 'ITEM_LIMIT');
+    assert.equal(decision.limit.maxItems, 1);
+  });
+
+  it('bloqueia volume acima do plano', () => {
+    const decision = evaluatePrivateVideoQuota(
+      'basic',
+      { currentItems: 0, currentReservedBytes: 2 * GIB - 100 },
+      200
+    );
+
+    assert.equal(decision.allowed, false);
+    assert.equal(decision.reason, 'BYTE_LIMIT');
+    assert.equal(decision.limit.maxReservedBytes, 2 * GIB);
+  });
+
+  it('libera capacidade dentro dos limites', () => {
+    const decision = evaluatePrivateVideoQuota(
+      'vip',
+      { currentItems: 4, currentReservedBytes: 4 * GIB },
+      500 * MIB
+    );
+
+    assert.equal(decision.allowed, true);
+    assert.equal(decision.reason, 'ALLOWED');
+    assert.equal(decision.nextItems, 5);
+    assert.equal(getPrivateVideoQuotaLimit('vip').maxItems, 10);
+  });
+});

--- a/functions/src/media/application/private-video-upload-quota.policy.ts
+++ b/functions/src/media/application/private-video-upload-quota.policy.ts
@@ -1,0 +1,213 @@
+export type PrivateVideoQuotaPlan = 'free' | 'basic' | 'premium' | 'vip';
+
+export interface PrivateVideoQuotaLimit {
+  readonly maxItems: number;
+  readonly maxReservedBytes: number;
+}
+
+export interface PrivateVideoQuotaUsage {
+  readonly currentItems: number;
+  readonly currentReservedBytes: number;
+}
+
+export type PrivateVideoQuotaDecision =
+  | {
+      readonly allowed: true;
+      readonly reason: 'ALLOWED';
+      readonly usage: PrivateVideoQuotaUsage;
+      readonly nextItems: number;
+      readonly nextReservedBytes: number;
+      readonly limit: PrivateVideoQuotaLimit;
+    }
+  | {
+      readonly allowed: false;
+      readonly reason: 'ITEM_LIMIT' | 'BYTE_LIMIT';
+      readonly usage: PrivateVideoQuotaUsage;
+      readonly nextItems: number;
+      readonly nextReservedBytes: number;
+      readonly limit: PrivateVideoQuotaLimit;
+    };
+
+const MIB = 1024 * 1024;
+const GIB = 1024 * MIB;
+
+const LIMITS: Readonly<Record<PrivateVideoQuotaPlan, PrivateVideoQuotaLimit>> = {
+  free: {
+    maxItems: 1,
+    maxReservedBytes: 800 * MIB,
+  },
+  basic: {
+    maxItems: 2,
+    maxReservedBytes: 2 * GIB,
+  },
+  premium: {
+    maxItems: 5,
+    maxReservedBytes: 5 * GIB,
+  },
+  vip: {
+    maxItems: 10,
+    maxReservedBytes: 10 * GIB,
+  },
+};
+
+function normalizeNonNegativeInteger(value: unknown): number {
+  const parsed = Number(value ?? 0);
+
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return 0;
+  }
+
+  return Math.min(Number.MAX_SAFE_INTEGER, Math.trunc(parsed));
+}
+
+function toMillis(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.trunc(value);
+  }
+
+  if (
+    value &&
+    typeof value === 'object' &&
+    typeof (value as { toMillis?: unknown }).toMillis === 'function'
+  ) {
+    const millis = (value as { toMillis(): number }).toMillis();
+    return Number.isFinite(millis) ? Math.trunc(millis) : null;
+  }
+
+  return null;
+}
+
+export function resolvePrivateVideoQuotaPlan(
+  user: Record<string, unknown> | null | undefined,
+  now = Date.now()
+): PrivateVideoQuotaPlan {
+  const role = String(user?.['tier'] ?? user?.['role'] ?? '')
+    .trim()
+    .toLowerCase();
+
+  if (role === 'admin') {
+    return 'vip';
+  }
+
+  if (
+    user?.['billingProjectionVersion'] !== 1 ||
+    user?.['isSubscriber'] !== true ||
+    user?.['subscriptionStatus'] !== 'active' ||
+    user?.['subscriptionScope'] !== 'platform_subscription'
+  ) {
+    return 'free';
+  }
+
+  const startsAt = toMillis(user?.['subscriptionStartedAt']);
+  const endsAt = toMillis(
+    user?.['subscriptionEndsAt'] ?? user?.['subscriptionExpires']
+  );
+
+  if (
+    startsAt === null ||
+    endsAt === null ||
+    startsAt >= endsAt ||
+    now < startsAt ||
+    now >= endsAt
+  ) {
+    return 'free';
+  }
+
+  return role === 'basic' || role === 'premium' || role === 'vip'
+    ? role
+    : 'free';
+}
+
+export function getPrivateVideoQuotaLimit(
+  plan: PrivateVideoQuotaPlan
+): PrivateVideoQuotaLimit {
+  return { ...LIMITS[plan] };
+}
+
+export function calculatePrivateVideoReservationBytes(
+  sourceSizeBytes: unknown,
+  posterSizeBytes: unknown = 0
+): number {
+  const source = normalizeNonNegativeInteger(sourceSizeBytes);
+  const poster = normalizeNonNegativeInteger(posterSizeBytes);
+
+  return Math.min(Number.MAX_SAFE_INTEGER, source * 2 + poster);
+}
+
+export function estimateRegisteredVideoReservedBytes(
+  video: Record<string, unknown>
+): number {
+  const persistedReservation = normalizeNonNegativeInteger(
+    video['quotaReservedBytes']
+  );
+
+  if (persistedReservation > 0) {
+    return persistedReservation;
+  }
+
+  const sourceSize = normalizeNonNegativeInteger(
+    video['sourceSizeBytes'] ?? video['sizeBytes']
+  );
+  const processedSize = normalizeNonNegativeInteger(
+    video['processedSizeBytes']
+  );
+  const posterSize = normalizeNonNegativeInteger(video['posterSizeBytes']);
+
+  if (sourceSize <= 0) {
+    return 0;
+  }
+
+  return Math.min(
+    Number.MAX_SAFE_INTEGER,
+    sourceSize + Math.max(sourceSize, processedSize) + posterSize
+  );
+}
+
+export function evaluatePrivateVideoQuota(
+  plan: PrivateVideoQuotaPlan,
+  usage: PrivateVideoQuotaUsage,
+  requestedReservedBytes: unknown
+): PrivateVideoQuotaDecision {
+  const limit = getPrivateVideoQuotaLimit(plan);
+  const currentItems = normalizeNonNegativeInteger(usage.currentItems);
+  const currentReservedBytes = normalizeNonNegativeInteger(
+    usage.currentReservedBytes
+  );
+  const reservationBytes = normalizeNonNegativeInteger(
+    requestedReservedBytes
+  );
+  const normalizedUsage = { currentItems, currentReservedBytes };
+  const nextItems = currentItems + 1;
+  const nextReservedBytes = currentReservedBytes + reservationBytes;
+
+  if (nextItems > limit.maxItems) {
+    return {
+      allowed: false,
+      reason: 'ITEM_LIMIT',
+      usage: normalizedUsage,
+      nextItems,
+      nextReservedBytes,
+      limit,
+    };
+  }
+
+  if (nextReservedBytes > limit.maxReservedBytes) {
+    return {
+      allowed: false,
+      reason: 'BYTE_LIMIT',
+      usage: normalizedUsage,
+      nextItems,
+      nextReservedBytes,
+      limit,
+    };
+  }
+
+  return {
+    allowed: true,
+    reason: 'ALLOWED',
+    usage: normalizedUsage,
+    nextItems,
+    nextReservedBytes,
+    limit,
+  };
+}

--- a/functions/src/media/application/private-video-upload-reservation-registration.service.ts
+++ b/functions/src/media/application/private-video-upload-reservation-registration.service.ts
@@ -1,0 +1,331 @@
+import { Timestamp } from 'firebase-admin/firestore';
+import * as logger from 'firebase-functions/logger';
+import { HttpsError } from 'firebase-functions/v2/https';
+import { onDocumentCreated } from 'firebase-functions/v2/firestore';
+
+import { FUNCTIONS_REGION } from '../../config/functions-region';
+import { db } from '../../firebaseApp';
+import type { PrivateVideoUploadReservationDocument } from './private-video-upload-reservation.handler';
+import {
+  extractOwnedPrivateVideoPathForId,
+  extractOwnedPrivateVideoPosterPath,
+} from './video-storage-path';
+
+export interface PrivateVideoReservationRegistrationInput {
+  reservationId: string;
+  ownerUid: string;
+  videoId: string;
+  videoStoragePath: string;
+  posterStoragePath: string | null;
+  videoSizeBytes: number;
+  mimeType: string;
+}
+
+const RESERVATIONS_COLLECTION = 'media_private_video_upload_reservations';
+const CAPACITY_LOCK_COLLECTION = 'media_private_video_upload_capacity';
+const TERMINAL_RETENTION_MS = 24 * 60 * 60 * 1000;
+
+function cleanId(value: unknown): string {
+  const normalized = String(value ?? '').trim();
+  return /^[A-Za-z0-9_-]{1,128}$/.test(normalized) ? normalized : '';
+}
+
+function normalizePositiveInteger(value: unknown): number {
+  const parsed = Number(value ?? 0);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.trunc(parsed) : 0;
+}
+
+function normalizeMimeType(value: unknown): string {
+  return String(value ?? '').trim().toLowerCase();
+}
+
+function reservationReference(reservationId: string) {
+  return db.collection(RESERVATIONS_COLLECTION).doc(reservationId);
+}
+
+function capacityLockReference(ownerUid: string) {
+  return db.collection(CAPACITY_LOCK_COLLECTION).doc(ownerUid);
+}
+
+function nextLockGeneration(snapshot: FirebaseFirestore.DocumentSnapshot): number {
+  const current = Number(snapshot.data()?.['generation'] ?? 0);
+  return Number.isFinite(current) && current >= 0
+    ? Math.trunc(current) + 1
+    : 1;
+}
+
+function normalizeInput(
+  input: PrivateVideoReservationRegistrationInput
+): PrivateVideoReservationRegistrationInput {
+  const ownerUid = cleanId(input.ownerUid);
+  const videoId = cleanId(input.videoId);
+  const reservationId = cleanId(input.reservationId);
+  const videoStoragePath = extractOwnedPrivateVideoPathForId(
+    ownerUid,
+    videoId,
+    input.videoStoragePath
+  );
+  const rawPosterPath = String(input.posterStoragePath ?? '').trim();
+  const posterStoragePath = rawPosterPath
+    ? extractOwnedPrivateVideoPosterPath(ownerUid, videoId, rawPosterPath)
+    : null;
+  const videoSizeBytes = normalizePositiveInteger(input.videoSizeBytes);
+  const mimeType = normalizeMimeType(input.mimeType);
+
+  if (
+    !ownerUid ||
+    !videoId ||
+    !reservationId ||
+    !videoStoragePath ||
+    (rawPosterPath && !posterStoragePath) ||
+    !videoSizeBytes ||
+    !mimeType
+  ) {
+    throw new HttpsError(
+      'failed-precondition',
+      'A reserva de upload não corresponde ao vídeo registrado.',
+      {
+        code: 'VIDEO_UPLOAD_RESERVATION_MISMATCH',
+        retryable: false,
+        recovery: 'Selecione novamente o arquivo e reinicie o envio.',
+      }
+    );
+  }
+
+  return {
+    reservationId,
+    ownerUid,
+    videoId,
+    videoStoragePath,
+    posterStoragePath,
+    videoSizeBytes,
+    mimeType,
+  };
+}
+
+function assertReservationMatches(
+  reservation: PrivateVideoUploadReservationDocument,
+  input: PrivateVideoReservationRegistrationInput
+): void {
+  if (
+    reservation.ownerUid !== input.ownerUid ||
+    reservation.videoId !== input.videoId ||
+    reservation.videoStoragePath !== input.videoStoragePath ||
+    reservation.posterStoragePath !== input.posterStoragePath ||
+    reservation.videoSizeBytes !== input.videoSizeBytes ||
+    reservation.mimeType !== input.mimeType
+  ) {
+    throw new HttpsError(
+      'failed-precondition',
+      'A reserva não corresponde ao arquivo enviado.',
+      {
+        code: 'VIDEO_UPLOAD_RESERVATION_MISMATCH',
+        retryable: false,
+        recovery: 'Selecione novamente o arquivo e reinicie o envio.',
+      }
+    );
+  }
+}
+
+export async function assertPrivateVideoUploadReservation(
+  inputValue: PrivateVideoReservationRegistrationInput
+): Promise<PrivateVideoUploadReservationDocument> {
+  const input = normalizeInput(inputValue);
+  const snapshot = await reservationReference(input.reservationId).get();
+
+  if (!snapshot.exists) {
+    throw new HttpsError(
+      'failed-precondition',
+      'A reserva do upload não existe ou expirou.',
+      {
+        code: 'VIDEO_UPLOAD_RESERVATION_EXPIRED',
+        retryable: true,
+        recovery: 'Inicie o envio novamente para gerar uma nova reserva.',
+      }
+    );
+  }
+
+  const reservation = snapshot.data() as PrivateVideoUploadReservationDocument;
+  assertReservationMatches(reservation, input);
+
+  if (
+    reservation.state !== 'CONSUMED' &&
+    (
+      reservation.state !== 'ACTIVE' ||
+      reservation.expiresAt.toMillis() <= Date.now()
+    )
+  ) {
+    throw new HttpsError(
+      'failed-precondition',
+      'A reserva do upload expirou ou já foi cancelada.',
+      {
+        code: 'VIDEO_UPLOAD_RESERVATION_EXPIRED',
+        retryable: true,
+        recovery: 'Inicie o envio novamente para gerar uma nova reserva.',
+      }
+    );
+  }
+
+  return reservation;
+}
+
+export async function consumePrivateVideoUploadReservationAfterRegistration(
+  inputValue: PrivateVideoReservationRegistrationInput
+): Promise<PrivateVideoUploadReservationDocument> {
+  const input = normalizeInput(inputValue);
+  const reservationRef = reservationReference(input.reservationId);
+  const lockRef = capacityLockReference(input.ownerUid);
+  const videoRef = db.doc(`users/${input.ownerUid}/videos/${input.videoId}`);
+  const now = Date.now();
+  const cleanupAfter = now + TERMINAL_RETENTION_MS;
+
+  return db.runTransaction(async (transaction) => {
+    const [reservationSnapshot, lockSnapshot, videoSnapshot] =
+      await Promise.all([
+        transaction.get(reservationRef),
+        transaction.get(lockRef),
+        transaction.get(videoRef),
+      ]);
+
+    if (!reservationSnapshot.exists || !videoSnapshot.exists) {
+      throw new HttpsError(
+        'failed-precondition',
+        'O vídeo ou sua reserva não estão disponíveis para confirmação.'
+      );
+    }
+
+    const reservation = reservationSnapshot.data() as
+      PrivateVideoUploadReservationDocument;
+    assertReservationMatches(reservation, input);
+
+    if (
+      reservation.state !== 'ACTIVE' &&
+      reservation.state !== 'CONSUMED'
+    ) {
+      throw new HttpsError(
+        'failed-precondition',
+        'A reserva do upload foi cancelada antes da confirmação.'
+      );
+    }
+
+    transaction.set(
+      videoRef,
+      {
+        videoReservationId: reservation.reservationId,
+        quotaPlanAtUpload: reservation.plan,
+        quotaReservedBytes: reservation.reservedBytes,
+        posterSizeBytes: reservation.posterSizeBytes,
+        updatedAt: now,
+      },
+      { merge: true }
+    );
+
+    if (reservation.state === 'ACTIVE') {
+      transaction.update(reservationRef, {
+        state: 'CONSUMED',
+        consumedAt: Timestamp.fromMillis(now),
+        updatedAt: Timestamp.fromMillis(now),
+        expiresAt: Timestamp.fromMillis(cleanupAfter),
+        cleanupAfter: Timestamp.fromMillis(cleanupAfter),
+      });
+      transaction.set(
+        lockRef,
+        {
+          generation: nextLockGeneration(lockSnapshot),
+          updatedAt: now,
+        },
+        { merge: true }
+      );
+    }
+
+    return reservation;
+  });
+}
+
+async function findReservationForRegisteredVideo(
+  ownerUid: string,
+  videoId: string
+): Promise<PrivateVideoUploadReservationDocument | null> {
+  const snapshot = await db
+    .collection(RESERVATIONS_COLLECTION)
+    .where('ownerUid', '==', ownerUid)
+    .get();
+  const candidates = snapshot.docs
+    .map((document) =>
+      document.data() as PrivateVideoUploadReservationDocument
+    )
+    .filter((reservation) =>
+      reservation.videoId === videoId &&
+      (
+        reservation.state === 'ACTIVE' ||
+        reservation.state === 'CONSUMED'
+      )
+    )
+    .sort((left, right) =>
+      right.createdAt.toMillis() - left.createdAt.toMillis()
+    );
+
+  return candidates[0] ?? null;
+}
+
+export const consumeVideoUploadReservationOnRegistration = onDocumentCreated(
+  {
+    document: 'users/{ownerUid}/videos/{videoId}',
+    region: FUNCTIONS_REGION,
+    retry: true,
+  },
+  async (event) => {
+    const ownerUid = cleanId(event.params.ownerUid);
+    const videoId = cleanId(event.params.videoId);
+    const video = event.data?.data() as Record<string, unknown> | undefined;
+
+    if (!ownerUid || !videoId || !video) {
+      return;
+    }
+
+    const reservation = await findReservationForRegisteredVideo(
+      ownerUid,
+      videoId
+    );
+
+    if (!reservation) {
+      logger.error('[videoUploadReservation] Registro sem reserva.', {
+        ownerUid,
+        videoId,
+      });
+      return;
+    }
+
+    const videoStoragePath = extractOwnedPrivateVideoPathForId(
+      ownerUid,
+      videoId,
+      video['path'] ?? video['url']
+    );
+    const rawPosterPath = String(
+      video['thumbnailPath'] ?? video['thumbnailUrl'] ?? ''
+    ).trim();
+    const posterStoragePath = rawPosterPath
+      ? extractOwnedPrivateVideoPosterPath(ownerUid, videoId, rawPosterPath)
+      : null;
+    const videoSizeBytes = normalizePositiveInteger(
+      video['sourceSizeBytes'] ?? video['sizeBytes']
+    );
+    const mimeType = normalizeMimeType(
+      video['sourceMimeType'] ?? video['mimeType']
+    );
+
+    if (!videoStoragePath || (rawPosterPath && !posterStoragePath)) {
+      throw new Error('O vídeo registrado possui paths incompatíveis.');
+    }
+
+    await consumePrivateVideoUploadReservationAfterRegistration({
+      reservationId: reservation.reservationId,
+      ownerUid,
+      videoId,
+      videoStoragePath,
+      posterStoragePath,
+      videoSizeBytes,
+      mimeType,
+    });
+  }
+);

--- a/functions/src/media/application/private-video-upload-reservation.handler.ts
+++ b/functions/src/media/application/private-video-upload-reservation.handler.ts
@@ -1,0 +1,780 @@
+import { createHash } from 'node:crypto';
+
+import { Timestamp, type Transaction } from 'firebase-admin/firestore';
+import * as logger from 'firebase-functions/logger';
+import { HttpsError, onCall } from 'firebase-functions/v2/https';
+import { onSchedule } from 'firebase-functions/v2/scheduler';
+
+import { FUNCTIONS_REGION } from '../../config/functions-region';
+import { db, storage } from '../../firebaseApp';
+import { assertPrivateVideoUploadEligibility } from './private-video-upload-eligibility.service';
+import {
+  calculatePrivateVideoReservationBytes,
+  estimateRegisteredVideoReservedBytes,
+  evaluatePrivateVideoQuota,
+  resolvePrivateVideoQuotaPlan,
+  type PrivateVideoQuotaPlan,
+} from './private-video-upload-quota.policy';
+import {
+  extractOwnedPrivateVideoPathForId,
+  extractOwnedPrivateVideoPosterPath,
+} from './video-storage-path';
+
+export type PrivateVideoUploadReservationState =
+  | 'ACTIVE'
+  | 'CONSUMED'
+  | 'CANCELLED'
+  | 'EXPIRED';
+
+export interface PrivateVideoUploadReservationDocument {
+  reservationId: string;
+  clientRequestId: string;
+  ownerUid: string;
+  videoId: string;
+  state: PrivateVideoUploadReservationState;
+  videoStoragePath: string;
+  posterStoragePath: string | null;
+  videoSizeBytes: number;
+  posterSizeBytes: number;
+  mimeType: string;
+  reservedBytes: number;
+  plan: PrivateVideoQuotaPlan;
+  createdAt: Timestamp;
+  updatedAt: Timestamp;
+  expiresAt: Timestamp;
+  consumedAt: Timestamp | null;
+  cleanupAfter: Timestamp | null;
+}
+
+interface ReservePrivateVideoUploadRequest {
+  clientRequestId?: unknown;
+  ownerUid?: unknown;
+  videoId?: unknown;
+  videoStoragePath?: unknown;
+  posterStoragePath?: unknown;
+  videoSizeBytes?: unknown;
+  posterSizeBytes?: unknown;
+  mimeType?: unknown;
+}
+
+interface ReservePrivateVideoUploadResponse {
+  reservationId: string;
+  ownerUid: string;
+  videoId: string;
+  plan: PrivateVideoQuotaPlan;
+  expiresAt: number;
+  reservedBytes: number;
+  maxItems: number;
+  maxReservedBytes: number;
+  currentItems: number;
+  currentReservedBytes: number;
+}
+
+interface CancelPrivateVideoUploadReservationRequest {
+  reservationId?: unknown;
+}
+
+interface CancelPrivateVideoUploadReservationResponse {
+  reservationId: string;
+  released: boolean;
+}
+
+export interface ConsumePrivateVideoUploadReservationInput {
+  reservationId: string;
+  ownerUid: string;
+  videoId: string;
+  videoStoragePath: string;
+  posterStoragePath: string | null;
+  videoSizeBytes: number;
+  posterSizeBytes: number;
+  mimeType: string;
+  now?: number;
+}
+
+const RESERVATIONS_COLLECTION = 'media_private_video_upload_reservations';
+const CAPACITY_LOCK_COLLECTION = 'media_private_video_upload_capacity';
+const ACTIVE_RESERVATION_MS = 30 * 60 * 1000;
+const TERMINAL_RETENTION_MS = 24 * 60 * 60 * 1000;
+const CLEANUP_BATCH_SIZE = 50;
+const MAX_VIDEO_SIZE_BYTES = 500 * 1024 * 1024;
+const MAX_POSTER_SIZE_BYTES = 10 * 1024 * 1024;
+const ALLOWED_VIDEO_TYPES = new Set([
+  'video/mp4',
+  'video/webm',
+  'video/quicktime',
+]);
+
+function containsControlCharacter(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+
+    if (code <= 31 || code === 127) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function cleanId(value: unknown): string {
+  const normalized = String(value ?? '').trim();
+
+  if (
+    !normalized ||
+    normalized.length > 128 ||
+    normalized.includes('/') ||
+    containsControlCharacter(normalized)
+  ) {
+    return '';
+  }
+
+  return normalized;
+}
+
+function normalizePositiveInteger(value: unknown): number {
+  const parsed = Number(value ?? 0);
+
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return 0;
+  }
+
+  return Math.min(Number.MAX_SAFE_INTEGER, Math.trunc(parsed));
+}
+
+function normalizeMimeType(value: unknown): string {
+  return String(value ?? '').trim().toLowerCase();
+}
+
+function timestampToMillis(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.trunc(value);
+  }
+
+  const candidate = value as { toMillis?: () => number } | null | undefined;
+  return typeof candidate?.toMillis === 'function'
+    ? candidate.toMillis()
+    : 0;
+}
+
+function normalizeErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) {
+    return error.message.slice(0, 500);
+  }
+
+  return String(error ?? 'unknown').slice(0, 500);
+}
+
+function reservationDocumentId(
+  ownerUid: string,
+  clientRequestId: string
+): string {
+  return createHash('sha256')
+    .update(`${ownerUid}:${clientRequestId}`)
+    .digest('hex');
+}
+
+function reservationReference(reservationId: string) {
+  return db.collection(RESERVATIONS_COLLECTION).doc(reservationId);
+}
+
+function capacityLockReference(ownerUid: string) {
+  return db.collection(CAPACITY_LOCK_COLLECTION).doc(ownerUid);
+}
+
+function nextLockGeneration(snapshot: FirebaseFirestore.DocumentSnapshot): number {
+  const current = Number(snapshot.data()?.['generation'] ?? 0);
+  return Number.isFinite(current) && current >= 0
+    ? Math.trunc(current) + 1
+    : 1;
+}
+
+function validateMaximumSizes(
+  videoSizeBytes: number,
+  posterSizeBytes: number
+): void {
+  if (!videoSizeBytes || videoSizeBytes > MAX_VIDEO_SIZE_BYTES) {
+    throw new HttpsError(
+      'invalid-argument',
+      'O vídeo excede o limite permitido ou está vazio.'
+    );
+  }
+
+  if (posterSizeBytes > MAX_POSTER_SIZE_BYTES) {
+    throw new HttpsError(
+      'invalid-argument',
+      'A capa excede o limite permitido.'
+    );
+  }
+}
+
+function sameReservationRequest(
+  reservation: PrivateVideoUploadReservationDocument,
+  input: {
+    clientRequestId: string;
+    ownerUid: string;
+    videoId: string;
+    videoStoragePath: string;
+    posterStoragePath: string | null;
+    videoSizeBytes: number;
+    posterSizeBytes: number;
+    mimeType: string;
+  }
+): boolean {
+  return reservation.clientRequestId === input.clientRequestId &&
+    reservation.ownerUid === input.ownerUid &&
+    reservation.videoId === input.videoId &&
+    reservation.videoStoragePath === input.videoStoragePath &&
+    reservation.posterStoragePath === input.posterStoragePath &&
+    reservation.videoSizeBytes === input.videoSizeBytes &&
+    reservation.posterSizeBytes === input.posterSizeBytes &&
+    reservation.mimeType === input.mimeType;
+}
+
+function quotaHttpsError(
+  reason: 'ITEM_LIMIT' | 'BYTE_LIMIT',
+  details: Record<string, unknown>
+): HttpsError {
+  return new HttpsError(
+    'resource-exhausted',
+    reason === 'ITEM_LIMIT'
+      ? 'Você atingiu o limite de vídeos do seu plano.'
+      : 'Seus vídeos atingiram o limite de armazenamento do seu plano.',
+    {
+      code: reason === 'ITEM_LIMIT'
+        ? 'VIDEO_UPLOAD_ITEM_LIMIT'
+        : 'VIDEO_UPLOAD_BYTE_LIMIT',
+      retryable: false,
+      recovery: 'Exclua um vídeo existente ou altere o plano antes de continuar.',
+      ...details,
+    }
+  );
+}
+
+function reservationExpiredError(): HttpsError {
+  return new HttpsError(
+    'failed-precondition',
+    'A reserva do upload expirou ou já foi utilizada.',
+    {
+      code: 'VIDEO_UPLOAD_RESERVATION_EXPIRED',
+      retryable: true,
+      recovery: 'Inicie o envio novamente para gerar uma nova reserva.',
+    }
+  );
+}
+
+function reservationMismatchError(): HttpsError {
+  return new HttpsError(
+    'failed-precondition',
+    'A reserva não corresponde ao arquivo enviado.',
+    {
+      code: 'VIDEO_UPLOAD_RESERVATION_MISMATCH',
+      retryable: false,
+      recovery: 'Selecione novamente o arquivo e reinicie o envio.',
+    }
+  );
+}
+
+function buildReserveResponse(
+  reservation: PrivateVideoUploadReservationDocument,
+  usage: {
+    currentItems: number;
+    currentReservedBytes: number;
+  },
+  limit: {
+    maxItems: number;
+    maxReservedBytes: number;
+  }
+): ReservePrivateVideoUploadResponse {
+  return {
+    reservationId: reservation.reservationId,
+    ownerUid: reservation.ownerUid,
+    videoId: reservation.videoId,
+    plan: reservation.plan,
+    expiresAt: reservation.expiresAt.toMillis(),
+    reservedBytes: reservation.reservedBytes,
+    maxItems: limit.maxItems,
+    maxReservedBytes: limit.maxReservedBytes,
+    currentItems: usage.currentItems,
+    currentReservedBytes: usage.currentReservedBytes,
+  };
+}
+
+async function deleteReservedObjectsBestEffort(
+  reservation: PrivateVideoUploadReservationDocument
+): Promise<void> {
+  const videoPath = extractOwnedPrivateVideoPathForId(
+    reservation.ownerUid,
+    reservation.videoId,
+    reservation.videoStoragePath
+  );
+  const posterPath = reservation.posterStoragePath
+    ? extractOwnedPrivateVideoPosterPath(
+      reservation.ownerUid,
+      reservation.videoId,
+      reservation.posterStoragePath
+    )
+    : null;
+  const paths = [
+    ...(videoPath ? [videoPath] : []),
+    ...(posterPath ? [posterPath] : []),
+  ];
+
+  await Promise.all(paths.map(async (storagePath) => {
+    try {
+      await storage
+        .bucket()
+        .file(storagePath)
+        .delete({ ignoreNotFound: true });
+    } catch (error) {
+      logger.warn('[privateVideoUploadReservation] Limpeza pendente.', {
+        reservationId: reservation.reservationId,
+        ownerUid: reservation.ownerUid,
+        videoId: reservation.videoId,
+        error: normalizeErrorMessage(error),
+      });
+    }
+  }));
+}
+
+async function transitionActiveReservation(
+  reservationId: string,
+  expectedOwnerUid: string | null,
+  terminalState: 'CANCELLED' | 'EXPIRED'
+): Promise<PrivateVideoUploadReservationDocument | null> {
+  const reservationRef = reservationReference(reservationId);
+  const now = Date.now();
+  const cleanupAfter = now + TERMINAL_RETENTION_MS;
+
+  return db.runTransaction(async (transaction) => {
+    const reservationSnapshot = await transaction.get(reservationRef);
+
+    if (!reservationSnapshot.exists) {
+      return null;
+    }
+
+    const reservation = reservationSnapshot.data() as
+      PrivateVideoUploadReservationDocument;
+
+    if (
+      reservation.state !== 'ACTIVE' ||
+      (expectedOwnerUid && reservation.ownerUid !== expectedOwnerUid)
+    ) {
+      return null;
+    }
+
+    const lockRef = capacityLockReference(reservation.ownerUid);
+    const lockSnapshot = await transaction.get(lockRef);
+
+    transaction.update(reservationRef, {
+      state: terminalState,
+      updatedAt: Timestamp.fromMillis(now),
+      expiresAt: Timestamp.fromMillis(cleanupAfter),
+      cleanupAfter: Timestamp.fromMillis(cleanupAfter),
+    });
+    transaction.set(
+      lockRef,
+      {
+        generation: nextLockGeneration(lockSnapshot),
+        updatedAt: now,
+      },
+      { merge: true }
+    );
+
+    return reservation;
+  });
+}
+
+export async function cancelPrivateVideoUploadReservationById(
+  reservationIdValue: unknown,
+  expectedOwnerUid: string | null = null
+): Promise<boolean> {
+  const reservationId = cleanId(reservationIdValue);
+
+  if (!reservationId) {
+    return false;
+  }
+
+  const reservation = await transitionActiveReservation(
+    reservationId,
+    expectedOwnerUid,
+    'CANCELLED'
+  );
+
+  if (!reservation) {
+    return false;
+  }
+
+  await deleteReservedObjectsBestEffort(reservation);
+  return true;
+}
+
+export async function consumePrivateVideoUploadReservation(
+  transaction: Transaction,
+  input: ConsumePrivateVideoUploadReservationInput
+): Promise<PrivateVideoUploadReservationDocument> {
+  const reservationId = cleanId(input.reservationId);
+
+  if (!reservationId) {
+    throw reservationExpiredError();
+  }
+
+  const reservationRef = reservationReference(reservationId);
+  const lockRef = capacityLockReference(input.ownerUid);
+  const [reservationSnapshot, lockSnapshot] = await Promise.all([
+    transaction.get(reservationRef),
+    transaction.get(lockRef),
+  ]);
+
+  if (!reservationSnapshot.exists) {
+    throw reservationExpiredError();
+  }
+
+  const reservation = reservationSnapshot.data() as
+    PrivateVideoUploadReservationDocument;
+  const now = input.now ?? Date.now();
+
+  if (
+    reservation.state !== 'ACTIVE' ||
+    reservation.expiresAt.toMillis() <= now
+  ) {
+    throw reservationExpiredError();
+  }
+
+  if (
+    reservation.ownerUid !== input.ownerUid ||
+    reservation.videoId !== input.videoId ||
+    reservation.videoStoragePath !== input.videoStoragePath ||
+    reservation.posterStoragePath !== input.posterStoragePath ||
+    reservation.videoSizeBytes !== input.videoSizeBytes ||
+    reservation.posterSizeBytes !== input.posterSizeBytes ||
+    reservation.mimeType !== input.mimeType
+  ) {
+    throw reservationMismatchError();
+  }
+
+  const cleanupAfter = now + TERMINAL_RETENTION_MS;
+
+  transaction.update(reservationRef, {
+    state: 'CONSUMED',
+    consumedAt: Timestamp.fromMillis(now),
+    updatedAt: Timestamp.fromMillis(now),
+    expiresAt: Timestamp.fromMillis(cleanupAfter),
+    cleanupAfter: Timestamp.fromMillis(cleanupAfter),
+  });
+  transaction.set(
+    lockRef,
+    {
+      generation: nextLockGeneration(lockSnapshot),
+      updatedAt: now,
+    },
+    { merge: true }
+  );
+
+  return reservation;
+}
+
+export const reservePrivateVideoUpload = onCall<ReservePrivateVideoUploadRequest>(
+  { region: FUNCTIONS_REGION },
+  async (request): Promise<ReservePrivateVideoUploadResponse> => {
+    const requesterUid = cleanId(request.auth?.uid);
+    const ownerUid = cleanId(request.data?.ownerUid);
+    const videoId = cleanId(request.data?.videoId);
+    const clientRequestId = cleanId(request.data?.clientRequestId);
+
+    if (!requesterUid) {
+      throw new HttpsError('unauthenticated', 'Usuário não autenticado.');
+    }
+
+    if (
+      !ownerUid ||
+      requesterUid !== ownerUid ||
+      !videoId ||
+      !clientRequestId
+    ) {
+      throw new HttpsError(
+        'invalid-argument',
+        'Os dados da reserva de upload são inválidos.'
+      );
+    }
+
+    const videoStoragePath = extractOwnedPrivateVideoPathForId(
+      ownerUid,
+      videoId,
+      request.data?.videoStoragePath
+    );
+    const rawPosterPath = String(request.data?.posterStoragePath ?? '').trim();
+    const posterStoragePath = rawPosterPath
+      ? extractOwnedPrivateVideoPosterPath(
+        ownerUid,
+        videoId,
+        rawPosterPath
+      )
+      : null;
+    const videoSizeBytes = normalizePositiveInteger(
+      request.data?.videoSizeBytes
+    );
+    const posterSizeBytes = normalizePositiveInteger(
+      request.data?.posterSizeBytes
+    );
+    const mimeType = normalizeMimeType(request.data?.mimeType);
+
+    if (
+      !videoStoragePath ||
+      (rawPosterPath && !posterStoragePath) ||
+      (posterStoragePath === null) !== (posterSizeBytes === 0) ||
+      !ALLOWED_VIDEO_TYPES.has(mimeType)
+    ) {
+      throw new HttpsError(
+        'invalid-argument',
+        'O arquivo ou os caminhos da reserva são inválidos.'
+      );
+    }
+
+    validateMaximumSizes(videoSizeBytes, posterSizeBytes);
+    const user = await assertPrivateVideoUploadEligibility(ownerUid);
+    const reservationId = reservationDocumentId(ownerUid, clientRequestId);
+    const reservationRef = reservationReference(reservationId);
+    const lockRef = capacityLockReference(ownerUid);
+    const userRef = db.doc(`users/${ownerUid}`);
+    const videosQuery = db.collection(`users/${ownerUid}/videos`);
+    const reservationsQuery = db
+      .collection(RESERVATIONS_COLLECTION)
+      .where('ownerUid', '==', ownerUid);
+    const now = Date.now();
+    const reservedBytes = calculatePrivateVideoReservationBytes(
+      videoSizeBytes,
+      posterSizeBytes
+    );
+    const requestIdentity = {
+      clientRequestId,
+      ownerUid,
+      videoId,
+      videoStoragePath,
+      posterStoragePath,
+      videoSizeBytes,
+      posterSizeBytes,
+      mimeType,
+    };
+
+    return db.runTransaction(async (transaction) => {
+      const [
+        existingSnapshot,
+        lockSnapshot,
+        userSnapshot,
+        videosSnapshot,
+        reservationsSnapshot,
+      ] = await Promise.all([
+        transaction.get(reservationRef),
+        transaction.get(lockRef),
+        transaction.get(userRef),
+        transaction.get(videosQuery),
+        transaction.get(reservationsQuery),
+      ]);
+
+      if (existingSnapshot.exists) {
+        const existing = existingSnapshot.data() as
+          PrivateVideoUploadReservationDocument;
+
+        if (
+          existing.state === 'ACTIVE' &&
+          existing.expiresAt.toMillis() > now &&
+          sameReservationRequest(existing, requestIdentity)
+        ) {
+          const limit = evaluatePrivateVideoQuota(
+            existing.plan,
+            { currentItems: 0, currentReservedBytes: 0 },
+            0
+          ).limit;
+          return buildReserveResponse(
+            existing,
+            { currentItems: 0, currentReservedBytes: 0 },
+            limit
+          );
+        }
+
+        throw new HttpsError(
+          'already-exists',
+          'O identificador desta tentativa de upload já foi utilizado.'
+        );
+      }
+
+      const transactionalUser = userSnapshot.exists
+        ? userSnapshot.data() as Record<string, unknown>
+        : user;
+      const plan = resolvePrivateVideoQuotaPlan(transactionalUser, now);
+      const registeredReservedBytes = videosSnapshot.docs.reduce(
+        (total, document) =>
+          total + estimateRegisteredVideoReservedBytes(document.data()),
+        0
+      );
+      const activeReservations = reservationsSnapshot.docs
+        .map((document) =>
+          document.data() as PrivateVideoUploadReservationDocument
+        )
+        .filter((reservation) =>
+          reservation.state === 'ACTIVE' &&
+          reservation.expiresAt.toMillis() > now
+        );
+      const usage = {
+        currentItems: videosSnapshot.size + activeReservations.length,
+        currentReservedBytes:
+          registeredReservedBytes +
+          activeReservations.reduce(
+            (total, reservation) => total + reservation.reservedBytes,
+            0
+          ),
+      };
+      const decision = evaluatePrivateVideoQuota(
+        plan,
+        usage,
+        reservedBytes
+      );
+
+      if (!decision.allowed) {
+        throw quotaHttpsError(decision.reason, {
+          plan,
+          currentItems: decision.usage.currentItems,
+          currentReservedBytes: decision.usage.currentReservedBytes,
+          maxItems: decision.limit.maxItems,
+          maxReservedBytes: decision.limit.maxReservedBytes,
+        });
+      }
+
+      const createdAt = Timestamp.fromMillis(now);
+      const reservation: PrivateVideoUploadReservationDocument = {
+        reservationId,
+        clientRequestId,
+        ownerUid,
+        videoId,
+        state: 'ACTIVE',
+        videoStoragePath,
+        posterStoragePath,
+        videoSizeBytes,
+        posterSizeBytes,
+        mimeType,
+        reservedBytes,
+        plan,
+        createdAt,
+        updatedAt: createdAt,
+        expiresAt: Timestamp.fromMillis(now + ACTIVE_RESERVATION_MS),
+        consumedAt: null,
+        cleanupAfter: null,
+      };
+
+      transaction.create(reservationRef, reservation);
+      transaction.set(
+        lockRef,
+        {
+          generation: nextLockGeneration(lockSnapshot),
+          updatedAt: now,
+          lastReservationId: reservationId,
+        },
+        { merge: true }
+      );
+
+      return buildReserveResponse(
+        reservation,
+        decision.usage,
+        decision.limit
+      );
+    });
+  }
+);
+
+export const cancelPrivateVideoUploadReservation = onCall<
+  CancelPrivateVideoUploadReservationRequest
+>(
+  { region: FUNCTIONS_REGION },
+  async (request): Promise<CancelPrivateVideoUploadReservationResponse> => {
+    const requesterUid = cleanId(request.auth?.uid);
+    const reservationId = cleanId(request.data?.reservationId);
+
+    if (!requesterUid) {
+      throw new HttpsError('unauthenticated', 'Usuário não autenticado.');
+    }
+
+    if (!reservationId) {
+      throw new HttpsError('invalid-argument', 'Reserva inválida.');
+    }
+
+    const snapshot = await reservationReference(reservationId).get();
+
+    if (!snapshot.exists) {
+      return { reservationId, released: false };
+    }
+
+    const reservation = snapshot.data() as
+      PrivateVideoUploadReservationDocument;
+
+    if (reservation.ownerUid !== requesterUid) {
+      throw new HttpsError(
+        'permission-denied',
+        'A reserva não pertence ao usuário autenticado.'
+      );
+    }
+
+    const released = await cancelPrivateVideoUploadReservationById(
+      reservationId,
+      requesterUid
+    );
+
+    return { reservationId, released };
+  }
+);
+
+export const cleanupPrivateVideoUploadReservations = onSchedule(
+  {
+    region: FUNCTIONS_REGION,
+    schedule: 'every 30 minutes',
+    timeZone: 'America/Sao_Paulo',
+    retryCount: 3,
+  },
+  async () => {
+    const now = Timestamp.now();
+    const terminalSnapshot = await db
+      .collection(RESERVATIONS_COLLECTION)
+      .where('cleanupAfter', '<=', now)
+      .limit(CLEANUP_BATCH_SIZE)
+      .get();
+
+    if (!terminalSnapshot.empty) {
+      const batch = db.batch();
+      terminalSnapshot.docs.forEach((document) => batch.delete(document.ref));
+      await batch.commit();
+    }
+
+    const expiredSnapshot = await db
+      .collection(RESERVATIONS_COLLECTION)
+      .where('expiresAt', '<=', now)
+      .limit(CLEANUP_BATCH_SIZE)
+      .get();
+
+    for (const document of expiredSnapshot.docs) {
+      const reservation = document.data() as
+        PrivateVideoUploadReservationDocument;
+
+      if (reservation.state !== 'ACTIVE') {
+        continue;
+      }
+
+      try {
+        const expired = await transitionActiveReservation(
+          document.id,
+          reservation.ownerUid,
+          'EXPIRED'
+        );
+
+        if (expired) {
+          await deleteReservedObjectsBestEffort(expired);
+        }
+      } catch (error) {
+        logger.error('[privateVideoUploadReservation] Falha ao expirar.', {
+          reservationId: document.id,
+          ownerUid: reservation.ownerUid,
+          videoId: reservation.videoId,
+          error: normalizeErrorMessage(error),
+        });
+      }
+    }
+  }
+);

--- a/functions/src/media/application/private-video-upload-reservation.handler.ts
+++ b/functions/src/media/application/private-video-upload-reservation.handler.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
 
-import { Timestamp, type Transaction } from 'firebase-admin/firestore';
+import { Timestamp } from 'firebase-admin/firestore';
 import * as logger from 'firebase-functions/logger';
 import { HttpsError, onCall } from 'firebase-functions/v2/https';
 import { onSchedule } from 'firebase-functions/v2/scheduler';
@@ -15,6 +15,9 @@ import {
   resolvePrivateVideoQuotaPlan,
   type PrivateVideoQuotaPlan,
 } from './private-video-upload-quota.policy';
+import {
+  consumePrivateVideoUploadReservationAfterRegistration,
+} from './private-video-upload-reservation-registration.service';
 import {
   extractOwnedPrivateVideoPathForId,
   extractOwnedPrivateVideoPosterPath,
@@ -79,16 +82,11 @@ interface CancelPrivateVideoUploadReservationResponse {
   released: boolean;
 }
 
-export interface ConsumePrivateVideoUploadReservationInput {
-  reservationId: string;
-  ownerUid: string;
-  videoId: string;
-  videoStoragePath: string;
-  posterStoragePath: string | null;
-  videoSizeBytes: number;
-  posterSizeBytes: number;
-  mimeType: string;
-  now?: number;
+interface RegisteredPrivateVideoDocument {
+  path?: unknown;
+  url?: unknown;
+  thumbnailPath?: unknown;
+  thumbnailUrl?: unknown;
 }
 
 const RESERVATIONS_COLLECTION = 'media_private_video_upload_reservations';
@@ -143,17 +141,6 @@ function normalizePositiveInteger(value: unknown): number {
 
 function normalizeMimeType(value: unknown): string {
   return String(value ?? '').trim().toLowerCase();
-}
-
-function timestampToMillis(value: unknown): number {
-  if (typeof value === 'number' && Number.isFinite(value)) {
-    return Math.trunc(value);
-  }
-
-  const candidate = value as { toMillis?: () => number } | null | undefined;
-  return typeof candidate?.toMillis === 'function'
-    ? candidate.toMillis()
-    : 0;
 }
 
 function normalizeErrorMessage(error: unknown): string {
@@ -250,30 +237,6 @@ function quotaHttpsError(
   );
 }
 
-function reservationExpiredError(): HttpsError {
-  return new HttpsError(
-    'failed-precondition',
-    'A reserva do upload expirou ou já foi utilizada.',
-    {
-      code: 'VIDEO_UPLOAD_RESERVATION_EXPIRED',
-      retryable: true,
-      recovery: 'Inicie o envio novamente para gerar uma nova reserva.',
-    }
-  );
-}
-
-function reservationMismatchError(): HttpsError {
-  return new HttpsError(
-    'failed-precondition',
-    'A reserva não corresponde ao arquivo enviado.',
-    {
-      code: 'VIDEO_UPLOAD_RESERVATION_MISMATCH',
-      retryable: false,
-      recovery: 'Selecione novamente o arquivo e reinicie o envio.',
-    }
-  );
-}
-
 function buildReserveResponse(
   reservation: PrivateVideoUploadReservationDocument,
   usage: {
@@ -299,9 +262,53 @@ function buildReserveResponse(
   };
 }
 
+async function isReservationRegistered(
+  reservation: PrivateVideoUploadReservationDocument
+): Promise<boolean> {
+  const snapshot = await db
+    .doc(`users/${reservation.ownerUid}/videos/${reservation.videoId}`)
+    .get();
+
+  if (!snapshot.exists) {
+    return false;
+  }
+
+  const video = snapshot.data() as RegisteredPrivateVideoDocument;
+  const registeredVideoPath = extractOwnedPrivateVideoPathForId(
+    reservation.ownerUid,
+    reservation.videoId,
+    video.path ?? video.url
+  );
+  const rawPosterPath = String(
+    video.thumbnailPath ?? video.thumbnailUrl ?? ''
+  ).trim();
+  const registeredPosterPath = rawPosterPath
+    ? extractOwnedPrivateVideoPosterPath(
+      reservation.ownerUid,
+      reservation.videoId,
+      rawPosterPath
+    )
+    : null;
+
+  return registeredVideoPath === reservation.videoStoragePath &&
+    registeredPosterPath === reservation.posterStoragePath;
+}
+
 async function deleteReservedObjectsBestEffort(
   reservation: PrivateVideoUploadReservationDocument
 ): Promise<void> {
+  if (await isReservationRegistered(reservation)) {
+    logger.info(
+      '[privateVideoUploadReservation] Limpeza ignorada para vídeo registrado.',
+      {
+        reservationId: reservation.reservationId,
+        ownerUid: reservation.ownerUid,
+        videoId: reservation.videoId,
+      }
+    );
+    return;
+  }
+
   const videoPath = extractOwnedPrivateVideoPathForId(
     reservation.ownerUid,
     reservation.videoId,
@@ -408,71 +415,6 @@ export async function cancelPrivateVideoUploadReservationById(
   return true;
 }
 
-export async function consumePrivateVideoUploadReservation(
-  transaction: Transaction,
-  input: ConsumePrivateVideoUploadReservationInput
-): Promise<PrivateVideoUploadReservationDocument> {
-  const reservationId = cleanId(input.reservationId);
-
-  if (!reservationId) {
-    throw reservationExpiredError();
-  }
-
-  const reservationRef = reservationReference(reservationId);
-  const lockRef = capacityLockReference(input.ownerUid);
-  const [reservationSnapshot, lockSnapshot] = await Promise.all([
-    transaction.get(reservationRef),
-    transaction.get(lockRef),
-  ]);
-
-  if (!reservationSnapshot.exists) {
-    throw reservationExpiredError();
-  }
-
-  const reservation = reservationSnapshot.data() as
-    PrivateVideoUploadReservationDocument;
-  const now = input.now ?? Date.now();
-
-  if (
-    reservation.state !== 'ACTIVE' ||
-    reservation.expiresAt.toMillis() <= now
-  ) {
-    throw reservationExpiredError();
-  }
-
-  if (
-    reservation.ownerUid !== input.ownerUid ||
-    reservation.videoId !== input.videoId ||
-    reservation.videoStoragePath !== input.videoStoragePath ||
-    reservation.posterStoragePath !== input.posterStoragePath ||
-    reservation.videoSizeBytes !== input.videoSizeBytes ||
-    reservation.posterSizeBytes !== input.posterSizeBytes ||
-    reservation.mimeType !== input.mimeType
-  ) {
-    throw reservationMismatchError();
-  }
-
-  const cleanupAfter = now + TERMINAL_RETENTION_MS;
-
-  transaction.update(reservationRef, {
-    state: 'CONSUMED',
-    consumedAt: Timestamp.fromMillis(now),
-    updatedAt: Timestamp.fromMillis(now),
-    expiresAt: Timestamp.fromMillis(cleanupAfter),
-    cleanupAfter: Timestamp.fromMillis(cleanupAfter),
-  });
-  transaction.set(
-    lockRef,
-    {
-      generation: nextLockGeneration(lockSnapshot),
-      updatedAt: now,
-    },
-    { merge: true }
-  );
-
-  return reservation;
-}
-
 export const reservePrivateVideoUpload = onCall<ReservePrivateVideoUploadRequest>(
   { region: FUNCTIONS_REGION },
   async (request): Promise<ReservePrivateVideoUploadResponse> => {
@@ -570,6 +512,36 @@ export const reservePrivateVideoUpload = onCall<ReservePrivateVideoUploadRequest
         transaction.get(videosQuery),
         transaction.get(reservationsQuery),
       ]);
+      const transactionalUser = userSnapshot.exists
+        ? userSnapshot.data() as Record<string, unknown>
+        : user;
+      const plan = resolvePrivateVideoQuotaPlan(transactionalUser, now);
+      const registeredVideoIds = new Set(
+        videosSnapshot.docs.map((document) => document.id)
+      );
+      const registeredReservedBytes = videosSnapshot.docs.reduce(
+        (total, document) =>
+          total + estimateRegisteredVideoReservedBytes(document.data()),
+        0
+      );
+      const activeReservations = reservationsSnapshot.docs
+        .map((document) =>
+          document.data() as PrivateVideoUploadReservationDocument
+        )
+        .filter((reservation) =>
+          reservation.state === 'ACTIVE' &&
+          reservation.expiresAt.toMillis() > now &&
+          !registeredVideoIds.has(reservation.videoId)
+        );
+      const usage = {
+        currentItems: videosSnapshot.size + activeReservations.length,
+        currentReservedBytes:
+          registeredReservedBytes +
+          activeReservations.reduce(
+            (total, reservation) => total + reservation.reservedBytes,
+            0
+          ),
+      };
 
       if (existingSnapshot.exists) {
         const existing = existingSnapshot.data() as
@@ -585,11 +557,7 @@ export const reservePrivateVideoUpload = onCall<ReservePrivateVideoUploadRequest
             { currentItems: 0, currentReservedBytes: 0 },
             0
           ).limit;
-          return buildReserveResponse(
-            existing,
-            { currentItems: 0, currentReservedBytes: 0 },
-            limit
-          );
+          return buildReserveResponse(existing, usage, limit);
         }
 
         throw new HttpsError(
@@ -598,32 +566,6 @@ export const reservePrivateVideoUpload = onCall<ReservePrivateVideoUploadRequest
         );
       }
 
-      const transactionalUser = userSnapshot.exists
-        ? userSnapshot.data() as Record<string, unknown>
-        : user;
-      const plan = resolvePrivateVideoQuotaPlan(transactionalUser, now);
-      const registeredReservedBytes = videosSnapshot.docs.reduce(
-        (total, document) =>
-          total + estimateRegisteredVideoReservedBytes(document.data()),
-        0
-      );
-      const activeReservations = reservationsSnapshot.docs
-        .map((document) =>
-          document.data() as PrivateVideoUploadReservationDocument
-        )
-        .filter((reservation) =>
-          reservation.state === 'ACTIVE' &&
-          reservation.expiresAt.toMillis() > now
-        );
-      const usage = {
-        currentItems: videosSnapshot.size + activeReservations.length,
-        currentReservedBytes:
-          registeredReservedBytes +
-          activeReservations.reduce(
-            (total, reservation) => total + reservation.reservedBytes,
-            0
-          ),
-      };
       const decision = evaluatePrivateVideoQuota(
         plan,
         usage,
@@ -758,6 +700,19 @@ export const cleanupPrivateVideoUploadReservations = onSchedule(
       }
 
       try {
+        if (await isReservationRegistered(reservation)) {
+          await consumePrivateVideoUploadReservationAfterRegistration({
+            reservationId: reservation.reservationId,
+            ownerUid: reservation.ownerUid,
+            videoId: reservation.videoId,
+            videoStoragePath: reservation.videoStoragePath,
+            posterStoragePath: reservation.posterStoragePath,
+            videoSizeBytes: reservation.videoSizeBytes,
+            mimeType: reservation.mimeType,
+          });
+          continue;
+        }
+
         const expired = await transitionActiveReservation(
           document.id,
           reservation.ownerUid,

--- a/functions/src/media/application/register-private-video-upload-orchestrator.handler.ts
+++ b/functions/src/media/application/register-private-video-upload-orchestrator.handler.ts
@@ -1,11 +1,14 @@
 import { createHash } from 'node:crypto';
 
 import * as logger from 'firebase-functions/logger';
-import { HttpsError, onCall } from 'firebase-functions/v2/https';
+import { onCall } from 'firebase-functions/v2/https';
 
-import { assertInteractionAccessData } from '../../account_lifecycle/interaction-access.policy';
 import { FUNCTIONS_REGION } from '../../config/functions-region';
-import { auth, db, storage } from '../../firebaseApp';
+import { db, storage } from '../../firebaseApp';
+import { assertPrivateVideoUploadEligibility } from './private-video-upload-eligibility.service';
+import {
+  cancelPrivateVideoUploadReservationById,
+} from './private-video-upload-reservation.handler';
 import { ensurePrivateVideoProcessingQueued } from './queue-video-processing.handler';
 import {
   registerPrivateVideoUpload as registerPrivateVideoUploadCore,
@@ -18,6 +21,7 @@ import {
 interface RegisterPrivateVideoUploadRequest {
   ownerUid?: string;
   videoId?: string;
+  reservationId?: string;
   videoStoragePath?: string;
   posterStoragePath?: string | null;
   [key: string]: unknown;
@@ -27,24 +31,6 @@ interface RegisteredPrivateVideoResponse {
   ownerUid: string;
   videoId: string;
   [key: string]: unknown;
-}
-
-interface PrivateMediaUploadAuthSnapshot {
-  disabled?: boolean;
-  emailVerified?: boolean;
-}
-
-interface PrivateMediaUploadAccountSnapshot {
-  uid?: unknown;
-  profileCompleted?: unknown;
-  accountLocked?: unknown;
-  loginAllowed?: unknown;
-  accountStatus?: unknown;
-  suspended?: unknown;
-  interactionBlocked?: unknown;
-  ageReverification?: {
-    status?: unknown;
-  } | null;
 }
 
 interface RegisteredVideoDocument {
@@ -96,107 +82,8 @@ function normalizeErrorMessage(error: unknown): string {
   return String(error ?? 'unknown').slice(0, 500);
 }
 
-function authErrorCode(error: unknown): string {
-  if (!error || typeof error !== 'object') {
-    return '';
-  }
-
-  const candidate = error as {
-    code?: unknown;
-    errorInfo?: { code?: unknown };
-  };
-
-  return String(candidate.errorInfo?.code ?? candidate.code ?? '')
-    .trim()
-    .toLowerCase();
-}
-
 function cleanupJobId(storagePath: string): string {
   return createHash('sha256').update(storagePath).digest('hex');
-}
-
-function assertPrivateVideoUploadEligibilityData(
-  authUser: PrivateMediaUploadAuthSnapshot | null | undefined,
-  user: PrivateMediaUploadAccountSnapshot | null | undefined,
-  expectedUid: string
-): void {
-  if (!authUser || !user) {
-    throw new HttpsError(
-      'failed-precondition',
-      'Seu perfil não está disponível para enviar vídeos.'
-    );
-  }
-
-  const documentUid = String(user.uid ?? expectedUid).trim();
-
-  if (documentUid && documentUid !== expectedUid) {
-    throw new HttpsError(
-      'permission-denied',
-      'O perfil informado não corresponde à conta autenticada.'
-    );
-  }
-
-  if (
-    authUser.disabled === true ||
-    user.accountLocked === true ||
-    user.loginAllowed === false
-  ) {
-    throw new HttpsError(
-      'permission-denied',
-      'Sua conta não está disponível para enviar vídeos.'
-    );
-  }
-
-  assertInteractionAccessData(user);
-
-  if (authUser.emailVerified !== true) {
-    throw new HttpsError(
-      'failed-precondition',
-      'Verifique seu e-mail antes de enviar vídeos.'
-    );
-  }
-
-  if (user.profileCompleted !== true) {
-    throw new HttpsError(
-      'failed-precondition',
-      'Complete seu perfil antes de enviar vídeos.'
-    );
-  }
-}
-
-async function assertPrivateVideoUploadEligibility(
-  ownerUid: string
-): Promise<void> {
-  try {
-    const [authUser, userSnapshot] = await Promise.all([
-      auth.getUser(ownerUid),
-      db.doc(`users/${ownerUid}`).get(),
-    ]);
-
-    assertPrivateVideoUploadEligibilityData(
-      {
-        disabled: authUser.disabled,
-        emailVerified: authUser.emailVerified,
-      },
-      userSnapshot.exists
-        ? userSnapshot.data() as PrivateMediaUploadAccountSnapshot
-        : null,
-      ownerUid
-    );
-  } catch (error) {
-    if (error instanceof HttpsError) {
-      throw error;
-    }
-
-    if (authErrorCode(error) === 'auth/user-not-found') {
-      throw new HttpsError(
-        'failed-precondition',
-        'Sua conta não está disponível para enviar vídeos.'
-      );
-    }
-
-    throw error;
-  }
 }
 
 async function isRegisteredAsset(
@@ -343,6 +230,7 @@ export const registerPrivateVideoUpload = onCall<
     const requesterUid = cleanId(request.auth?.uid);
     const ownerUid = cleanId(request.data?.ownerUid);
     const videoId = cleanId(request.data?.videoId);
+    const reservationId = cleanId(request.data?.reservationId);
     const assets = ownerUid && videoId
       ? resolveOwnedUploadAssets(ownerUid, videoId, request.data)
       : null;
@@ -351,7 +239,15 @@ export const registerPrivateVideoUpload = onCall<
       try {
         await assertPrivateVideoUploadEligibility(ownerUid);
       } catch (error) {
-        await cleanupDeniedUploadAssets(ownerUid, videoId, assets);
+        const released = await cancelPrivateVideoUploadReservationById(
+          reservationId,
+          ownerUid
+        );
+
+        if (!released) {
+          await cleanupDeniedUploadAssets(ownerUid, videoId, assets);
+        }
+
         throw error;
       }
     }

--- a/functions/src/media/application/register-private-video-upload-orchestrator.handler.ts
+++ b/functions/src/media/application/register-private-video-upload-orchestrator.handler.ts
@@ -7,6 +7,11 @@ import { FUNCTIONS_REGION } from '../../config/functions-region';
 import { db, storage } from '../../firebaseApp';
 import { assertPrivateVideoUploadEligibility } from './private-video-upload-eligibility.service';
 import {
+  assertPrivateVideoUploadReservation,
+  consumePrivateVideoUploadReservationAfterRegistration,
+  type PrivateVideoReservationRegistrationInput,
+} from './private-video-upload-reservation-registration.service';
+import {
   cancelPrivateVideoUploadReservationById,
 } from './private-video-upload-reservation.handler';
 import { ensurePrivateVideoProcessingQueued } from './queue-video-processing.handler';
@@ -24,6 +29,8 @@ interface RegisterPrivateVideoUploadRequest {
   reservationId?: string;
   videoStoragePath?: string;
   posterStoragePath?: string | null;
+  sizeBytes?: number;
+  mimeType?: string;
   [key: string]: unknown;
 }
 
@@ -72,6 +79,15 @@ function cleanId(value: unknown): string {
   }
 
   return normalized;
+}
+
+function normalizePositiveInteger(value: unknown): number {
+  const parsed = Number(value ?? 0);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.trunc(parsed) : 0;
+}
+
+function normalizeMimeType(value: unknown): string {
+  return String(value ?? '').trim().toLowerCase();
 }
 
 function normalizeErrorMessage(error: unknown): string {
@@ -216,11 +232,53 @@ function resolveOwnedUploadAssets(
   ];
 }
 
+function buildReservationInput(
+  ownerUid: string,
+  videoId: string,
+  data: RegisterPrivateVideoUploadRequest | undefined
+): PrivateVideoReservationRegistrationInput | null {
+  const reservationId = cleanId(data?.reservationId);
+  const videoStoragePath = extractOwnedPrivateVideoPathForId(
+    ownerUid,
+    videoId,
+    data?.videoStoragePath
+  );
+  const rawPosterStoragePath = String(data?.posterStoragePath ?? '').trim();
+  const posterStoragePath = rawPosterStoragePath
+    ? extractOwnedPrivateVideoPosterPath(
+      ownerUid,
+      videoId,
+      rawPosterStoragePath
+    )
+    : null;
+  const videoSizeBytes = normalizePositiveInteger(data?.sizeBytes);
+  const mimeType = normalizeMimeType(data?.mimeType);
+
+  if (
+    !reservationId ||
+    !videoStoragePath ||
+    (rawPosterStoragePath && !posterStoragePath) ||
+    !videoSizeBytes ||
+    !mimeType
+  ) {
+    return null;
+  }
+
+  return {
+    reservationId,
+    ownerUid,
+    videoId,
+    videoStoragePath,
+    posterStoragePath,
+    videoSizeBytes,
+    mimeType,
+  };
+}
+
 /**
  * Registra o upload e só responde depois que a fila idempotente foi persistida.
  * O trigger Firestore continua como mecanismo de reconciliação e recuperação.
- * A elegibilidade é revalidada no backend antes do registro definitivo.
- * Todo novo vídeo mantém a intenção de publicação até o derivado ficar pronto.
+ * A elegibilidade e a reserva são revalidadas antes do registro definitivo.
  */
 export const registerPrivateVideoUpload = onCall<
   RegisterPrivateVideoUploadRequest
@@ -234,8 +292,23 @@ export const registerPrivateVideoUpload = onCall<
     const assets = ownerUid && videoId
       ? resolveOwnedUploadAssets(ownerUid, videoId, request.data)
       : null;
+    const reservationInput = ownerUid && videoId
+      ? buildReservationInput(ownerUid, videoId, request.data)
+      : null;
 
-    if (requesterUid && requesterUid === ownerUid && assets) {
+    if (
+      requesterUid &&
+      requesterUid === ownerUid &&
+      assets &&
+      reservationInput
+    ) {
+      try {
+        await assertPrivateVideoUploadReservation(reservationInput);
+      } catch (error) {
+        await cleanupDeniedUploadAssets(ownerUid, videoId, assets);
+        throw error;
+      }
+
       try {
         await assertPrivateVideoUploadEligibility(ownerUid);
       } catch (error) {
@@ -264,6 +337,24 @@ export const registerPrivateVideoUpload = onCall<
         requestWithRequiredPublication as any
       )
     ) as RegisteredPrivateVideoResponse;
+
+    if (reservationInput) {
+      try {
+        await consumePrivateVideoUploadReservationAfterRegistration(
+          reservationInput
+        );
+      } catch (error) {
+        logger.warn(
+          '[registerPrivateVideoUpload] Reconciliação da reserva pendente.',
+          {
+            ownerUid: response.ownerUid,
+            videoId: response.videoId,
+            reservationId,
+            error: normalizeErrorMessage(error),
+          }
+        );
+      }
+    }
 
     await ensurePrivateVideoProcessingQueued(
       response.ownerUid,

--- a/functions/src/media/application/register-private-video-upload-orchestrator.handler.ts
+++ b/functions/src/media/application/register-private-video-upload-orchestrator.handler.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 
 import * as logger from 'firebase-functions/logger';
-import { onCall } from 'firebase-functions/v2/https';
+import { HttpsError, onCall } from 'firebase-functions/v2/https';
 
 import { FUNCTIONS_REGION } from '../../config/functions-region';
 import { db, storage } from '../../firebaseApp';
@@ -278,7 +278,7 @@ function buildReservationInput(
 /**
  * Registra o upload e só responde depois que a fila idempotente foi persistida.
  * O trigger Firestore continua como mecanismo de reconciliação e recuperação.
- * A elegibilidade e a reserva são revalidadas antes do registro definitivo.
+ * A elegibilidade e a reserva são obrigatórias e revalidadas no backend.
  */
 export const registerPrivateVideoUpload = onCall<
   RegisterPrivateVideoUploadRequest
@@ -289,40 +289,66 @@ export const registerPrivateVideoUpload = onCall<
     const ownerUid = cleanId(request.data?.ownerUid);
     const videoId = cleanId(request.data?.videoId);
     const reservationId = cleanId(request.data?.reservationId);
-    const assets = ownerUid && videoId
-      ? resolveOwnedUploadAssets(ownerUid, videoId, request.data)
-      : null;
-    const reservationInput = ownerUid && videoId
-      ? buildReservationInput(ownerUid, videoId, request.data)
-      : null;
 
-    if (
-      requesterUid &&
-      requesterUid === ownerUid &&
-      assets &&
-      reservationInput
-    ) {
-      try {
-        await assertPrivateVideoUploadReservation(reservationInput);
-      } catch (error) {
-        await cleanupDeniedUploadAssets(ownerUid, videoId, assets);
-        throw error;
-      }
+    if (!requesterUid) {
+      throw new HttpsError('unauthenticated', 'Usuário não autenticado.');
+    }
 
-      try {
-        await assertPrivateVideoUploadEligibility(ownerUid);
-      } catch (error) {
-        const released = await cancelPrivateVideoUploadReservationById(
+    if (!ownerUid || !videoId) {
+      throw new HttpsError('invalid-argument', 'Vídeo inválido.');
+    }
+
+    if (requesterUid !== ownerUid) {
+      throw new HttpsError(
+        'permission-denied',
+        'O vídeo só pode ser registrado no perfil autenticado.'
+      );
+    }
+
+    const assets = resolveOwnedUploadAssets(ownerUid, videoId, request.data);
+    const reservationInput = buildReservationInput(
+      ownerUid,
+      videoId,
+      request.data
+    );
+
+    if (!assets || !reservationInput) {
+      if (reservationId) {
+        await cancelPrivateVideoUploadReservationById(
           reservationId,
           ownerUid
         );
-
-        if (!released) {
-          await cleanupDeniedUploadAssets(ownerUid, videoId, assets);
-        }
-
-        throw error;
       }
+
+      throw new HttpsError(
+        'failed-precondition',
+        'O upload não possui uma reserva válida.',
+        {
+          code: 'VIDEO_UPLOAD_RESERVATION_REQUIRED',
+          retryable: true,
+          recovery: 'Inicie o envio novamente para gerar uma nova reserva.',
+        }
+      );
+    }
+
+    try {
+      await assertPrivateVideoUploadReservation(reservationInput);
+    } catch (error) {
+      await Promise.all([
+        cancelPrivateVideoUploadReservationById(reservationId, ownerUid),
+        cleanupDeniedUploadAssets(ownerUid, videoId, assets),
+      ]);
+      throw error;
+    }
+
+    try {
+      await assertPrivateVideoUploadEligibility(ownerUid);
+    } catch (error) {
+      await Promise.all([
+        cancelPrivateVideoUploadReservationById(reservationId, ownerUid),
+        cleanupDeniedUploadAssets(ownerUid, videoId, assets),
+      ]);
+      throw error;
     }
 
     const requestWithRequiredPublication = {
@@ -338,22 +364,20 @@ export const registerPrivateVideoUpload = onCall<
       )
     ) as RegisteredPrivateVideoResponse;
 
-    if (reservationInput) {
-      try {
-        await consumePrivateVideoUploadReservationAfterRegistration(
-          reservationInput
-        );
-      } catch (error) {
-        logger.warn(
-          '[registerPrivateVideoUpload] Reconciliação da reserva pendente.',
-          {
-            ownerUid: response.ownerUid,
-            videoId: response.videoId,
-            reservationId,
-            error: normalizeErrorMessage(error),
-          }
-        );
-      }
+    try {
+      await consumePrivateVideoUploadReservationAfterRegistration(
+        reservationInput
+      );
+    } catch (error) {
+      logger.warn(
+        '[registerPrivateVideoUpload] Reconciliação da reserva pendente.',
+        {
+          ownerUid: response.ownerUid,
+          videoId: response.videoId,
+          reservationId,
+          error: normalizeErrorMessage(error),
+        }
+      );
     }
 
     await ensurePrivateVideoProcessingQueued(

--- a/functions/src/media/index.ts
+++ b/functions/src/media/index.ts
@@ -56,6 +56,15 @@ export {
 } from './application/cleanup-unpublished-video-interactions.handler';
 
 export {
+  cancelPrivateVideoUploadReservation,
+  cleanupPrivateVideoUploadReservations,
+  reservePrivateVideoUpload,
+} from './application/private-video-upload-reservation.handler';
+export {
+  consumeVideoUploadReservationOnRegistration,
+} from './application/private-video-upload-reservation-registration.service';
+
+export {
   cleanupPendingPrivateVideoUploadAssets,
 } from './application/register-private-video-upload.handler';
 export {

--- a/scripts/tests/video-publication.e2e.mjs
+++ b/scripts/tests/video-publication.e2e.mjs
@@ -1,9 +1,9 @@
 // scripts/tests/video-publication.e2e.mjs
 // -----------------------------------------------------------------------------
 // Integração isolada de vídeo:
-// upload privado -> registro com publicação obrigatória -> fila -> conclusão
-// simulada do provedor externo -> publicação automática -> edição -> acesso
-// temporário -> bloqueio da despublicação.
+// elegibilidade -> reserva de quota -> upload privado autorizado -> registro
+// obrigatório -> fila -> conclusão simulada -> publicação automática -> edição
+// -> acesso temporário -> bloqueio da despublicação.
 // -----------------------------------------------------------------------------
 
 import assert from 'node:assert/strict';
@@ -18,6 +18,7 @@ import {
   createUserWithEmailAndPassword,
   deleteUser,
   getAuth,
+  reload,
 } from 'firebase/auth';
 import {
   connectFunctionsEmulator,
@@ -35,6 +36,7 @@ import {
   deleteApp as deleteAdminApp,
   initializeApp as initializeAdminApp,
 } from 'firebase-admin/app';
+import { getAuth as getAdminAuth } from 'firebase-admin/auth';
 import { getFirestore as getAdminFirestore } from 'firebase-admin/firestore';
 import { getStorage as getAdminStorage } from 'firebase-admin/storage';
 
@@ -150,12 +152,15 @@ async function run() {
     },
     `video-e2e-admin-${runId}`
   );
+  const adminAuth = getAdminAuth(adminApp);
   const adminDb = getAdminFirestore(adminApp);
   const bucket = getAdminStorage(adminApp).bucket(STORAGE_BUCKET);
 
   let authenticatedUser = null;
   let ownerUid = '';
   let jobRef = null;
+  let reservationRef = null;
+  let capacityRef = null;
 
   try {
     const credential = await createUserWithEmailAndPassword(
@@ -166,6 +171,20 @@ async function run() {
     authenticatedUser = credential.user;
     ownerUid = credential.user.uid;
 
+    await Promise.all([
+      adminAuth.updateUser(ownerUid, { emailVerified: true }),
+      adminDb.doc(`users/${ownerUid}`).set({
+        uid: ownerUid,
+        profileCompleted: true,
+        accountStatus: 'active',
+        loginAllowed: true,
+        interactionBlocked: false,
+        updatedAt: Date.now(),
+      }),
+    ]);
+    await reload(authenticatedUser);
+    await authenticatedUser.getIdToken(true);
+
     const sourcePath =
       `users/${ownerUid}/uploads/videos/${videoId}-${runId}.mp4`;
     const posterPath =
@@ -173,13 +192,58 @@ async function run() {
     const sourceStorageRef = ref(clientStorage, sourcePath);
     const posterStorageRef = ref(clientStorage, posterPath);
 
-    await uploadBytes(sourceStorageRef, sourceBytes, {
-      contentType: 'video/mp4',
+    const reservePrivateVideoUpload = httpsCallable(
+      clientFunctions,
+      'reservePrivateVideoUpload'
+    );
+    const reservationResponse = await reservePrivateVideoUpload({
+      clientRequestId: runId,
+      ownerUid,
+      videoId,
+      videoStoragePath: sourcePath,
+      posterStoragePath: posterPath,
+      videoSizeBytes: sourceBytes.byteLength,
+      posterSizeBytes: posterBytes.byteLength,
+      mimeType: 'video/mp4',
+    });
+    const reservation = reservationResponse.data;
+    const reservationId = String(reservation.reservationId ?? '');
+    assert.ok(reservationId);
+    assert.equal(reservation.ownerUid, ownerUid);
+    assert.equal(reservation.videoId, videoId);
+    assert.equal(reservation.plan, 'free');
+    assert.ok(reservation.expiresAt > Date.now());
+    assert.equal(
+      reservation.reservedBytes,
+      sourceBytes.byteLength * 2 + posterBytes.byteLength
+    );
+
+    reservationRef = adminDb.doc(
+      `media_private_video_upload_reservations/${reservationId}`
+    );
+    capacityRef = adminDb.doc(
+      `media_private_video_upload_capacity/${ownerUid}`
+    );
+    assert.equal(
+      (await readDocumentData(reservationRef))?.state,
+      'ACTIVE'
+    );
+
+    const uploadMetadata = {
       cacheControl: 'private, max-age=0, no-store, no-transform',
+      customMetadata: {
+        videoReservationId: reservationId,
+        videoId,
+      },
+    };
+
+    await uploadBytes(sourceStorageRef, sourceBytes, {
+      ...uploadMetadata,
+      contentType: 'video/mp4',
     });
     await uploadBytes(posterStorageRef, posterBytes, {
+      ...uploadMetadata,
       contentType: 'image/jpeg',
-      cacheControl: 'private, max-age=0, no-store, no-transform',
     });
 
     const registerPrivateVideoUpload = httpsCallable(
@@ -189,6 +253,7 @@ async function run() {
     const registrationResponse = await registerPrivateVideoUpload({
       ownerUid,
       videoId,
+      reservationId,
       videoStoragePath: sourcePath,
       posterStoragePath: posterPath,
       fileName: 'video-e2e.mp4',
@@ -220,6 +285,23 @@ async function run() {
     );
     jobRef = adminDb.doc(
       `media_video_processing_jobs/${ownerUid}_${videoId}`
+    );
+
+    const consumedReservation = await waitFor(
+      'reserva ser consumida pelo registro do vídeo',
+      async () => ({
+        reservation: await readDocumentData(reservationRef),
+        video: await readDocumentData(privateVideoRef),
+      }),
+      (value) =>
+        value.reservation?.state === 'CONSUMED' &&
+        value.video?.videoReservationId === reservationId &&
+        value.video?.quotaReservedBytes === reservation.reservedBytes
+    );
+    assert.equal(consumedReservation.video.quotaPlanAtUpload, 'free');
+    assert.equal(
+      consumedReservation.video.posterSizeBytes,
+      posterBytes.byteLength
     );
 
     await publicProfileRef.set({
@@ -434,7 +516,10 @@ async function run() {
     assert.equal(await readFileExists(publishedVideoFile), true);
     assert.equal(await readFileExists(publishedPosterFile), true);
 
-    console.log('✔ upload privado de vídeo autorizado pelas Storage Rules');
+    console.log('✔ conta elegível validada antes da transferência');
+    console.log('✔ quota reservada antes do primeiro byte');
+    console.log('✔ upload privado autorizado pela reserva nas Storage Rules');
+    console.log('✔ reserva consumida e vinculada ao vídeo registrado');
     console.log('✔ registro autenticado e fila de processamento criados');
     console.log('✔ intenção de publicação obrigatória aplicada pelo backend');
     console.log('✔ publicação automática concluída após o processamento');
@@ -461,6 +546,14 @@ async function run() {
 
     if (jobRef) {
       cleanupTasks.push(jobRef.delete().catch(() => undefined));
+    }
+
+    if (reservationRef) {
+      cleanupTasks.push(reservationRef.delete().catch(() => undefined));
+    }
+
+    if (capacityRef) {
+      cleanupTasks.push(capacityRef.delete().catch(() => undefined));
     }
 
     if (authenticatedUser) {

--- a/src/app/core/services/media/private-video-upload-reservation.service.ts
+++ b/src/app/core/services/media/private-video-upload-reservation.service.ts
@@ -1,0 +1,64 @@
+import { Injectable, inject } from '@angular/core';
+import { Functions, httpsCallable } from '@angular/fire/functions';
+import { Observable, from } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+export type PrivateVideoQuotaPlan = 'free' | 'basic' | 'premium' | 'vip';
+
+export interface ReservePrivateVideoUploadCommand {
+  readonly clientRequestId: string;
+  readonly ownerUid: string;
+  readonly videoId: string;
+  readonly videoStoragePath: string;
+  readonly posterStoragePath: string | null;
+  readonly videoSizeBytes: number;
+  readonly posterSizeBytes: number;
+  readonly mimeType: string;
+}
+
+export interface PrivateVideoUploadReservation {
+  readonly reservationId: string;
+  readonly ownerUid: string;
+  readonly videoId: string;
+  readonly plan: PrivateVideoQuotaPlan;
+  readonly expiresAt: number;
+  readonly reservedBytes: number;
+  readonly maxItems: number;
+  readonly maxReservedBytes: number;
+  readonly currentItems: number;
+  readonly currentReservedBytes: number;
+}
+
+interface CancelPrivateVideoUploadReservationResponse {
+  reservationId: string;
+  released: boolean;
+}
+
+@Injectable({ providedIn: 'root' })
+export class PrivateVideoUploadReservationService {
+  private readonly functions = inject(Functions);
+
+  private readonly reserveCallable = httpsCallable<
+    ReservePrivateVideoUploadCommand,
+    PrivateVideoUploadReservation
+  >(this.functions, 'reservePrivateVideoUpload');
+
+  private readonly cancelCallable = httpsCallable<
+    { reservationId: string },
+    CancelPrivateVideoUploadReservationResponse
+  >(this.functions, 'cancelPrivateVideoUploadReservation');
+
+  reserveUpload$(
+    command: ReservePrivateVideoUploadCommand
+  ): Observable<PrivateVideoUploadReservation> {
+    return from(this.reserveCallable(command)).pipe(
+      map((response) => response.data)
+    );
+  }
+
+  cancelReservation$(reservationId: string): Observable<boolean> {
+    return from(this.cancelCallable({ reservationId })).pipe(
+      map((response) => response.data.released === true)
+    );
+  }
+}

--- a/src/app/core/services/media/video-upload-flow.service.ts
+++ b/src/app/core/services/media/video-upload-flow.service.ts
@@ -9,7 +9,6 @@ import { Firestore, collection, doc } from '@angular/fire/firestore';
 import { Functions, httpsCallable } from '@angular/fire/functions';
 import { Storage } from '@angular/fire/storage';
 import {
-  deleteObject,
   ref,
   type UploadTask,
   uploadBytesResumable,
@@ -20,6 +19,10 @@ import { IVideoItem } from 'src/app/core/interfaces/media/i-video-item';
 import { IVideoPublicationSettingsInput } from 'src/app/core/interfaces/media/i-video-publication-config';
 import { GlobalErrorHandlerService } from 'src/app/core/services/error-handler/global-error-handler.service';
 import { PrivacyDebugLoggerService } from 'src/app/core/services/privacy/privacy-debug-logger.service';
+import {
+  PrivateVideoUploadReservation,
+  PrivateVideoUploadReservationService,
+} from './private-video-upload-reservation.service';
 import { VideoMetadataPreparationService } from './video-metadata-preparation.service';
 import {
   VideoUploadFormat,
@@ -29,6 +32,7 @@ import {
 
 export type VideoUploadProgressPhase =
   | 'preparing'
+  | 'reserving'
   | 'uploading-video'
   | 'uploading-poster'
   | 'saving';
@@ -65,6 +69,7 @@ interface RegisterPrivateVideoUploadRequest
   extends IVideoPublicationSettingsInput {
   ownerUid: string;
   videoId: string;
+  reservationId: string;
   videoStoragePath: string;
   posterStoragePath: string | null;
   fileName: string;
@@ -106,6 +111,9 @@ export class VideoUploadFlowService {
   private readonly storage = inject(Storage);
   private readonly injector = inject(Injector);
   private readonly metadataPreparation = inject(VideoMetadataPreparationService);
+  private readonly reservationService = inject(
+    PrivateVideoUploadReservationService
+  );
   private readonly errorHandler = inject(GlobalErrorHandlerService);
   private readonly privacyDebug = inject(PrivacyDebugLoggerService);
   private readonly registerPrivateVideoUploadCallable = httpsCallable<
@@ -142,38 +150,37 @@ export class VideoUploadFlowService {
         doc(collection(this.firestore, `users/${ownerUid}/videos`))
       );
       const videoId = videoRef.id;
+      const clientRequestId = this.randomId();
       const videoPath = this.buildVideoPath(ownerUid, videoId, sourceFormat);
       let posterPath: string | null = null;
+      let reservation: PrivateVideoUploadReservation | null = null;
       let activeTask: UploadTask | null = null;
       let cancelRequested = false;
       let registrationStarted = false;
       let completed = false;
-      let cleanupChain = Promise.resolve();
-      let videoUploadStarted = false;
-      let posterUploadStarted = false;
+      let cancellationStarted = false;
 
-      const scheduleCleanup = (): Promise<void> => {
-        cleanupChain = cleanupChain.then(async () => {
-          const cleanupTasks: Promise<void>[] = [];
+      const cancelReservationBestEffort = async (): Promise<void> => {
+        if (!reservation || cancellationStarted) {
+          return;
+        }
 
-          if (posterUploadStarted && posterPath) {
-            cleanupTasks.push(
-              this.deleteBinaryBestEffort(posterPath, 'poster')
-            );
-            posterUploadStarted = false;
-          }
+        cancellationStarted = true;
 
-          if (videoUploadStarted) {
-            cleanupTasks.push(
-              this.deleteBinaryBestEffort(videoPath, 'video')
-            );
-            videoUploadStarted = false;
-          }
-
-          await Promise.all(cleanupTasks);
-        });
-
-        return cleanupChain;
+        try {
+          await firstValueFrom(
+            this.reservationService.cancelReservation$(
+              reservation.reservationId
+            )
+          );
+        } catch (error) {
+          this.reportError(error, {
+            op: 'cancelPrivateVideoUploadReservation',
+            hasOwnerUid: true,
+            hasVideoId: true,
+            hasReservationId: true,
+          });
+        }
       };
 
       const assertNotCancelled = (): void => {
@@ -190,15 +197,33 @@ export class VideoUploadFlowService {
             this.metadataPreparation.prepare$(file)
           );
           const posterBlob = selectedPosterBlob ?? metadata.posterBlob;
+          posterPath = posterBlob
+            ? this.buildPosterPath(ownerUid, videoId)
+            : null;
           assertNotCancelled();
 
-          observer.next({ type: 'progress', phase: 'preparing', progress: 6 });
-          videoUploadStarted = true;
+          observer.next({ type: 'progress', phase: 'reserving', progress: 5 });
+          reservation = await firstValueFrom(
+            this.reservationService.reserveUpload$({
+              clientRequestId,
+              ownerUid,
+              videoId,
+              videoStoragePath: videoPath,
+              posterStoragePath: posterPath,
+              videoSizeBytes: file.size,
+              posterSizeBytes: posterBlob?.size ?? 0,
+              mimeType: sourceFormat.mimeType,
+            })
+          );
+          assertNotCancelled();
 
+          observer.next({ type: 'progress', phase: 'preparing', progress: 7 });
           const videoBinary = await this.uploadBinary(
             videoPath,
             file,
             sourceFormat.mimeType,
+            reservation.reservationId,
+            videoId,
             (task) => {
               activeTask = task;
             },
@@ -206,7 +231,7 @@ export class VideoUploadFlowService {
               observer.next({
                 type: 'progress',
                 phase: 'uploading-video',
-                progress: this.mapProgress(progress, 6, 86),
+                progress: this.mapProgress(progress, 7, 86),
               });
             }
           );
@@ -215,13 +240,13 @@ export class VideoUploadFlowService {
 
           let posterBinary: UploadedBinary | null = null;
 
-          if (posterBlob) {
-            posterPath = this.buildPosterPath(ownerUid, videoId);
-            posterUploadStarted = true;
+          if (posterBlob && posterPath) {
             posterBinary = await this.uploadBinary(
               posterPath,
               posterBlob,
               'image/jpeg',
+              reservation.reservationId,
+              videoId,
               (task) => {
                 activeTask = task;
               },
@@ -246,6 +271,7 @@ export class VideoUploadFlowService {
           const registration = await this.registerUploadedVideo({
             ownerUid,
             videoId,
+            reservationId: reservation.reservationId,
             videoStoragePath: videoBinary.path,
             posterStoragePath: posterBinary?.path ?? null,
             fileName,
@@ -283,9 +309,12 @@ export class VideoUploadFlowService {
           this.privacyDebug.log('media', 'VideoUploadFlow: upload concluído', {
             hasOwnerUid: true,
             hasVideoId: true,
+            hasReservationId: true,
             hasPoster: !!posterBinary,
             processingQueued: true,
             publishWhenReady: publication.publishWhenReady,
+            quotaPlan: reservation.plan,
+            reservedBytes: reservation.reservedBytes,
             mimeType: registration.mimeType,
             sourceExtension: sourceFormat.extension,
             sizeBytes: registration.sizeBytes,
@@ -294,13 +323,12 @@ export class VideoUploadFlowService {
           activeTask = null;
 
           /**
-           * Antes da callable, o cliente ainda é responsável pelo rollback.
-           * Depois que o registro backend começa, a Function assume a limpeza e a
-           * idempotência. Isso evita apagar um arquivo já registrado quando a rede
-           * perde apenas a resposta da callable.
+           * Antes do registro, o cancelamento backend encerra a reserva e remove
+           * qualquer objeto parcial. Depois que a callable começa, o backend e o
+           * trigger idempotente assumem a confirmação e a limpeza.
            */
           if (!completed && !registrationStarted) {
-            await scheduleCleanup();
+            await cancelReservationBestEffort();
           }
 
           if (cancelRequested || error instanceof VideoUploadCancelledError) {
@@ -311,6 +339,7 @@ export class VideoUploadFlowService {
             op: 'uploadPrivateVideo$',
             hasOwnerUid: !!ownerUid,
             hasVideoId: !!videoId,
+            hasReservationId: !!reservation?.reservationId,
             mimeType: sourceFormat.mimeType,
             sourceExtension: sourceFormat.extension,
             sizeBytes: file.size,
@@ -329,7 +358,7 @@ export class VideoUploadFlowService {
 
         cancelRequested = true;
         activeTask?.cancel();
-        void scheduleCleanup();
+        void cancelReservationBestEffort();
       };
     });
   }
@@ -376,6 +405,8 @@ export class VideoUploadFlowService {
     storagePath: string,
     data: Blob,
     contentType: string,
+    reservationId: string,
+    videoId: string,
     registerTask: (task: UploadTask) => void,
     onProgress: (progress: number) => void
   ): Promise<UploadedBinary> {
@@ -384,6 +415,10 @@ export class VideoUploadFlowService {
       const task = uploadBytesResumable(storageRef, data, {
         contentType,
         cacheControl: 'private, max-age=0, no-store, no-transform',
+        customMetadata: {
+          videoReservationId: reservationId,
+          videoId,
+        },
       });
 
       registerTask(task);
@@ -400,28 +435,6 @@ export class VideoUploadFlowService {
         () => resolve({ path: storagePath })
       );
     });
-  }
-
-  private deleteBinaryBestEffort(
-    storagePath: string,
-    assetKind: 'video' | 'poster'
-  ): Promise<void> {
-    return deleteObject(ref(this.storage, storagePath)).catch((error) => {
-      if (this.isObjectNotFoundError(error)) {
-        return;
-      }
-
-      this.reportCleanupError(error, assetKind);
-    });
-  }
-
-  private isObjectNotFoundError(error: unknown): boolean {
-    if (typeof error !== 'object' || error === null || !('code' in error)) {
-      return false;
-    }
-
-    return String((error as { code?: unknown }).code ?? '') ===
-      'storage/object-not-found';
   }
 
   private requireOwnedUid(ownerUid: string): string {
@@ -483,9 +496,7 @@ export class VideoUploadFlowService {
 
   private normalizePublication(
     publication: IVideoUploadCommand['publication']
-  ): RegisterPrivateVideoUploadRequest extends infer _Unused
-    ? IVideoPublicationSettingsInput & { publishWhenReady: boolean }
-    : never {
+  ): IVideoPublicationSettingsInput & { publishWhenReady: true } {
     const title = String(publication?.title ?? '')
       .replace(/\s+/g, ' ')
       .trim()
@@ -495,19 +506,13 @@ export class VideoUploadFlowService {
       .trim()
       .slice(0, 1000);
 
-    /**
-     * MANUTENÇÃO — ARMAZENAMENTO PRIVADO POR PLANO
-     * `publishWhenReady: false` não pode representar armazenamento ilimitado.
-     * Cota, retenção, expiração e entitlement devem ser validados no backend;
-     * a interface não é uma barreira de cobrança ou de capacidade.
-     */
     return {
       title: title || null,
       description: description || null,
       reactionsEnabled: publication?.reactionsEnabled !== false,
       commentsEnabled: publication?.commentsEnabled !== false,
       ratingsEnabled: publication?.ratingsEnabled !== false,
-      publishWhenReady: publication?.publishWhenReady === true,
+      publishWhenReady: true,
     };
   }
 
@@ -567,16 +572,6 @@ export class VideoUploadFlowService {
     }
 
     return Math.max(0, Math.min(100, Math.round(value)));
-  }
-
-  private reportCleanupError(
-    error: unknown,
-    assetKind: 'video' | 'poster'
-  ): void {
-    this.reportError(error, {
-      op: 'rollbackUploadedBinary',
-      assetKind,
-    });
   }
 
   private reportError(

--- a/src/app/core/services/media/video-upload-format.policy.spec.ts
+++ b/src/app/core/services/media/video-upload-format.policy.spec.ts
@@ -2,34 +2,32 @@ import { describe, expect, it } from 'vitest';
 
 import {
   VIDEO_UPLOAD_ACCEPT,
+  VIDEO_UPLOAD_FORMAT_LABEL,
   isAcceptedVideoUploadFile,
   resolveVideoUploadFormat,
 } from './video-upload-format.policy';
 
 describe('video-upload-format.policy', () => {
   it.each([
-    ['video.mp4', 'video/mp4', 'mp4'],
-    ['video.m4v', 'video/x-m4v', 'm4v'],
-    ['video.mov', 'video/quicktime', 'mov'],
-    ['video.webm', 'video/webm', 'webm'],
-    ['video.mkv', 'video/x-matroska', 'mkv'],
-    ['video.avi', 'video/x-msvideo', 'avi'],
-    ['video.wmv', 'video/x-ms-wmv', 'wmv'],
-    ['video.mts', 'video/mp2t', 'mts'],
-    ['video.m2ts', '', 'm2ts'],
-    ['video.mxf', 'application/mxf', 'mxf'],
-  ])('aceita %s com tipo %s', (name, type, extension) => {
-    expect(resolveVideoUploadFormat({ name, type })).toEqual(
-      expect.objectContaining({ extension })
-    );
-    expect(isAcceptedVideoUploadFile({ name, type })).toBe(true);
-  });
+    ['video.mp4', 'video/mp4', 'mp4', 'video/mp4'],
+    ['video.m4v', 'video/x-m4v', 'm4v', 'video/mp4'],
+    ['video.mov', 'video/quicktime', 'mov', 'video/quicktime'],
+    ['video.webm', 'video/webm', 'webm', 'video/webm'],
+  ])(
+    'aceita %s com tipo %s, extensão %s e MIME normalizado %s',
+    (name, type, extension, mimeType) => {
+      expect(resolveVideoUploadFormat({ name, type })).toEqual(
+        expect.objectContaining({ extension, mimeType })
+      );
+      expect(isAcceptedVideoUploadFile({ name, type })).toBe(true);
+    }
+  );
 
-  it('aceita extensão conhecida quando o navegador não informa MIME type', () => {
-    expect(resolveVideoUploadFormat({ name: 'camera.MKV', type: '' })).toEqual(
+  it('aceita extensão compatível quando o navegador não informa MIME type', () => {
+    expect(resolveVideoUploadFormat({ name: 'camera.MOV', type: '' })).toEqual(
       expect.objectContaining({
-        extension: 'mkv',
-        mimeType: 'video/x-matroska',
+        extension: 'mov',
+        mimeType: 'video/quicktime',
         browserPreviewLikely: false,
       })
     );
@@ -37,15 +35,33 @@ describe('video-upload-format.policy', () => {
 
   it('rejeita divergência entre extensão e MIME type conhecidos', () => {
     expect(
-      resolveVideoUploadFormat({ name: 'arquivo.mp4', type: 'video/x-msvideo' })
+      resolveVideoUploadFormat({ name: 'arquivo.mp4', type: 'video/quicktime' })
     ).toBeNull();
   });
 
-  it('não anuncia formatos fora da política', () => {
-    expect(VIDEO_UPLOAD_ACCEPT).toContain('.mkv');
-    expect(VIDEO_UPLOAD_ACCEPT).toContain('.m2ts');
+  it.each([
+    ['arquivo.mkv', 'video/x-matroska'],
+    ['arquivo.avi', 'video/x-msvideo'],
+    ['arquivo.wmv', 'video/x-ms-wmv'],
+    ['arquivo.ts', 'video/mp2t'],
+    ['arquivo.mts', 'video/mp2t'],
+    ['arquivo.m2ts', 'video/mp2t'],
+    ['arquivo.mxf', 'application/mxf'],
+    ['arquivo.ogv', 'video/ogg'],
+  ])('rejeita formato sem suporte integral: %s', (name, type) => {
+    expect(resolveVideoUploadFormat({ name, type })).toBeNull();
+    expect(isAcceptedVideoUploadFile({ name, type })).toBe(false);
+  });
+
+  it('anuncia somente formatos processáveis pelo pipeline atual', () => {
+    expect(VIDEO_UPLOAD_FORMAT_LABEL).toBe('MP4, M4V, MOV ou WebM');
+    expect(VIDEO_UPLOAD_ACCEPT).toContain('.mp4');
+    expect(VIDEO_UPLOAD_ACCEPT).toContain('.m4v');
+    expect(VIDEO_UPLOAD_ACCEPT).toContain('.mov');
+    expect(VIDEO_UPLOAD_ACCEPT).toContain('.webm');
+    expect(VIDEO_UPLOAD_ACCEPT).not.toContain('.mkv');
+    expect(VIDEO_UPLOAD_ACCEPT).not.toContain('.m2ts');
+    expect(VIDEO_UPLOAD_ACCEPT).not.toContain('application/mxf');
     expect(VIDEO_UPLOAD_ACCEPT).not.toContain('video/*');
-    expect(isAcceptedVideoUploadFile({ name: 'arquivo.ogv', type: 'video/ogg' }))
-      .toBe(false);
   });
 });

--- a/src/app/core/services/media/video-upload-format.policy.ts
+++ b/src/app/core/services/media/video-upload-format.policy.ts
@@ -4,6 +4,13 @@ export interface VideoUploadFormat {
   browserPreviewLikely: boolean;
 }
 
+/**
+ * Contrato de entrada compatível com o pipeline atual de processamento.
+ *
+ * O cliente normaliza M4V para video/mp4 antes do envio. MOV permanece como
+ * video/quicktime para ser transcodificado no backend. Formatos adicionais só
+ * devem ser anunciados quando registro, fila e Transcoder os aceitarem juntos.
+ */
 const FORMAT_BY_EXTENSION: Readonly<Record<string, VideoUploadFormat>> = {
   mp4: {
     extension: 'mp4',
@@ -25,41 +32,6 @@ const FORMAT_BY_EXTENSION: Readonly<Record<string, VideoUploadFormat>> = {
     mimeType: 'video/webm',
     browserPreviewLikely: true,
   },
-  mkv: {
-    extension: 'mkv',
-    mimeType: 'video/x-matroska',
-    browserPreviewLikely: false,
-  },
-  avi: {
-    extension: 'avi',
-    mimeType: 'video/x-msvideo',
-    browserPreviewLikely: false,
-  },
-  wmv: {
-    extension: 'wmv',
-    mimeType: 'video/x-ms-wmv',
-    browserPreviewLikely: false,
-  },
-  ts: {
-    extension: 'ts',
-    mimeType: 'video/mp2t',
-    browserPreviewLikely: false,
-  },
-  mts: {
-    extension: 'mts',
-    mimeType: 'video/mp2t',
-    browserPreviewLikely: false,
-  },
-  m2ts: {
-    extension: 'm2ts',
-    mimeType: 'video/mp2t',
-    browserPreviewLikely: false,
-  },
-  mxf: {
-    extension: 'mxf',
-    mimeType: 'application/mxf',
-    browserPreviewLikely: false,
-  },
 };
 
 const EXTENSION_BY_MIME_TYPE: Readonly<Record<string, string>> = {
@@ -67,14 +39,6 @@ const EXTENSION_BY_MIME_TYPE: Readonly<Record<string, string>> = {
   'video/x-m4v': 'm4v',
   'video/quicktime': 'mov',
   'video/webm': 'webm',
-  'video/x-matroska': 'mkv',
-  'video/x-msvideo': 'avi',
-  'video/avi': 'avi',
-  'video/msvideo': 'avi',
-  'video/x-ms-wmv': 'wmv',
-  'video/mp2t': 'ts',
-  'application/mxf': 'mxf',
-  'video/mxf': 'mxf',
 };
 
 export const VIDEO_UPLOAD_ACCEPT = [
@@ -82,8 +46,7 @@ export const VIDEO_UPLOAD_ACCEPT = [
   ...Object.keys(FORMAT_BY_EXTENSION).map((extension) => `.${extension}`),
 ].join(',');
 
-export const VIDEO_UPLOAD_FORMAT_LABEL =
-  'MP4, M4V, MOV, WebM, MKV, AVI, WMV, TS, MTS, M2TS ou MXF';
+export const VIDEO_UPLOAD_FORMAT_LABEL = 'MP4, M4V, MOV ou WebM';
 
 export function resolveVideoUploadFormat(
   candidate: Pick<File, 'name' | 'type'> | null | undefined

--- a/src/app/media/videos/profile-videos/profile-videos.component.ts
+++ b/src/app/media/videos/profile-videos/profile-videos.component.ts
@@ -872,6 +872,14 @@ export class ProfileVideosComponent {
       return;
     }
 
+    if (phase === 'reserving') {
+      this.uploadPhaseSubject.next('PREPARING');
+      this.uploadStepSubject.next(
+        'Confirmando limite da conta e reservando espaço.'
+      );
+      return;
+    }
+
     if (phase === 'uploading-video') {
       this.uploadPhaseSubject.next('UPLOADING');
       this.uploadStepSubject.next('Enviando vídeo. Mantenha esta página aberta.');
@@ -890,6 +898,53 @@ export class ProfileVideosComponent {
 
   private describeUploadFailure(error: unknown): VideoUploadFailureFeedback {
     const code = this.uploadErrorCode(error);
+    const details = this.uploadErrorDetails(error);
+    const domainCode = String(details['code'] ?? '')
+      .trim()
+      .toUpperCase();
+    const domainRecovery = String(details['recovery'] ?? '').trim();
+    const errorMessage = error instanceof Error && error.message.trim()
+      ? error.message.trim()
+      : '';
+
+    if (
+      domainCode === 'VIDEO_UPLOAD_ITEM_LIMIT' ||
+      domainCode === 'VIDEO_UPLOAD_BYTE_LIMIT'
+    ) {
+      return {
+        title: 'Limite do plano atingido',
+        message: errorMessage || 'Não há capacidade disponível para outro vídeo.',
+        recovery:
+          domainRecovery ||
+          'Exclua um vídeo existente ou altere o plano antes de continuar.',
+        retryable: false,
+      };
+    }
+
+    if (
+      domainCode === 'VIDEO_UPLOAD_RESERVATION_EXPIRED' ||
+      domainCode === 'VIDEO_UPLOAD_RESERVATION_REQUIRED'
+    ) {
+      return {
+        title: 'Reserva expirada',
+        message: errorMessage || 'A autorização temporária do envio expirou.',
+        recovery:
+          domainRecovery ||
+          'Tente novamente para gerar uma nova reserva antes do upload.',
+        retryable: true,
+      };
+    }
+
+    if (domainCode === 'VIDEO_UPLOAD_RESERVATION_MISMATCH') {
+      return {
+        title: 'Arquivo divergente',
+        message: errorMessage || 'O arquivo não corresponde à reserva criada.',
+        recovery:
+          domainRecovery ||
+          'Selecione novamente o arquivo e reinicie o envio.',
+        retryable: false,
+      };
+    }
 
     if (typeof navigator !== 'undefined' && navigator.onLine === false) {
       return {
@@ -946,9 +1001,7 @@ export class ProfileVideosComponent {
       };
     }
 
-    const message = error instanceof Error && error.message.trim()
-      ? error.message.trim()
-      : 'Não foi possível concluir o envio do vídeo.';
+    const message = errorMessage || 'Não foi possível concluir o envio do vídeo.';
 
     return {
       title: 'Falha no envio',
@@ -966,6 +1019,21 @@ export class ProfileVideosComponent {
     return String((error as { code?: unknown }).code ?? '')
       .trim()
       .toLowerCase();
+  }
+
+  private uploadErrorDetails(error: unknown): Record<string, unknown> {
+    if (
+      typeof error !== 'object' ||
+      error === null ||
+      !('details' in error)
+    ) {
+      return {};
+    }
+
+    const details = (error as { details?: unknown }).details;
+    return details && typeof details === 'object'
+      ? details as Record<string, unknown>
+      : {};
   }
 
   private setBusyAction(videoId: string, action: VideoBusyAction): void {

--- a/storage.rules
+++ b/storage.rules
@@ -38,7 +38,8 @@ service firebase.storage {
 
     function hasOperationalVideoUploadAccount(uid) {
       let user = privateVideoUploadUser(uid);
-      return user.uid == uid
+      return (!('uid' in user) || user.uid == uid)
+        && 'email_verified' in request.auth.token
         && request.auth.token.email_verified == true
         && user.profileCompleted == true
         && (!('accountStatus' in user) || user.accountStatus == 'active')

--- a/storage.rules
+++ b/storage.rules
@@ -3,7 +3,7 @@ service firebase.storage {
   match /b/{bucket}/o {
 
     // ============================================================
-    // Helpers básicos - 14ABR2026
+    // Helpers básicos
     // ============================================================
 
     function signedIn() {
@@ -23,16 +23,87 @@ service firebase.storage {
     function isVideoCreateOrUpdate() {
       return request.resource != null
         && (
-          request.resource.contentType.matches('video/.*')
-          || request.resource.contentType == 'application/mxf'
+          request.resource.contentType == 'video/mp4'
+          || request.resource.contentType == 'video/webm'
+          || request.resource.contentType == 'video/quicktime'
         )
         && request.resource.size <= 500 * 1024 * 1024;
     }
 
+    function privateVideoUploadUser(uid) {
+      return firestore.get(
+        /databases/(default)/documents/users/$(uid)
+      ).data;
+    }
+
+    function hasOperationalVideoUploadAccount(uid) {
+      let user = privateVideoUploadUser(uid);
+      return user.uid == uid
+        && request.auth.token.email_verified == true
+        && user.profileCompleted == true
+        && (!('accountStatus' in user) || user.accountStatus == 'active')
+        && (!('suspended' in user) || user.suspended != true)
+        && (!('interactionBlocked' in user) || user.interactionBlocked != true)
+        && (!('accountLocked' in user) || user.accountLocked != true)
+        && (!('loginAllowed' in user) || user.loginAllowed != false)
+        && (
+          !('ageReverification' in user)
+          || !(user.ageReverification is map)
+          || !('status' in user.ageReverification)
+          || (
+            user.ageReverification.status != 'REQUIRED'
+            && user.ageReverification.status != 'SUBMITTED'
+            && user.ageReverification.status != 'UNDER_REVIEW'
+            && user.ageReverification.status != 'REJECTED'
+            && user.ageReverification.status != 'EXPIRED'
+          )
+        );
+    }
+
+    function hasVideoReservationMetadata(videoId) {
+      return request.resource != null
+        && request.resource.metadata != null
+        && request.resource.metadata.videoReservationId is string
+        && request.resource.metadata.videoReservationId.size() > 0
+        && request.resource.metadata.videoReservationId.size() <= 128
+        && request.resource.metadata.videoId == videoId;
+    }
+
+    function videoUploadReservation() {
+      return firestore.get(
+        /databases/(default)/documents/media_private_video_upload_reservations/$(request.resource.metadata.videoReservationId)
+      ).data;
+    }
+
+    function hasActiveVideoReservation(uid, videoId) {
+      let reservation = videoUploadReservation();
+      return hasVideoReservationMetadata(videoId)
+        && hasOperationalVideoUploadAccount(uid)
+        && reservation.ownerUid == uid
+        && reservation.videoId == videoId
+        && reservation.state == 'ACTIVE'
+        && reservation.expiresAt > request.time;
+    }
+
+    function reservedVideoUpload(uid, videoId, objectPath) {
+      let reservation = videoUploadReservation();
+      return hasActiveVideoReservation(uid, videoId)
+        && reservation.videoStoragePath == objectPath
+        && reservation.videoSizeBytes == request.resource.size
+        && reservation.mimeType == request.resource.contentType;
+    }
+
+    function reservedVideoPosterUpload(uid, videoId, objectPath) {
+      let reservation = videoUploadReservation();
+      return hasActiveVideoReservation(uid, videoId)
+        && reservation.posterStoragePath == objectPath
+        && reservation.posterSizeBytes == request.resource.size
+        && request.resource.contentType == 'image/jpeg'
+        && request.resource.size <= 10 * 1024 * 1024;
+    }
+
     // ============================================================
     // Upload bruto e privado do usuário
-    // - upload e rollback continuam sob controle do proprietário;
-    // - reprodução usa URL temporária emitida pelo backend.
     // ============================================================
 
     match /users/{uid}/uploads/images/{fileName} {
@@ -43,20 +114,28 @@ service firebase.storage {
 
     match /users/{uid}/uploads/videos/{fileName} {
       allow read: if false;
-      allow create, update: if isSelf(uid) && isVideoCreateOrUpdate();
-      allow delete: if isSelf(uid);
+      allow create: if isSelf(uid)
+        && isVideoCreateOrUpdate()
+        && reservedVideoUpload(
+          uid,
+          request.resource.metadata.videoId,
+          'users/' + uid + '/uploads/videos/' + fileName
+        );
+      allow update, delete: if false;
     }
 
-    // Poster gerado localmente para um vídeo privado específico.
-    // O namespace separado permite limpeza segura junto do vídeo sem afetar fotos.
     match /users/{uid}/uploads/video-posters/{videoId}/{fileName} {
       allow read: if false;
-      allow create, update: if isSelf(uid) && isImageCreateOrUpdate();
-      allow delete: if isSelf(uid);
+      allow create: if isSelf(uid)
+        && reservedVideoPosterUpload(
+          uid,
+          videoId,
+          'users/' + uid + '/uploads/video-posters/' + videoId + '/' + fileName
+        );
+      allow update, delete: if false;
     }
 
     // Derivados produzidos exclusivamente pelo backend.
-    // Reprodução também ocorre somente por URL temporária emitida pelo backend.
     match /users/{uid}/processed/videos/{videoId}/{allPaths=**} {
       allow read, write: if false;
     }
@@ -73,8 +152,6 @@ service firebase.storage {
 
     // ============================================================
     // Mídia publicada sensível
-    // - leitura ocorre somente por URL temporária emitida pelo backend;
-    // - clientes não acessam nem escrevem diretamente estes namespaces.
     // ============================================================
 
     match /users/{uid}/published/images/{allPaths=**} {


### PR DESCRIPTION
## Dependências

Este PR é empilhado sobre o **#69** (`agent/model-video-lifecycle-states`). Também replica temporariamente o contrato de formatos do **#67**, porque o branch-base ainda não o contém; essa diferença desaparece quando a cadeia for reorganizada após a integração do #67.

## O que mudou

- cria reserva backend obrigatória antes de qualquer byte ser enviado;
- calcula capacidade a partir dos vídeos realmente registrados e das reservas ativas, sem contador acumulado sujeito a drift;
- serializa concorrência por um documento-lock por usuário;
- reserva espaço para original, margem do derivado processado e capa;
- aplica limites por plano: Free 1 vídeo/800 MiB, Basic 2/2 GiB, Premium 5/5 GiB e VIP 10/10 GiB;
- só reconhece plano pago por projeção financeira ativa, versionada, vigente e de escopo `platform_subscription`;
- revalida elegibilidade no preflight, nas Storage Rules e no registro definitivo;
- exige metadata de reserva, `videoId`, path, tamanho e MIME idênticos nas Storage Rules;
- bloqueia criação sem reserva, reutilização divergente, overwrite e exclusão física direta pelo navegador;
- cancela a reserva pelo backend quando o usuário interrompe o upload ou ocorre falha antes do registro;
- consome a reserva de forma idempotente após o registro e também por trigger Firestore com retry;
- grava no vídeo `videoReservationId`, `quotaPlanAtUpload`, `quotaReservedBytes` e `posterSizeBytes`;
- reconcilia reservas expiradas associadas a vídeos já registrados em vez de apagar seus ativos;
- impede dupla contagem durante a janela entre registro e consumo;
- apresenta feedback específico para limite de itens, limite de armazenamento, reserva expirada e divergência do arquivo;
- mantém o fluxo Angular reativo e os métodos públicos existentes.

## Arquitetura

A capacidade não depende de um contador persistido. Cada transação lê:

1. vídeos existentes em `users/{uid}/videos`;
2. reservas `ACTIVE` e ainda vigentes;
3. projeção atual do plano;
4. documento-lock de capacidade do usuário.

O lock força retry transacional em reservas concorrentes. A exclusão definitiva libera capacidade quando o documento privado do vídeo é removido, sem necessidade de decrementar contadores manualmente.

A reserva dura 30 minutos. Estados terminais são retidos por 24 horas para diagnóstico e idempotência e depois removidos pelo job agendado.

## Segurança

- reserva determinística por `ownerUid + clientRequestId`;
- somente o proprietário autenticado pode reservar ou cancelar;
- Storage Rules consultam o documento da reserva e o estado operacional da conta;
- objetos parciais são removidos exclusivamente pelo backend;
- a limpeza consulta o documento do vídeo antes de apagar qualquer objeto;
- um vídeo registrado nunca é removido por expiração ou cancelamento tardio da reserva;
- o registrador rejeita clientes sem reserva mesmo que consigam chamar a callable diretamente.

## Limites

A reserva considera `2 × tamanho do original + tamanho da capa`. A margem cobre o original privado e o derivado processado sem depender do tamanho final ainda desconhecido.

## Testes e validação

No commit atual:

- **Quality Gate: aprovado**;
- **Angular CI Validation: aprovado**;
- Functions lint, build e testes: aprovados;
- Angular tests: aprovados;
- Angular safe build: aprovado;
- Firestore Rules tests: aprovados;
- validação de índices: aprovada;
- configuração de emuladores: construída com sucesso.

O E2E `scripts/tests/video-publication.e2e.mjs` foi atualizado para criar conta elegível, reservar quota, enviar metadata autorizada, consumir a reserva e validar o vínculo no vídeo. Esse script não é executado pelos workflows padrão atuais, portanto sua atualização não deve ser confundida com uma execução E2E neste PR.

## Supressões intencionais

- removido do fluxo Angular o rollback físico com `deleteObject`; o navegador não é mais autoridade para liberar quota ou apagar objetos parciais;
- a limpeza foi transferida para `cancelPrivateVideoUploadReservation` e para o job de expiração;
- formatos sem suporte integral foram novamente ocultados neste branch para manter frontend, reserva e Storage Rules coerentes.

Nenhuma lógica de retry, cancelamento, edição, exclusão definitiva, publicação automática, moderação ou acompanhamento reativo do ciclo de vida foi ocultada.