### PR TITLE
test(video): add staging validation workflow

### DIFF
--- a/.github/workflows/video-staging-contract.yml
+++ b/.github/workflows/video-staging-contract.yml
@@ -1,0 +1,52 @@
+name: Video Staging Contract
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: video-staging-contract-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract:
+    name: Validate staging scripts and safety contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check script syntax
+        run: |
+          node --check scripts/tests/video-staging-readiness.mjs
+          node --check scripts/tests/video-staging-smoke.mjs
+
+      - name: Validate repository staging contract
+        env:
+          VIDEO_STAGING_REPORT_DIR: artifacts/video-staging
+        run: node scripts/tests/video-staging-readiness.mjs --contract
+
+      - name: Upload readiness report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: video-staging-contract-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/video-staging/readiness.json
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/video-staging-smoke.yml
+++ b/.github/workflows/video-staging-smoke.yml
@@ -1,0 +1,125 @@
+name: Video Staging Smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm_project:
+        description: Digite exatamente entretenimento-staging
+        required: true
+        type: string
+      formats:
+        description: Formatos separados por vírgula
+        required: true
+        default: mp4,webm,mov
+        type: string
+      cleanup:
+        description: Remover todos os dados efêmeros ao final
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: video-staging-smoke
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    name: Real video pipeline smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    environment: video-staging
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          package-manager-cache: false
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Audit staging configuration
+        run: npm run test:media:video:staging:readiness
+
+      - name: Prepare deterministic media samples
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if ! command -v ffmpeg >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y ffmpeg
+          fi
+
+          mkdir -p artifacts/video-staging/samples
+
+          ffmpeg -hide_banner -loglevel error -y \
+            -f lavfi -i "testsrc=size=640x360:rate=24" \
+            -t 6 -c:v libx264 -pix_fmt yuv420p \
+            artifacts/video-staging/samples/sample.mp4
+
+          ffmpeg -hide_banner -loglevel error -y \
+            -f lavfi -i "testsrc=size=640x360:rate=24" \
+            -t 6 -c:v libvpx-vp9 -pix_fmt yuv420p \
+            artifacts/video-staging/samples/sample.webm
+
+          ffmpeg -hide_banner -loglevel error -y \
+            -f lavfi -i "testsrc=size=640x360:rate=24" \
+            -t 6 -c:v libx264 -pix_fmt yuv420p \
+            artifacts/video-staging/samples/sample.mov
+
+          ffmpeg -hide_banner -loglevel error -y \
+            -i artifacts/video-staging/samples/sample.mp4 \
+            -frames:v 1 -q:v 2 \
+            artifacts/video-staging/samples/poster.jpg
+
+      - name: Authenticate to Google Cloud with OIDC
+        id: google-auth
+        uses: google-github-actions/auth@v3
+        with:
+          project_id: ${{ vars.FIREBASE_STAGING_PROJECT_ID }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_VIDEO_STAGING_SERVICE_ACCOUNT }}
+          create_credentials_file: true
+          export_environment_variables: true
+
+      - name: Execute real staging smoke
+        env:
+          VIDEO_STAGING_CONFIRM: ${{ inputs.confirm_project }}
+          VIDEO_STAGING_PROJECT_ID: ${{ vars.FIREBASE_STAGING_PROJECT_ID }}
+          VIDEO_STAGING_STORAGE_BUCKET: ${{ vars.FIREBASE_STAGING_STORAGE_BUCKET }}
+          VIDEO_STAGING_AUTH_DOMAIN: ${{ vars.FIREBASE_STAGING_AUTH_DOMAIN }}
+          VIDEO_STAGING_API_KEY: ${{ secrets.FIREBASE_STAGING_API_KEY }}
+          VIDEO_STAGING_APP_ID: ${{ vars.FIREBASE_STAGING_APP_ID }}
+          VIDEO_STAGING_FUNCTIONS_REGION: us-central1
+          VIDEO_STAGING_FORMATS: ${{ inputs.formats }}
+          VIDEO_STAGING_MP4_PATH: artifacts/video-staging/samples/sample.mp4
+          VIDEO_STAGING_WEBM_PATH: artifacts/video-staging/samples/sample.webm
+          VIDEO_STAGING_MOV_PATH: artifacts/video-staging/samples/sample.mov
+          VIDEO_STAGING_POSTER_PATH: artifacts/video-staging/samples/poster.jpg
+          VIDEO_STAGING_DURATION_MS: 6000
+          VIDEO_STAGING_TIMEOUT_MS: 1200000
+          VIDEO_STAGING_INTERVAL_MS: 5000
+          VIDEO_STAGING_CLEANUP: ${{ inputs.cleanup }}
+          VIDEO_STAGING_REPORT_DIR: artifacts/video-staging
+        run: npm run test:media:video:staging:smoke
+
+      - name: Upload staging report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: video-staging-smoke-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            artifacts/video-staging/readiness.json
+            artifacts/video-staging/smoke.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,12 @@ testem.log
 # Exportações avulsas criadas pela Firebase Emulator UI
 /firebase-export-*/
 
+# Credenciais efêmeras criadas por google-github-actions/auth
+/gha-creds-*.json
+
+# Relatórios locais de homologação
+/artifacts/video-staging/
+
 # System files
 .DS_Store
 Thumbs.db

--- a/docs/video-development-stage.md
+++ b/docs/video-development-stage.md
@@ -1,0 +1,110 @@
+# Estado atual do pipeline de vídeos
+
+## Classificação
+
+A plataforma permanece em **desenvolvimento local e validação automatizada**.
+
+O repositório, os pull requests empilhados e os workflows de staging não constituem autorização para:
+
+- implantar a aplicação em produção;
+- disponibilizar a plataforma para usuários reais;
+- configurar credenciais de produção;
+- executar migrações sobre dados reais;
+- habilitar monetização;
+- executar o smoke test contra serviços reais;
+- integrar a pilha de PRs em `main` sem revisão individual.
+
+## Significado de `video-staging`
+
+`video-staging` é somente um contrato técnico preservado para uma homologação futura e isolada do pipeline de vídeos.
+
+Ele documenta como validar, quando a plataforma estiver madura:
+
+```text
+App Check
+  -> reserva de quota
+  -> Storage Rules
+  -> registro do upload
+  -> Cloud Tasks
+  -> Google Transcoder
+  -> publicação
+  -> observabilidade
+  -> limpeza dos dados sintéticos
+```
+
+O workflow real permanece:
+
+- manual;
+- inativo sem GitHub Environment, OIDC, IAM, secrets e variables;
+- proibido para o projeto `entretenimento-sexual`;
+- limitado ao projeto isolado `entretenimento-staging`;
+- sem capacidade de deploy.
+
+## Fase autorizada
+
+Neste momento estão autorizados apenas:
+
+1. desenvolvimento local;
+2. Firebase Emulators;
+3. testes unitários, de integração e de Rules;
+4. builds de verificação;
+5. auditoria estática de contratos;
+6. revisão arquitetural e de segurança;
+7. pull requests em rascunho;
+8. correções incrementais sem promoção de ambiente.
+
+## Fase não autorizada
+
+Permanecem suspensos até decisão explícita futura:
+
+1. deploy de Functions, Rules, índices, Hosting ou aplicativo;
+2. execução do `Video Staging Smoke`;
+3. criação de secrets para o smoke;
+4. concessão de IAM à service account de homologação;
+5. ativação de faturamento motivada apenas pelo smoke;
+6. uso de dados ou contas reais;
+7. merge da pilha #68–#73 em `main`.
+
+## Critérios mínimos antes de homologação real
+
+A futura homologação somente deve ser considerada após coerência comprovada dos fluxos de:
+
+- conta e ciclo de vida;
+- idade e reverificação;
+- privacidade e audiência;
+- bloqueios nos dois sentidos;
+- compatibilidade entre perfis;
+- publicação e visualização;
+- moderação e denúncias;
+- exclusão e retenção;
+- recuperação de falhas;
+- segurança das URLs de mídia;
+- navegação mobile e acessibilidade;
+- custos, quotas e observabilidade.
+
+## Próxima prioridade técnica
+
+O próximo lote deve tratar a política centralizada de acesso e audiência dos vídeos, reutilizada por perfil, viewer, chat e futura descoberta.
+
+Essa política deve impedir que a entrega de metadados ou URLs assinadas dependa apenas do cliente ou de projeções públicas, considerando:
+
+- proprietário e administrador;
+- autenticação;
+- maioridade e reverificação;
+- estado da conta;
+- publicação, processamento e moderação;
+- visibilidade;
+- bloqueio em ambos os sentidos;
+- amizade, assinatura, associação e compatibilidade;
+- conteúdo removido, suspenso ou rejeitado.
+
+## Terminologia
+
+Nos documentos e PRs atuais:
+
+- **homologação futura** significa procedimento técnico ainda não autorizado;
+- **staging** significa projeto isolado sem usuários reais;
+- **deploy** aparece apenas como descrição da sequência que poderá ser usada no futuro;
+- **produção** significa ambiente real e permanece fora do escopo atual.
+
+Nenhum procedimento futuro deve ser executado por inferência. É necessária autorização explícita para configurar infraestrutura, secrets, IAM, staging real ou produção.

--- a/docs/video-staging-validation.md
+++ b/docs/video-staging-validation.md
@@ -9,6 +9,7 @@ Comprovar no ambiente real:
 
 ```text
 conta elegível
+  -> App Check válido
   -> reserva de quota
   -> Storage Rules
   -> registro privado
@@ -35,8 +36,17 @@ appCheck.siteKey = staging-recaptcha-v3-site-key
 apiEndpoint       = https://api.staging.seuprojeto.com
 ```
 
-A site key de App Check é bloqueante. A auditoria estática falha enquanto esse
-placeholder permanecer no `environment.staging.ts`.
+A site key de App Check é bloqueante para o build Angular de staging. A auditoria
+estática em modo de deploy falha enquanto esse placeholder permanecer no
+`environment.staging.ts`.
+
+O smoke de Node não tenta executar reCAPTCHA. Ele usa `CustomProvider` e recebe
+um token App Check efêmero emitido pelo Firebase Admin SDK para o `appId` Web de
+staging. Assim, Functions e Storage continuam sendo exercitados com App Check
+mesmo quando a aplicação obrigatória está habilitada.
+
+Esse token não substitui a configuração real do aplicativo Angular. A site key
+pública de staging ainda precisa existir antes da homologação integral da UI.
 
 O endpoint auxiliar não participa diretamente do smoke de Firebase, mas continua
 sendo uma pendência para homologar o aplicativo completo.
@@ -57,7 +67,9 @@ gcloud services enable firestore.googleapis.com `
   cloudtasks.googleapis.com `
   transcoder.googleapis.com `
   firebase.googleapis.com `
+  firebaseappcheck.googleapis.com `
   identitytoolkit.googleapis.com `
+  iamcredentials.googleapis.com `
   --project=entretenimento-staging
 ```
 
@@ -142,7 +154,8 @@ Permissões mínimas esperadas para essa identidade:
 - administrar usuários efêmeros do Firebase Auth;
 - ler e gravar documentos efêmeros de Firestore;
 - apagar objetos apenas do projeto de staging;
-- assinar custom tokens para os usuários efêmeros;
+- assinar custom tokens do Firebase Auth;
+- assinar custom tokens do App Check para o `appId` de staging;
 - ler a configuração básica do projeto.
 
 Papéis a avaliar no projeto de staging:
@@ -155,10 +168,32 @@ roles/iam.serviceAccountTokenCreator
 ```
 
 `roles/iam.serviceAccountTokenCreator` deve ser concedido de forma restrita à
-própria service account usada no smoke, somente para permitir a assinatura dos
-custom tokens.
+própria service account usada no smoke. A permissão `iam.serviceAccounts.signBlob`
+é necessária para assinar tanto o custom token de autenticação quanto o custom
+token usado pelo App Check.
+
+Não conceder `roles/firebaseappcheck.admin` apenas para executar o smoke. O fluxo
+não altera configuração, enforcement ou debug tokens do App Check.
 
 A identidade do smoke não deve receber permissão de deploy.
+
+## App Check no smoke de Node
+
+Os provedores reCAPTCHA não funcionam diretamente no runtime Node. O script usa:
+
+```text
+Firebase Admin AppCheck.createToken(appId)
+  -> Firebase Web CustomProvider
+  -> initializeAppCheck(clientApp)
+  -> Auth, Functions e Storage com X-Firebase-AppCheck
+```
+
+O token tem duração de 30 minutos e é renovado pelo provider quando necessário.
+Ele nunca é impresso nem salvo no relatório.
+
+Esse mecanismo é exclusivo do ambiente protegido de homologação. Não deve ser
+copiado para o bundle Angular, exposto ao navegador ou transformado em endpoint
+público de emissão de tokens.
 
 ## GitHub Environment
 
@@ -204,13 +239,15 @@ A auditoria verifica:
 - Node 22;
 - isolamento entre staging e produção;
 - configuração Angular e bucket;
-- App Check não-placeholder;
+- App Check não-placeholder para o build real;
 - exports do dispatcher, worker, diagnóstico e recuperação;
 - contrato MP4/M4V, MOV e WebM;
 - Storage Rules com reserva obrigatória;
 - registro definitivo com reserva;
 - TTL de despachos e DLQ;
 - índice da auditoria administrativa;
+- proteção manual e OIDC do workflow real;
+- uso de App Check customizado no smoke;
 - proteção contra credenciais temporárias do OIDC.
 
 O relatório é salvo em:
@@ -218,6 +255,16 @@ O relatório é salvo em:
 ```text
 artifacts/video-staging/readiness.json
 ```
+
+Para validar apenas o contrato do repositório no CI:
+
+```powershell
+node scripts/tests/video-staging-readiness.mjs --contract
+```
+
+Nesse modo, placeholders externos conhecidos são warnings. Erros arquiteturais,
+remoção de proteções, divergência de projetos ou quebra dos contratos continuam
+falhando o gate.
 
 ## Execução pelo GitHub Actions
 
@@ -236,15 +283,16 @@ O workflow:
 1. executa a auditoria estática;
 2. gera vídeos sintéticos de seis segundos com FFmpeg;
 3. autentica no Google Cloud por OIDC;
-4. executa o pipeline real para cada formato;
-5. consulta `getVideoProcessingOperationalStatus` com claim administrativo;
-6. apaga usuários, documentos e objetos efêmeros;
-7. publica os relatórios como artifact por 30 dias.
+4. emite tokens efêmeros de Auth e App Check sem imprimi-los;
+5. executa o pipeline real para cada formato;
+6. consulta `getVideoProcessingOperationalStatus` com claim administrativo;
+7. apaga usuários, documentos e objetos efêmeros;
+8. publica os relatórios como artifact por 30 dias.
 
 ## Execução local
 
 É necessário possuir Application Default Credentials da service account de
-smoke e arquivos de vídeo válidos.
+smoke, permissão de assinatura e arquivos de vídeo válidos.
 
 Exemplo PowerShell:
 
@@ -281,6 +329,7 @@ indicados no relatório.
 
 Cada formato precisa comprovar:
 
+- token App Check aceito por Functions e Storage;
 - reserva `ACTIVE` antes do upload;
 - upload autorizado pelas Storage Rules;
 - reserva `CONSUMED` após o registro;
@@ -294,6 +343,7 @@ Cada formato precisa comprovar:
 - despacho `COMPLETED`;
 - ausência do job bem-sucedido na DLQ;
 - provider `READY` no painel operacional;
+- amostra de latência consultada antes da limpeza;
 - limpeza dos recursos efêmeros.
 
 Falha em qualquer item reprova o lote. Não converter falhas em warnings apenas

--- a/docs/video-staging-validation.md
+++ b/docs/video-staging-validation.md
@@ -1,0 +1,365 @@
+# Homologação real do pipeline de vídeos
+
+Este procedimento valida o fluxo de vídeo contra o projeto
+`entretenimento-staging`. Ele não deve ser executado no projeto de produção.
+
+## Objetivo
+
+Comprovar no ambiente real:
+
+```text
+conta elegível
+  -> reserva de quota
+  -> Storage Rules
+  -> registro privado
+  -> job Firestore
+  -> trigger de despacho
+  -> Cloud Tasks
+  -> Google Transcoder
+  -> derivado privado
+  -> publicação automática
+  -> moderação pendente/aprovada
+  -> painel operacional
+  -> limpeza dos dados efêmeros
+```
+
+O smoke usa um usuário diferente para cada formato. Isso evita que o limite do
+plano Free interfira na validação de MP4, WebM e MOV.
+
+## Bloqueios atuais que devem ser resolvidos
+
+A configuração versionada de staging ainda contém:
+
+```text
+appCheck.siteKey = staging-recaptcha-v3-site-key
+apiEndpoint       = https://api.staging.seuprojeto.com
+```
+
+A site key de App Check é bloqueante. A auditoria estática falha enquanto esse
+placeholder permanecer no `environment.staging.ts`.
+
+O endpoint auxiliar não participa diretamente do smoke de Firebase, mas continua
+sendo uma pendência para homologar o aplicativo completo.
+
+Não inventar ou copiar uma chave de outro projeto. Criar o recurso de App Check
+no projeto `entretenimento-staging` e versionar somente a site key pública
+correspondente.
+
+## APIs e faturamento
+
+Confirmar faturamento ativo e APIs habilitadas:
+
+```powershell
+gcloud services enable firestore.googleapis.com `
+  cloudfunctions.googleapis.com `
+  run.googleapis.com `
+  eventarc.googleapis.com `
+  cloudtasks.googleapis.com `
+  transcoder.googleapis.com `
+  firebase.googleapis.com `
+  identitytoolkit.googleapis.com `
+  --project=entretenimento-staging
+```
+
+## Ordem obrigatória do primeiro deploy
+
+Não promover Angular antes dos contratos backend e índices.
+
+```text
+1. firestore:indexes
+2. Firestore Rules e Storage Rules
+3. Functions
+4. aplicação Angular de staging
+5. smoke test real
+```
+
+Exemplo:
+
+```powershell
+firebase deploy --only firestore:indexes `
+  --project entretenimento-staging
+
+# Aguarde os índices ficarem READY antes da próxima etapa.
+
+gcloud firestore indexes composite list `
+  --project=entretenimento-staging
+
+firebase deploy --only firestore:rules,storage `
+  --project entretenimento-staging
+
+npm run functions:prepare
+firebase deploy --only functions `
+  --project entretenimento-staging
+
+npm run build:staging
+firebase deploy --only hosting `
+  --project entretenimento-staging
+```
+
+Também habilitar as duas políticas TTL do campo `cleanupAfter`:
+
+```powershell
+gcloud firestore fields ttls update cleanupAfter `
+  --collection-group=media_video_processing_dispatches `
+  --enable-ttl `
+  --project=entretenimento-staging
+
+gcloud firestore fields ttls update cleanupAfter `
+  --collection-group=media_video_processing_dead_letters `
+  --enable-ttl `
+  --project=entretenimento-staging
+```
+
+## IAM do pipeline
+
+A identidade real das Functions precisa de:
+
+- criação de tasks na fila regional;
+- invocação da task function;
+- criação, consulta e cancelamento de jobs do Transcoder;
+- leitura dos originais privados;
+- escrita e exclusão dos derivados processados;
+- acesso aos documentos técnicos do Firestore.
+
+Papéis normalmente envolvidos:
+
+```text
+roles/cloudtasks.enqueuer
+roles/cloudfunctions.invoker
+roles/transcoder.admin
+```
+
+Não atribuir papéis ao endereço presumido de uma service account. Conferir a
+identidade efetivamente implantada nas Functions de segunda geração.
+
+## Identidade do workflow de smoke
+
+O workflow `.github/workflows/video-staging-smoke.yml` não faz deploy. Ele usa
+uma service account exclusiva para teste e limpeza.
+
+Permissões mínimas esperadas para essa identidade:
+
+- administrar usuários efêmeros do Firebase Auth;
+- ler e gravar documentos efêmeros de Firestore;
+- apagar objetos apenas do projeto de staging;
+- assinar custom tokens para os usuários efêmeros;
+- ler a configuração básica do projeto.
+
+Papéis a avaliar no projeto de staging:
+
+```text
+roles/firebaseauth.admin
+roles/datastore.user
+roles/storage.objectAdmin
+roles/iam.serviceAccountTokenCreator
+```
+
+`roles/iam.serviceAccountTokenCreator` deve ser concedido de forma restrita à
+própria service account usada no smoke, somente para permitir a assinatura dos
+custom tokens.
+
+A identidade do smoke não deve receber permissão de deploy.
+
+## GitHub Environment
+
+Criar um Environment chamado:
+
+```text
+video-staging
+```
+
+Configurar aprovação obrigatória antes da execução e restringir o workflow às
+branches autorizadas.
+
+### Secrets
+
+```text
+GCP_WORKLOAD_IDENTITY_PROVIDER
+GCP_VIDEO_STAGING_SERVICE_ACCOUNT
+FIREBASE_STAGING_API_KEY
+```
+
+### Variables
+
+```text
+FIREBASE_STAGING_PROJECT_ID=entretenimento-staging
+FIREBASE_STAGING_STORAGE_BUCKET=entretenimento-staging.appspot.com
+FIREBASE_STAGING_AUTH_DOMAIN=entretenimento-staging.firebaseapp.com
+FIREBASE_STAGING_APP_ID=<appId web do projeto de staging>
+```
+
+A autenticação usa Workload Identity Federation. Não armazenar arquivo JSON de
+service account no repositório nem como primeira opção de secret.
+
+## Auditoria estática
+
+Executar antes de qualquer chamada externa:
+
+```powershell
+npm run test:media:video:staging:readiness
+```
+
+A auditoria verifica:
+
+- Node 22;
+- isolamento entre staging e produção;
+- configuração Angular e bucket;
+- App Check não-placeholder;
+- exports do dispatcher, worker, diagnóstico e recuperação;
+- contrato MP4/M4V, MOV e WebM;
+- Storage Rules com reserva obrigatória;
+- registro definitivo com reserva;
+- TTL de despachos e DLQ;
+- índice da auditoria administrativa;
+- proteção contra credenciais temporárias do OIDC.
+
+O relatório é salvo em:
+
+```text
+artifacts/video-staging/readiness.json
+```
+
+## Execução pelo GitHub Actions
+
+Abra **Actions → Video Staging Smoke → Run workflow**.
+
+Preencha:
+
+```text
+confirm_project = entretenimento-staging
+formats        = mp4,webm,mov
+cleanup        = true
+```
+
+O workflow:
+
+1. executa a auditoria estática;
+2. gera vídeos sintéticos de seis segundos com FFmpeg;
+3. autentica no Google Cloud por OIDC;
+4. executa o pipeline real para cada formato;
+5. consulta `getVideoProcessingOperationalStatus` com claim administrativo;
+6. apaga usuários, documentos e objetos efêmeros;
+7. publica os relatórios como artifact por 30 dias.
+
+## Execução local
+
+É necessário possuir Application Default Credentials da service account de
+smoke e arquivos de vídeo válidos.
+
+Exemplo PowerShell:
+
+```powershell
+$env:VIDEO_STAGING_CONFIRM = "entretenimento-staging"
+$env:VIDEO_STAGING_PROJECT_ID = "entretenimento-staging"
+$env:VIDEO_STAGING_STORAGE_BUCKET = "entretenimento-staging.appspot.com"
+$env:VIDEO_STAGING_AUTH_DOMAIN = "entretenimento-staging.firebaseapp.com"
+$env:VIDEO_STAGING_API_KEY = "<api-key-web>"
+$env:VIDEO_STAGING_APP_ID = "<app-id-web>"
+$env:VIDEO_STAGING_FUNCTIONS_REGION = "us-central1"
+$env:VIDEO_STAGING_FORMATS = "mp4,webm,mov"
+$env:VIDEO_STAGING_MP4_PATH = "C:\temp\video-smoke.mp4"
+$env:VIDEO_STAGING_WEBM_PATH = "C:\temp\video-smoke.webm"
+$env:VIDEO_STAGING_MOV_PATH = "C:\temp\video-smoke.mov"
+$env:VIDEO_STAGING_POSTER_PATH = "C:\temp\poster.jpg"
+$env:VIDEO_STAGING_DURATION_MS = "6000"
+$env:VIDEO_STAGING_CLEANUP = "true"
+
+npm run test:media:video:staging:smoke
+```
+
+Não definir `VIDEO_STAGING_CLEANUP=false` em execução normal. Para preservar um
+incidente, use temporariamente:
+
+```text
+VIDEO_STAGING_KEEP_ON_FAILURE=true
+```
+
+Depois da análise, remova manualmente o usuário, documentos e prefixo de Storage
+indicados no relatório.
+
+## Critérios de aprovação
+
+Cada formato precisa comprovar:
+
+- reserva `ACTIVE` antes do upload;
+- upload autorizado pelas Storage Rules;
+- reserva `CONSUMED` após o registro;
+- job criado em `media_video_processing_jobs`;
+- pelo menos um despacho técnico;
+- job terminal `SUCCEEDED`;
+- derivado em `users/{uid}/processed/videos/{videoId}/...`;
+- MIME final `video/mp4` ou `video/webm`;
+- publicação automática criada;
+- moderação `PENDING_REVIEW` ou `APPROVED`;
+- despacho `COMPLETED`;
+- ausência do job bem-sucedido na DLQ;
+- provider `READY` no painel operacional;
+- limpeza dos recursos efêmeros.
+
+Falha em qualquer item reprova o lote. Não converter falhas em warnings apenas
+para liberar merge.
+
+## O que o smoke não simula automaticamente
+
+Continuam exigindo cenários controlados separados:
+
+- indisponibilidade proposital do Transcoder;
+- esgotamento das cinco tentativas do Cloud Tasks;
+- criação deliberada de DLQ;
+- cancelamento durante um job externo ativo;
+- evento duplicado e atrasado injetado manualmente;
+- falha de limpeza do prefixo processado;
+- reprodução visual em Safari/iOS, Firefox, Chrome e Edge;
+- audiência, bloqueios, idade e compatibilidade entre perfis.
+
+Não adicionar fault injection de produção sem flag exclusiva de staging,
+auditoria e garantia de que a configuração não pode ser habilitada em produção.
+
+## Preparação da pilha de PRs
+
+A cadeia funcional é:
+
+```text
+#68 publicação automática
+  -> #69 ciclo de vida
+  -> #70 reserva de quota + contrato de formatos
+  -> #71 Cloud Tasks
+  -> #72 painel operacional
+  -> PR de homologação
+```
+
+O conteúdo funcional do #67 foi absorvido pelo #70:
+
+- política Angular de formatos;
+- testes da política;
+- restrição de MIME no backend;
+- restrição correspondente nas Storage Rules.
+
+Não fazer cherry-pick cego do #67 sobre o topo da pilha. Depois de confirmar o
+diff final, ele pode ser encerrado como substituído pelo #70.
+
+Ordem de integração sugerida:
+
+1. integrar #68 em `main`;
+2. redirecionar #69 para `main` e validar novamente;
+3. integrar #69;
+4. redirecionar #70 para `main` e validar novamente;
+5. encerrar #67 como substituído pelo #70;
+6. integrar #70;
+7. repetir o processo com #71, #72 e o PR de homologação.
+
+Não integrar toda a pilha por merge commits fora de ordem. Cada redirecionamento
+precisa executar novamente o Quality Gate contra a base efetiva.
+
+## Rollback
+
+Se o smoke falhar após deploy:
+
+1. interromper novos testes;
+2. registrar o run ID e preservar o artifact;
+3. verificar painel, dispatch, job e DLQ;
+4. não editar manualmente `state`, `leaseUntil`, `processingVersion` ou
+   `externalJobName`;
+5. usar somente as ações administrativas idempotentes já implementadas;
+6. reverter Functions/Rules/Angular para a versão anterior compatível;
+7. manter os índices e TTL, pois são aditivos e não expõem dados ao cliente.

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "test:rules:rooms": "npm run test:rules",
     "test:media:e2e": "npm run rules:build && npm run rules:check && npm run functions:build && firebase emulators:exec --config firebase.media-e2e.json --only auth,firestore,storage,functions --project demo-entretenimento-media-e2e \"node scripts/tests/photo-publication.e2e.mjs\"",
     "test:media:video:e2e": "npm run rules:build && npm run rules:check && npm run functions:build && node scripts/tests/run-video-publication-e2e.mjs",
+    "test:media:video:staging:readiness": "node scripts/tests/video-staging-readiness.mjs",
+    "test:media:video:staging:smoke": "npm run test:media:video:staging:readiness && node scripts/tests/video-staging-smoke.mjs",
     "test:compliance:age:e2e": "npm run rules:build && npm run rules:check && npm run functions:build && node scripts/tests/run-profile-age-reverification-e2e.mjs",
     "seed:hot-places:emu": "set FIRESTORE_EMULATOR_HOST=127.0.0.1:8080&& set FIREBASE_PROJECT_ID=entretenimento-sexual&& node scripts/dev/seed-regional-hot-places.mjs",
     "seed:venues:emu": "set FIRESTORE_EMULATOR_HOST=127.0.0.1:8080&& set FIREBASE_PROJECT_ID=entretenimento-sexual&& node scripts/dev/seed-venues.mjs",

--- a/scripts/tests/video-staging-readiness.mjs
+++ b/scripts/tests/video-staging-readiness.mjs
@@ -253,20 +253,40 @@ function run() {
     'Storage Rules ainda permitem formato amplo, overwrite/delete ou upload sem reserva.'
   );
 
-  const registerHandler = readText(
-    'functions/src/media/application/register-private-video-upload.handler.ts'
+  const reservationHandler = readText(
+    'functions/src/media/application/private-video-upload-reservation.handler.ts'
   );
+  const registerOrchestrator = readText(
+    'functions/src/media/application/register-private-video-upload-orchestrator.handler.ts'
+  );
+  const effectiveRegistrationExport = includesAll(mediaIndex, [
+    'registerPrivateVideoUpload,',
+    "from './application/register-private-video-upload-orchestrator.handler';",
+  ]);
+  const reservationMimeBoundary = includesAll(reservationHandler, [
+    "'video/mp4'",
+    "'video/webm'",
+    "'video/quicktime'",
+    'ALLOWED_VIDEO_TYPES.has(mimeType)',
+  ]) &&
+    !reservationHandler.includes("'video/x-matroska'") &&
+    !reservationHandler.includes("'video/x-msvideo'") &&
+    !reservationHandler.includes("'application/mxf'");
+  const registrationReservationBoundary = includesAll(registerOrchestrator, [
+    'reservationId?: string;',
+    'assertPrivateVideoUploadReservation',
+    'consumePrivateVideoUploadReservationAfterRegistration',
+    'publishWhenReady: true',
+    "from './register-private-video-upload.handler';",
+  ]);
+
   check(
-    includesAll(registerHandler, [
-      "'video/mp4'",
-      "'video/webm'",
-      "'video/quicktime'",
-      'reservationId',
-    ]) &&
-      !registerHandler.includes("'video/x-matroska'"),
+    effectiveRegistrationExport &&
+      reservationMimeBoundary &&
+      registrationReservationBoundary,
     'REGISTER_CONTRACT',
-    'Registro definitivo exige reserva e MIME compatível.',
-    'A callable de registro não está alinhada a reserva e formatos processáveis.'
+    'Callable exportada exige reserva e o boundary externo aceita somente MP4, WebM e MOV.',
+    'A callable efetiva, a reserva ou o export público divergem do contrato de registro.'
   );
 
   const indexesJson = readJson('firestore.indexes.json');
@@ -312,14 +332,18 @@ function run() {
     includesAll(smokeScript, [
       "assert.notEqual(\n    projectId,\n    'entretenimento-sexual'",
       'VIDEO_STAGING_CONFIRM',
+      'CustomProvider',
+      'initializeAppCheck',
+      'getAdminAppCheck',
+      'adminAppCheck.createToken',
       'getVideoProcessingOperationalStatus',
       'validateOperationalPanel(observer, report)',
       'cleanupOwnerResources',
       "result.dispatchStates.includes('COMPLETED')",
     ]),
     'SMOKE_SAFETY_CONTRACT',
-    'Smoke protege produção, valida o painel antes da limpeza e exige despacho concluído.',
-    'As proteções ou os critérios essenciais do smoke foram removidos.'
+    'Smoke protege produção, usa App Check, valida o painel antes da limpeza e exige despacho concluído.',
+    'As proteções, o App Check ou os critérios essenciais do smoke foram removidos.'
   );
 
   const workflow = readText('.github/workflows/video-staging-smoke.yml');

--- a/scripts/tests/video-staging-readiness.mjs
+++ b/scripts/tests/video-staging-readiness.mjs
@@ -1,0 +1,323 @@
+// scripts/tests/video-staging-readiness.mjs
+// -----------------------------------------------------------------------------
+// Auditoria estática e segura do ambiente de homologação do pipeline de vídeos.
+// Não acessa Google Cloud, Firebase ou dados de usuários.
+// -----------------------------------------------------------------------------
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ROOT = process.cwd();
+const REPORT_DIRECTORY = path.resolve(
+  process.env.VIDEO_STAGING_REPORT_DIR || 'artifacts/video-staging'
+);
+const REPORT_PATH = path.join(REPORT_DIRECTORY, 'readiness.json');
+
+const results = [];
+
+function readText(relativePath) {
+  return fs.readFileSync(path.join(ROOT, relativePath), 'utf8');
+}
+
+function readJson(relativePath) {
+  return JSON.parse(readText(relativePath));
+}
+
+function record(status, code, message, details = null) {
+  results.push({ status, code, message, details });
+
+  const marker = status === 'PASS' ? '✔' : status === 'WARN' ? '⚠' : '✖';
+  console.log(`${marker} [${code}] ${message}`);
+
+  if (details) {
+    console.log(`  ${typeof details === 'string' ? details : JSON.stringify(details)}`);
+  }
+}
+
+function check(condition, code, successMessage, failureMessage, details = null) {
+  record(
+    condition ? 'PASS' : 'FAIL',
+    code,
+    condition ? successMessage : failureMessage,
+    details
+  );
+}
+
+function warn(condition, code, successMessage, warningMessage, details = null) {
+  record(
+    condition ? 'PASS' : 'WARN',
+    code,
+    condition ? successMessage : warningMessage,
+    details
+  );
+}
+
+function includesAll(text, values) {
+  return values.every((value) => text.includes(value));
+}
+
+function extractQuotedValue(text, property) {
+  const pattern = new RegExp(`${property}\\s*:\\s*['\"]([^'\"]+)['\"]`);
+  return text.match(pattern)?.[1] ?? '';
+}
+
+function hasCompositeIndex(indexes, collectionGroup, orderedFields) {
+  return indexes.some((index) => {
+    if (
+      index.collectionGroup !== collectionGroup ||
+      !Array.isArray(index.fields) ||
+      index.fields.length !== orderedFields.length
+    ) {
+      return false;
+    }
+
+    return orderedFields.every((expected, position) => {
+      const field = index.fields[position] ?? {};
+      return field.fieldPath === expected.fieldPath &&
+        field.order === expected.order;
+    });
+  });
+}
+
+function hasTtlOverride(fieldOverrides, collectionGroup) {
+  return fieldOverrides.some((override) =>
+    override.collectionGroup === collectionGroup &&
+    override.fieldPath === 'cleanupAfter' &&
+    override.ttl === true &&
+    Array.isArray(override.indexes) &&
+    override.indexes.length === 0
+  );
+}
+
+function run() {
+  console.log('[video:staging:readiness] Iniciando auditoria estática.');
+
+  const nodeMajor = Number.parseInt(process.versions.node.split('.')[0], 10);
+  check(
+    nodeMajor === 22,
+    'NODE_RUNTIME',
+    'Node 22 está ativo.',
+    `Node 22 é obrigatório; runtime atual: ${process.versions.node}.`
+  );
+
+  const firebaseRc = readJson('.firebaserc');
+  const defaultProject = String(firebaseRc.projects?.default ?? '').trim();
+  const stagingProject = String(firebaseRc.projects?.staging ?? '').trim();
+
+  check(
+    !!stagingProject && stagingProject.toLowerCase().includes('staging'),
+    'STAGING_ALIAS',
+    `Alias staging aponta para ${stagingProject}.`,
+    'O alias staging está ausente ou não identifica um projeto de homologação.'
+  );
+  check(
+    !!defaultProject && stagingProject !== defaultProject,
+    'PROJECT_ISOLATION',
+    'Staging e produção usam projetos distintos.',
+    'Staging não pode apontar para o mesmo projeto padrão/produção.',
+    { defaultProject, stagingProject }
+  );
+
+  const stagingEnvironment = readText('src/environments/environment.staging.ts');
+  const environmentProject = extractQuotedValue(stagingEnvironment, 'projectId');
+  const environmentBucket = extractQuotedValue(stagingEnvironment, 'storageBucket');
+  const appCheckSiteKey = extractQuotedValue(stagingEnvironment, 'siteKey');
+  const apiEndpoint = extractQuotedValue(stagingEnvironment, 'apiEndpoint');
+
+  check(
+    environmentProject === stagingProject,
+    'ANGULAR_PROJECT',
+    'Configuração Angular usa o projeto de staging.',
+    'O projectId do environment.staging.ts diverge do alias staging.',
+    { environmentProject, stagingProject }
+  );
+  check(
+    environmentBucket.startsWith(`${stagingProject}.`) &&
+      environmentBucket.endsWith('.appspot.com'),
+    'STAGING_BUCKET',
+    `Bucket de staging configurado: ${environmentBucket}.`,
+    'O bucket de staging não pertence ao projeto esperado ou não usa appspot.com.'
+  );
+  check(
+    !!appCheckSiteKey &&
+      !appCheckSiteKey.includes('staging-recaptcha-v3-site-key') &&
+      !appCheckSiteKey.toLowerCase().includes('placeholder'),
+    'APPCHECK_SITE_KEY',
+    'App Check de staging possui site key não-placeholder.',
+    'App Check de staging ainda usa uma site key placeholder. Homologação real deve permanecer bloqueada.'
+  );
+  warn(
+    !!apiEndpoint && !apiEndpoint.includes('seuprojeto.com'),
+    'STAGING_API_ENDPOINT',
+    'Endpoint auxiliar de staging não é placeholder.',
+    'O apiEndpoint de staging ainda é placeholder; não bloqueia este smoke de Firebase, mas bloqueia homologação integral do aplicativo.'
+  );
+
+  const packageJson = readJson('package.json');
+  check(
+    packageJson.scripts?.['test:media:video:staging:readiness'] ===
+      'node scripts/tests/video-staging-readiness.mjs',
+    'READINESS_SCRIPT',
+    'Comando de auditoria de staging está registrado.',
+    'package.json não expõe o comando de auditoria de staging.'
+  );
+  check(
+    packageJson.scripts?.['test:media:video:staging:smoke'] ===
+      'npm run test:media:video:staging:readiness && node scripts/tests/video-staging-smoke.mjs',
+    'SMOKE_SCRIPT',
+    'Comando de smoke real está registrado.',
+    'package.json não expõe o smoke test real de staging.'
+  );
+
+  const functionsRegion = readText('functions/src/config/functions-region.ts');
+  check(
+    functionsRegion.includes("FUNCTIONS_REGION = 'us-central1'"),
+    'FUNCTIONS_REGION',
+    'Região canônica das Functions é us-central1.',
+    'A região canônica das Functions não é us-central1; revise o smoke e o IAM.'
+  );
+
+  const mediaIndex = readText('functions/src/media/index.ts');
+  check(
+    includesAll(mediaIndex, [
+      'dispatchVideoProcessingOnJobWrite',
+      'processVideoProcessingTask',
+      'getVideoProcessingOperationalStatus',
+      'listVideoProcessingRecoveryJobs',
+      'recoverVideoProcessingJob',
+    ]),
+    'FUNCTION_EXPORTS',
+    'Dispatcher, worker, diagnóstico e recuperação estão exportados.',
+    'Um ou mais exports obrigatórios do pipeline não foram encontrados.'
+  );
+
+  const formatPolicy = readText(
+    'src/app/core/services/media/video-upload-format.policy.ts'
+  );
+  check(
+    includesAll(formatPolicy, [
+      "mimeType: 'video/mp4'",
+      "mimeType: 'video/quicktime'",
+      "mimeType: 'video/webm'",
+      "VIDEO_UPLOAD_FORMAT_LABEL = 'MP4, M4V, MOV ou WebM'",
+    ]) &&
+      !includesAll(formatPolicy, ["extension: 'mkv'"]) &&
+      !formatPolicy.includes("extension: 'avi'"),
+    'FORMAT_CONTRACT',
+    'Contrato Angular anuncia somente MP4/M4V, MOV e WebM.',
+    'O contrato Angular de formatos diverge do pipeline processável.'
+  );
+
+  const storageRules = readText('storage.rules');
+  check(
+    includesAll(storageRules, [
+      "request.resource.contentType == 'video/mp4'",
+      "request.resource.contentType == 'video/webm'",
+      "request.resource.contentType == 'video/quicktime'",
+      'reservedVideoUpload(',
+      'allow update, delete: if false;',
+    ]) &&
+      !storageRules.includes("request.resource.contentType.matches('video/.*')"),
+    'STORAGE_RULES',
+    'Storage Rules exigem reserva e MIME processável.',
+    'Storage Rules ainda permitem formato amplo, overwrite/delete ou upload sem reserva.'
+  );
+
+  const registerHandler = readText(
+    'functions/src/media/application/register-private-video-upload.handler.ts'
+  );
+  check(
+    includesAll(registerHandler, [
+      "'video/mp4'",
+      "'video/webm'",
+      "'video/quicktime'",
+      'reservationId',
+    ]) &&
+      !registerHandler.includes("'video/x-matroska'"),
+    'REGISTER_CONTRACT',
+    'Registro definitivo exige reserva e MIME compatível.',
+    'A callable de registro não está alinhada a reserva e formatos processáveis.'
+  );
+
+  const indexesJson = readJson('firestore.indexes.json');
+  const indexes = Array.isArray(indexesJson.indexes) ? indexesJson.indexes : [];
+  const fieldOverrides = Array.isArray(indexesJson.fieldOverrides)
+    ? indexesJson.fieldOverrides
+    : [];
+
+  check(
+    hasTtlOverride(fieldOverrides, 'media_video_processing_dispatches') &&
+      hasTtlOverride(fieldOverrides, 'media_video_processing_dead_letters'),
+    'FIRESTORE_TTL_SCHEMA',
+    'TTL de despachos e DLQ está versionado com indexação desabilitada.',
+    'As duas políticas TTL cleanupAfter não estão integralmente versionadas.'
+  );
+  check(
+    hasCompositeIndex(indexes, 'admin_logs', [
+      { fieldPath: 'action', order: 'ASCENDING' },
+      { fieldPath: 'timestamp', order: 'DESCENDING' },
+      { fieldPath: '__name__', order: 'DESCENDING' },
+    ]),
+    'ADMIN_AUDIT_INDEX',
+    'Índice da timeline administrativa está versionado.',
+    'O índice composto de admin_logs necessário ao painel não foi encontrado.'
+  );
+
+  const runbook = readText('docs/video-processing-runbook.md');
+  check(
+    includesAll(runbook, [
+      'cloudtasks.googleapis.com',
+      'roles/cloudtasks.enqueuer',
+      'roles/cloudfunctions.invoker',
+      'cleanupAfter',
+      'processVideoProcessingTask',
+    ]),
+    'OPERATIONS_RUNBOOK',
+    'Runbook contém APIs, IAM, TTL e worker.',
+    'O runbook operacional está incompleto para homologação.'
+  );
+
+  const gitignore = readText('.gitignore');
+  check(
+    gitignore.includes('gha-creds-*.json'),
+    'OIDC_CREDENTIAL_IGNORE',
+    'Credenciais temporárias do auth action estão ignoradas.',
+    'Adicione gha-creds-*.json ao .gitignore antes de autenticar por OIDC.'
+  );
+
+  const summary = {
+    generatedAt: new Date().toISOString(),
+    project: {
+      defaultProject,
+      stagingProject,
+      environmentProject,
+      environmentBucket,
+    },
+    totals: {
+      pass: results.filter((item) => item.status === 'PASS').length,
+      warn: results.filter((item) => item.status === 'WARN').length,
+      fail: results.filter((item) => item.status === 'FAIL').length,
+    },
+    results,
+  };
+
+  fs.mkdirSync(REPORT_DIRECTORY, { recursive: true });
+  fs.writeFileSync(REPORT_PATH, `${JSON.stringify(summary, null, 2)}\n`);
+
+  console.log(`[video:staging:readiness] Relatório: ${REPORT_PATH}`);
+  console.log(
+    `[video:staging:readiness] PASS=${summary.totals.pass} ` +
+      `WARN=${summary.totals.warn} FAIL=${summary.totals.fail}`
+  );
+
+  if (summary.totals.fail > 0) {
+    process.exitCode = 1;
+  }
+}
+
+try {
+  run();
+} catch (error) {
+  console.error('[video:staging:readiness] Falha inesperada.', error);
+  process.exitCode = 1;
+}

--- a/scripts/tests/video-staging-readiness.mjs
+++ b/scripts/tests/video-staging-readiness.mjs
@@ -2,12 +2,18 @@
 // -----------------------------------------------------------------------------
 // Auditoria estática e segura do ambiente de homologação do pipeline de vídeos.
 // Não acessa Google Cloud, Firebase ou dados de usuários.
+//
+// Modos:
+// - padrão: prontidão de deploy, placeholders bloqueiam a execução real;
+// - --contract: valida o contrato do repositório e converte pendências externas
+//   conhecidas em warnings para permitir execução automática em pull requests.
 // -----------------------------------------------------------------------------
 
 import fs from 'node:fs';
 import path from 'node:path';
 
 const ROOT = process.cwd();
+const CONTRACT_ONLY = process.argv.includes('--contract');
 const REPORT_DIRECTORY = path.resolve(
   process.env.VIDEO_STAGING_REPORT_DIR || 'artifacts/video-staging'
 );
@@ -30,7 +36,9 @@ function record(status, code, message, details = null) {
   console.log(`${marker} [${code}] ${message}`);
 
   if (details) {
-    console.log(`  ${typeof details === 'string' ? details : JSON.stringify(details)}`);
+    console.log(
+      `  ${typeof details === 'string' ? details : JSON.stringify(details)}`
+    );
   }
 }
 
@@ -50,6 +58,21 @@ function warn(condition, code, successMessage, warningMessage, details = null) {
     condition ? successMessage : warningMessage,
     details
   );
+}
+
+function deployCheck(
+  condition,
+  code,
+  successMessage,
+  failureMessage,
+  details = null
+) {
+  if (CONTRACT_ONLY) {
+    warn(condition, code, successMessage, failureMessage, details);
+    return;
+  }
+
+  check(condition, code, successMessage, failureMessage, details);
 }
 
 function includesAll(text, values) {
@@ -90,7 +113,10 @@ function hasTtlOverride(fieldOverrides, collectionGroup) {
 }
 
 function run() {
-  console.log('[video:staging:readiness] Iniciando auditoria estática.');
+  const mode = CONTRACT_ONLY ? 'contract' : 'deploy-readiness';
+  console.log(
+    `[video:staging:readiness] Iniciando auditoria estática (${mode}).`
+  );
 
   const nodeMajor = Number.parseInt(process.versions.node.split('.')[0], 10);
   check(
@@ -138,19 +164,23 @@ function run() {
     `Bucket de staging configurado: ${environmentBucket}.`,
     'O bucket de staging não pertence ao projeto esperado ou não usa appspot.com.'
   );
-  check(
-    !!appCheckSiteKey &&
-      !appCheckSiteKey.includes('staging-recaptcha-v3-site-key') &&
-      !appCheckSiteKey.toLowerCase().includes('placeholder'),
+
+  const hasRealAppCheckSiteKey = !!appCheckSiteKey &&
+    !appCheckSiteKey.includes('staging-recaptcha-v3-site-key') &&
+    !appCheckSiteKey.toLowerCase().includes('placeholder');
+  deployCheck(
+    hasRealAppCheckSiteKey,
     'APPCHECK_SITE_KEY',
     'App Check de staging possui site key não-placeholder.',
-    'App Check de staging ainda usa uma site key placeholder. Homologação real deve permanecer bloqueada.'
+    CONTRACT_ONLY
+      ? 'App Check continua placeholder; contrato válido, mas o smoke real permanece bloqueado.'
+      : 'App Check de staging ainda usa uma site key placeholder. Homologação real deve permanecer bloqueada.'
   );
   warn(
     !!apiEndpoint && !apiEndpoint.includes('seuprojeto.com'),
     'STAGING_API_ENDPOINT',
     'Endpoint auxiliar de staging não é placeholder.',
-    'O apiEndpoint de staging ainda é placeholder; não bloqueia este smoke de Firebase, mas bloqueia homologação integral do aplicativo.'
+    'O apiEndpoint de staging ainda é placeholder; não bloqueia o smoke de Firebase, mas bloqueia homologação integral do aplicativo.'
   );
 
   const packageJson = readJson('package.json');
@@ -201,7 +231,7 @@ function run() {
       "mimeType: 'video/webm'",
       "VIDEO_UPLOAD_FORMAT_LABEL = 'MP4, M4V, MOV ou WebM'",
     ]) &&
-      !includesAll(formatPolicy, ["extension: 'mkv'"]) &&
+      !formatPolicy.includes("extension: 'mkv'") &&
       !formatPolicy.includes("extension: 'avi'"),
     'FORMAT_CONTRACT',
     'Contrato Angular anuncia somente MP4/M4V, MOV e WebM.',
@@ -277,16 +307,52 @@ function run() {
     'O runbook operacional está incompleto para homologação.'
   );
 
+  const smokeScript = readText('scripts/tests/video-staging-smoke.mjs');
+  check(
+    includesAll(smokeScript, [
+      "assert.notEqual(\n    projectId,\n    'entretenimento-sexual'",
+      'VIDEO_STAGING_CONFIRM',
+      'getVideoProcessingOperationalStatus',
+      'validateOperationalPanel(observer, report)',
+      'cleanupOwnerResources',
+      "result.dispatchStates.includes('COMPLETED')",
+    ]),
+    'SMOKE_SAFETY_CONTRACT',
+    'Smoke protege produção, valida o painel antes da limpeza e exige despacho concluído.',
+    'As proteções ou os critérios essenciais do smoke foram removidos.'
+  );
+
+  const workflow = readText('.github/workflows/video-staging-smoke.yml');
+  check(
+    includesAll(workflow, [
+      'workflow_dispatch:',
+      'environment: video-staging',
+      'id-token: write',
+      'google-github-actions/auth@v3',
+      'confirm_project:',
+      'VIDEO_STAGING_CONFIRM: ${{ inputs.confirm_project }}',
+      'actions/upload-artifact@v7',
+    ]) &&
+      !workflow.includes('on:\n  push:') &&
+      !workflow.includes('on:\n  pull_request:'),
+    'MANUAL_WORKFLOW_CONTRACT',
+    'Workflow real é manual, protegido por environment e autenticado via OIDC.',
+    'O workflow real perdeu proteção manual, environment ou autenticação OIDC.'
+  );
+
   const gitignore = readText('.gitignore');
   check(
-    gitignore.includes('gha-creds-*.json'),
-    'OIDC_CREDENTIAL_IGNORE',
-    'Credenciais temporárias do auth action estão ignoradas.',
-    'Adicione gha-creds-*.json ao .gitignore antes de autenticar por OIDC.'
+    gitignore.includes('gha-creds-*.json') &&
+      gitignore.includes('/artifacts/video-staging/'),
+    'TEMPORARY_ARTIFACT_IGNORE',
+    'Credenciais OIDC e relatórios locais estão ignorados.',
+    'Credenciais temporárias ou relatórios locais podem entrar no repositório.'
   );
 
   const summary = {
     generatedAt: new Date().toISOString(),
+    mode,
+    deploymentReady: results.every((item) => item.status === 'PASS'),
     project: {
       defaultProject,
       stagingProject,

--- a/scripts/tests/video-staging-smoke.mjs
+++ b/scripts/tests/video-staging-smoke.mjs
@@ -5,7 +5,8 @@
 // Proteções:
 // - exige confirmação explícita do projectId;
 // - rejeita projeto sem a palavra staging;
-// - usa usuários e mídias efêmeros;
+// - usa um usuário efêmero por formato;
+// - valida o painel antes de remover a telemetria do teste;
 // - limpa Auth, Firestore e Storage ao final;
 // - não imprime credenciais, tokens nem URLs assinadas.
 // -----------------------------------------------------------------------------
@@ -45,7 +46,6 @@ const JOB_COLLECTION = 'media_video_processing_jobs';
 const RESERVATION_COLLECTION = 'media_private_video_upload_reservations';
 const CAPACITY_COLLECTION = 'media_private_video_upload_capacity';
 const TERMINAL_JOB_STATES = new Set(['SUCCEEDED', 'FAILED', 'CANCELLED']);
-const SUCCESS_JOB_STATE = 'SUCCEEDED';
 const DEFAULT_TIMEOUT_MS = 20 * 60 * 1000;
 const DEFAULT_INTERVAL_MS = 5_000;
 const REPORT_DIRECTORY = path.resolve(
@@ -105,10 +105,8 @@ function delay(milliseconds) {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
-async function waitFor(label, readValue, predicate, options = {}) {
-  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  const intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
-  const deadline = Date.now() + timeoutMs;
+async function waitFor(label, readValue, predicate, options) {
+  const deadline = Date.now() + options.timeoutMs;
   let lastValue = null;
 
   while (Date.now() < deadline) {
@@ -118,7 +116,7 @@ async function waitFor(label, readValue, predicate, options = {}) {
       return lastValue;
     }
 
-    await delay(intervalMs);
+    await delay(options.intervalMs);
   }
 
   throw new Error(
@@ -148,30 +146,20 @@ function parseFormats() {
     throw new Error('VIDEO_STAGING_FORMATS não contém formatos válidos.');
   }
 
-  return unique.map((format) => {
-    const configuration = FORMAT_CONFIG[format];
+  return unique.map((name) => {
+    const format = FORMAT_CONFIG[name];
 
-    if (!configuration) {
-      throw new Error(
-        `Formato desconhecido em VIDEO_STAGING_FORMATS: ${format}.`
-      );
+    if (!format) {
+      throw new Error(`Formato desconhecido: ${name}.`);
     }
 
-    const filePath = path.resolve(
-      requiredEnvironment(configuration.environmentVariable)
-    );
+    const filePath = path.resolve(requiredEnvironment(format.environmentVariable));
 
     if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile()) {
-      throw new Error(
-        `${configuration.environmentVariable} não aponta para um arquivo.`
-      );
+      throw new Error(`${format.environmentVariable} não aponta para um arquivo.`);
     }
 
-    return {
-      name: format,
-      filePath,
-      ...configuration,
-    };
+    return { name, filePath, ...format };
   });
 }
 
@@ -197,7 +185,7 @@ function buildConfiguration() {
   assert.match(
     projectId.toLowerCase(),
     /staging/,
-    'Este script aceita somente projetos explicitamente identificados como staging.'
+    'Este script aceita somente projetos identificados como staging.'
   );
   assert.notEqual(
     projectId,
@@ -207,7 +195,7 @@ function buildConfiguration() {
   assert.equal(
     storageBucket.startsWith(`${projectId}.`),
     true,
-    'O bucket deve pertencer ao projeto de staging confirmado.'
+    'O bucket deve pertencer ao projeto confirmado.'
   );
   assert.equal(
     fs.existsSync(posterPath) && fs.statSync(posterPath).isFile(),
@@ -229,10 +217,7 @@ function buildConfiguration() {
       'VIDEO_STAGING_FUNCTIONS_REGION',
       'us-central1'
     ),
-    durationMs: positiveIntegerEnvironment(
-      'VIDEO_STAGING_DURATION_MS',
-      6_000
-    ),
+    durationMs: positiveIntegerEnvironment('VIDEO_STAGING_DURATION_MS', 6_000),
     timeoutMs: positiveIntegerEnvironment(
       'VIDEO_STAGING_TIMEOUT_MS',
       DEFAULT_TIMEOUT_MS
@@ -279,9 +264,9 @@ async function createAuthenticatedClient({
     email,
     clientApp,
     clientAuth,
-    user: credential.user,
     functions: getFunctions(clientApp, functionsRegion),
     storage: getClientStorage(clientApp),
+    user: credential.user,
   };
 }
 
@@ -294,37 +279,43 @@ async function closeClient(client) {
   await deleteClientApp(client.clientApp).catch(() => undefined);
 }
 
-async function cleanupOwnerResources({ db, bucket, adminAuth, ownerUid, jobIds }) {
+async function cleanupOwnerResources({ db, bucket, adminAuth, resource }) {
   const deleted = {
     storageObjects: 0,
     dispatches: 0,
     deadLetters: 0,
     reservations: 0,
+    jobDeleted: false,
+    authUserDeleted: false,
   };
 
-  const [files] = await bucket.getFiles({ prefix: `users/${ownerUid}/` });
+  const [files] = await bucket.getFiles({ prefix: `users/${resource.ownerUid}/` });
   await Promise.all(files.map((file) => file.delete({ ignoreNotFound: true })));
   deleted.storageObjects = files.length;
 
-  for (const jobId of jobIds) {
-    deleted.dispatches += await deleteQuery(
-      db.collection(DISPATCH_COLLECTION).where('jobId', '==', jobId)
-    );
-    deleted.deadLetters += await deleteQuery(
-      db.collection(DEAD_LETTER_COLLECTION).where('jobId', '==', jobId)
-    );
-    await db.collection(JOB_COLLECTION).doc(jobId).delete().catch(() => undefined);
-  }
-
-  deleted.reservations += await deleteQuery(
-    db.collection(RESERVATION_COLLECTION).where('ownerUid', '==', ownerUid)
+  deleted.dispatches = await deleteQuery(
+    db.collection(DISPATCH_COLLECTION).where('jobId', '==', resource.jobId)
   );
-  await db.collection(CAPACITY_COLLECTION).doc(ownerUid).delete()
-    .catch(() => undefined);
-  await db.recursiveDelete(db.doc(`users/${ownerUid}`)).catch(() => undefined);
-  await db.recursiveDelete(db.doc(`public_profiles/${ownerUid}`))
-    .catch(() => undefined);
-  await adminAuth.deleteUser(ownerUid).catch(() => undefined);
+  deleted.deadLetters = await deleteQuery(
+    db.collection(DEAD_LETTER_COLLECTION).where('jobId', '==', resource.jobId)
+  );
+  await db.collection(JOB_COLLECTION).doc(resource.jobId).delete();
+  deleted.jobDeleted = true;
+
+  deleted.reservations = await deleteQuery(
+    db.collection(RESERVATION_COLLECTION)
+      .where('ownerUid', '==', resource.ownerUid)
+  );
+  await db.collection(CAPACITY_COLLECTION).doc(resource.ownerUid).delete()
+    .catch((error) => {
+      if (error?.code !== 5) {
+        throw error;
+      }
+    });
+  await db.recursiveDelete(db.doc(`users/${resource.ownerUid}`));
+  await db.recursiveDelete(db.doc(`public_profiles/${resource.ownerUid}`));
+  await adminAuth.deleteUser(resource.ownerUid);
+  deleted.authUserDeleted = true;
 
   return deleted;
 }
@@ -334,9 +325,8 @@ async function runFormat({
   configuration,
   adminAuth,
   db,
-  bucket,
   firebaseConfig,
-  report,
+  resources,
 }) {
   const formatRunId = `${format.name}-${randomUUID()}`;
   const startedAt = Date.now();
@@ -356,6 +346,7 @@ async function runFormat({
     `users/${ownerUid}/uploads/videos/${videoId}.${format.extension}`;
   const posterPath =
     `users/${ownerUid}/uploads/video-posters/${videoId}/poster.jpg`;
+  const resource = { ownerUid, videoId, jobId, format: format.name };
   const result = {
     format: format.name,
     mimeType: format.mimeType,
@@ -367,15 +358,13 @@ async function runFormat({
     terminalState: null,
     moderationStatus: null,
     dispatchStates: [],
+    cleanup: null,
   };
-  let failed = false;
+
+  resources.push({ ...resource, result });
 
   const step = (name, details = null) => {
-    result.steps.push({
-      name,
-      at: new Date().toISOString(),
-      details,
-    });
+    result.steps.push({ name, at: new Date().toISOString(), details });
     console.log(`✔ [${format.name}] ${name}`);
   };
 
@@ -406,7 +395,7 @@ async function runFormat({
       stagingSmoke: true,
       updatedAt: Date.now(),
     }, { merge: true });
-    step('Conta efêmera elegível e perfil público criados.');
+    step('Conta elegível e perfil público efêmeros criados.');
 
     const reservePrivateVideoUpload = httpsCallable(
       client.functions,
@@ -428,6 +417,7 @@ async function runFormat({
     assert.equal(reservation?.ownerUid, ownerUid);
     assert.equal(reservation?.videoId, videoId);
     assert.ok(Number(reservation?.expiresAt ?? 0) > Date.now());
+    result.reservationId = reservationId;
     step('Quota reservada antes da transferência.', {
       reservationId,
       reservedBytes: Number(reservation?.reservedBytes ?? 0),
@@ -435,10 +425,7 @@ async function runFormat({
 
     const uploadMetadata = {
       cacheControl: 'private, max-age=0, no-store, no-transform',
-      customMetadata: {
-        videoReservationId: reservationId,
-        videoId,
-      },
+      customMetadata: { videoReservationId: reservationId, videoId },
     };
     await uploadBytes(ref(client.storage, sourcePath), sourceBuffer, {
       ...uploadMetadata,
@@ -448,7 +435,7 @@ async function runFormat({
       ...uploadMetadata,
       contentType: 'image/jpeg',
     });
-    step('Vídeo e poster enviados pelas Storage Rules com reserva.');
+    step('Vídeo e poster autorizados pelas Storage Rules.');
 
     const registerPrivateVideoUpload = httpsCallable(
       client.functions,
@@ -525,10 +512,12 @@ async function runFormat({
     );
     result.terminalState = String(terminal.job.state ?? '');
 
-    if (result.terminalState !== SUCCESS_JOB_STATE) {
+    if (result.terminalState !== 'SUCCEEDED') {
       const code = String(terminal.job.lastErrorCode ?? 'PROCESSING_FAILED');
       const message = String(terminal.job.lastError ?? 'Falha sem detalhes.');
-      throw new Error(`Processamento terminou em ${result.terminalState}: ${code} - ${message}`);
+      throw new Error(
+        `Processamento terminou em ${result.terminalState}: ${code} - ${message}`
+      );
     }
     step('Google Transcoder concluiu o processamento.', {
       processingVersion: String(terminal.job.processingVersion ?? ''),
@@ -568,7 +557,7 @@ async function runFormat({
     result.moderationStatus = String(
       published.publicVideo.moderationStatus ?? ''
     );
-    step('Derivado reproduzível e publicação automática confirmados.', {
+    step('Derivado e publicação automática confirmados.', {
       processedMimeType,
       moderationStatus: result.moderationStatus,
     });
@@ -594,40 +583,116 @@ async function runFormat({
     assert.equal(deadLetterSnapshot.empty, true, 'Job bem-sucedido apareceu na DLQ.');
     step('Ausência indevida de DLQ confirmada.');
 
+    result.status = 'PASS';
     result.finishedAt = new Date().toISOString();
     result.durationMs = Date.now() - startedAt;
-    result.status = 'PASS';
     return result;
   } catch (error) {
-    failed = true;
     result.status = 'FAIL';
     result.error = safeError(error);
     result.finishedAt = new Date().toISOString();
     result.durationMs = Date.now() - startedAt;
-    throw Object.assign(error instanceof Error ? error : new Error(String(error)), {
-      smokeResult: result,
-    });
+    throw Object.assign(
+      error instanceof Error ? error : new Error(String(error)),
+      { smokeResult: result }
+    );
   } finally {
     await closeClient(client);
+  }
+}
 
-    const shouldCleanup = configuration.cleanup &&
-      !(failed && configuration.keepOnFailure);
+async function validateOperationalPanel(observer, report) {
+  const callable = httpsCallable(
+    observer.functions,
+    'getVideoProcessingOperationalStatus'
+  );
+  const response = await callable({});
+  const status = response.data;
 
-    if (shouldCleanup) {
-      result.cleanup = await cleanupOwnerResources({
-        db,
-        bucket,
-        adminAuth,
-        ownerUid,
-        jobIds: [jobId],
-      });
-      console.log(`✔ [${format.name}] Recursos efêmeros removidos.`);
-    } else {
-      result.cleanup = { skipped: true };
-      console.warn(
-        `⚠ [${format.name}] Limpeza ignorada por configuração explícita.`
-      );
+  assert.notEqual(status?.state, 'EMULATOR');
+  assert.equal(
+    status?.provider?.status,
+    'READY',
+    `Provider não está READY: ${JSON.stringify(status?.provider ?? {})}`
+  );
+  assert.ok(Number(status?.checkedAt ?? 0) > 0);
+  assert.ok(
+    Number(status?.dispatch?.latencySampleSize ?? 0) > 0,
+    'O painel não encontrou amostra de latência antes da limpeza.'
+  );
+
+  report.operationalStatus = {
+    state: status.state,
+    providerStatus: status.provider.status,
+    activeJobs: Number(status.queue?.activeTotal ?? 0),
+    staleJobs: Number(status.queue?.staleSampledJobs ?? 0),
+    pendingDispatches: Number(status.dispatch?.pendingTotal ?? 0),
+    latencySampleSize: Number(status.dispatch?.latencySampleSize ?? 0),
+    p50LatencyMs: status.dispatch?.p50LatencyMs ?? null,
+    p95LatencyMs: status.dispatch?.p95LatencyMs ?? null,
+    recentDeadLetters: Number(status.deadLetters?.recentTotal ?? 0),
+    alertCodes: Array.isArray(status.alerts)
+      ? status.alerts.map((alert) => String(alert.code ?? ''))
+      : [],
+  };
+  console.log('✔ Painel operacional respondeu com provider READY.');
+}
+
+async function cleanupAll({
+  configuration,
+  report,
+  resources,
+  observer,
+  db,
+  bucket,
+  adminAuth,
+}) {
+  const failedRun = report.status === 'FAIL';
+  const shouldCleanupOwners = configuration.cleanup &&
+    !(failedRun && configuration.keepOnFailure);
+  const cleanupErrors = [];
+
+  if (shouldCleanupOwners) {
+    for (const resource of resources) {
+      try {
+        resource.result.cleanup = await cleanupOwnerResources({
+          db,
+          bucket,
+          adminAuth,
+          resource,
+        });
+        console.log(`✔ [${resource.format}] Recursos efêmeros removidos.`);
+      } catch (error) {
+        const normalized = safeError(error);
+        resource.result.cleanup = { status: 'FAIL', error: normalized };
+        cleanupErrors.push({ resource: resource.jobId, ...normalized });
+      }
     }
+  } else {
+    resources.forEach((resource) => {
+      resource.result.cleanup = { skipped: true };
+    });
+    console.warn('⚠ Limpeza dos usuários de mídia ignorada por configuração.');
+  }
+
+  if (observer) {
+    await closeClient(observer);
+    try {
+      await adminAuth.deleteUser(observer.uid);
+      report.observerCleanup = { authUserDeleted: true };
+    } catch (error) {
+      const normalized = safeError(error);
+      report.observerCleanup = { authUserDeleted: false, error: normalized };
+      cleanupErrors.push({ resource: observer.uid, ...normalized });
+    }
+  }
+
+  if (cleanupErrors.length > 0) {
+    report.cleanupErrors = cleanupErrors;
+    report.status = 'FAIL';
+    throw new Error(
+      `A limpeza de staging falhou para ${cleanupErrors.length} recurso(s).`
+    );
   }
 }
 
@@ -643,9 +708,9 @@ async function main() {
     startedAt: new Date(startedAt).toISOString(),
     formats: [],
     operationalStatus: null,
-    cleanup: null,
     status: 'RUNNING',
   };
+  const resources = [];
   const firebaseConfig = {
     apiKey: configuration.apiKey,
     appId: configuration.appId,
@@ -662,6 +727,7 @@ async function main() {
   const db = getAdminFirestore(adminApp);
   const bucket = getAdminStorage(adminApp).bucket(configuration.storageBucket);
   let observer = null;
+  let primaryError = null;
 
   fs.mkdirSync(REPORT_DIRECTORY, { recursive: true });
   console.log(
@@ -685,9 +751,8 @@ async function main() {
           configuration,
           adminAuth,
           db,
-          bucket,
           firebaseConfig,
-          report,
+          resources,
         });
         report.formats.push(formatResult);
       } catch (error) {
@@ -698,52 +763,37 @@ async function main() {
       }
     }
 
-    const getOperationalStatus = httpsCallable(
-      observer.functions,
-      'getVideoProcessingOperationalStatus'
-    );
-    const operationalResponse = await getOperationalStatus({});
-    const operational = operationalResponse.data;
-    assert.notEqual(operational?.state, 'EMULATOR');
-    assert.equal(
-      operational?.provider?.status,
-      'READY',
-      `Provider não está READY: ${JSON.stringify(operational?.provider ?? {})}`
-    );
-    assert.ok(Number(operational?.checkedAt ?? 0) > 0);
-    assert.ok(Number(operational?.dispatch?.latencySampleSize ?? 0) > 0);
-    report.operationalStatus = {
-      state: operational.state,
-      providerStatus: operational.provider.status,
-      activeJobs: Number(operational.queue?.activeTotal ?? 0),
-      staleJobs: Number(operational.queue?.staleSampledJobs ?? 0),
-      pendingDispatches: Number(operational.dispatch?.pendingTotal ?? 0),
-      p50LatencyMs: operational.dispatch?.p50LatencyMs ?? null,
-      p95LatencyMs: operational.dispatch?.p95LatencyMs ?? null,
-      recentDeadLetters: Number(operational.deadLetters?.recentTotal ?? 0),
-      alertCodes: Array.isArray(operational.alerts)
-        ? operational.alerts.map((alert) => String(alert.code ?? ''))
-        : [],
-    };
-    console.log('✔ Painel operacional respondeu com provider READY.');
-
+    await validateOperationalPanel(observer, report);
     report.status = 'PASS';
   } catch (error) {
+    primaryError = error;
     report.status = 'FAIL';
     report.error = safeError(error);
-    throw error;
-  } finally {
-    if (observer) {
-      await closeClient(observer);
-      await adminAuth.deleteUser(observer.uid).catch(() => undefined);
-      report.cleanup = { observerUserDeleted: true };
-    }
+  }
 
+  try {
+    await cleanupAll({
+      configuration,
+      report,
+      resources,
+      observer,
+      db,
+      bucket,
+      adminAuth,
+    });
+  } catch (cleanupError) {
+    primaryError ??= cleanupError;
+    report.error ??= safeError(cleanupError);
+  } finally {
     report.finishedAt = new Date().toISOString();
     report.durationMs = Date.now() - startedAt;
     fs.writeFileSync(REPORT_PATH, `${JSON.stringify(report, null, 2)}\n`);
     await deleteAdminApp(adminApp).catch(() => undefined);
     console.log(`[video:staging] Relatório: ${REPORT_PATH}`);
+  }
+
+  if (primaryError) {
+    throw primaryError;
   }
 }
 

--- a/scripts/tests/video-staging-smoke.mjs
+++ b/scripts/tests/video-staging-smoke.mjs
@@ -8,7 +8,7 @@
 // - usa um usuário efêmero por formato;
 // - inicializa App Check no Node com CustomProvider e token Admin efêmero;
 // - valida o painel antes de remover a telemetria do teste;
-// - limpa Auth, Firestore e Storage ao final;
+// - limpa Auth, Firestore, Storage e filas técnicas ao final;
 // - não imprime credenciais, tokens nem URLs assinadas.
 // -----------------------------------------------------------------------------
 
@@ -52,6 +52,17 @@ const DEAD_LETTER_COLLECTION = 'media_video_processing_dead_letters';
 const JOB_COLLECTION = 'media_video_processing_jobs';
 const RESERVATION_COLLECTION = 'media_private_video_upload_reservations';
 const CAPACITY_COLLECTION = 'media_private_video_upload_capacity';
+const PRIVATE_UPLOAD_CLEANUP_COLLECTION =
+  'media_private_video_upload_cleanup_jobs';
+const PROCESSING_OUTPUT_CLEANUP_COLLECTION =
+  'media_video_processing_output_cleanup_jobs';
+const PUBLISHED_ASSET_CLEANUP_COLLECTION =
+  'media_published_video_asset_cleanup_jobs';
+const OWNER_TECHNICAL_CLEANUP_COLLECTIONS = [
+  PRIVATE_UPLOAD_CLEANUP_COLLECTION,
+  PROCESSING_OUTPUT_CLEANUP_COLLECTION,
+  PUBLISHED_ASSET_CLEANUP_COLLECTION,
+];
 const TERMINAL_JOB_STATES = new Set(['SUCCEEDED', 'FAILED', 'CANCELLED']);
 const DEFAULT_TIMEOUT_MS = 20 * 60 * 1000;
 const DEFAULT_INTERVAL_MS = 5_000;
@@ -333,6 +344,7 @@ async function cleanupOwnerResources({ db, bucket, adminAuth, resource }) {
     dispatches: 0,
     deadLetters: 0,
     reservations: 0,
+    technicalCleanupJobs: {},
     jobDeleted: false,
     authUserDeleted: false,
   };
@@ -354,6 +366,13 @@ async function cleanupOwnerResources({ db, bucket, adminAuth, resource }) {
     db.collection(RESERVATION_COLLECTION)
       .where('ownerUid', '==', resource.ownerUid)
   );
+
+  for (const collectionName of OWNER_TECHNICAL_CLEANUP_COLLECTIONS) {
+    deleted.technicalCleanupJobs[collectionName] = await deleteQuery(
+      db.collection(collectionName).where('ownerUid', '==', resource.ownerUid)
+    );
+  }
+
   await db.collection(CAPACITY_COLLECTION).doc(resource.ownerUid).delete()
     .catch((error) => {
       if (error?.code !== 5) {

--- a/scripts/tests/video-staging-smoke.mjs
+++ b/scripts/tests/video-staging-smoke.mjs
@@ -1,0 +1,753 @@
+// scripts/tests/video-staging-smoke.mjs
+// -----------------------------------------------------------------------------
+// Smoke test REAL do pipeline de vídeos em staging.
+//
+// Proteções:
+// - exige confirmação explícita do projectId;
+// - rejeita projeto sem a palavra staging;
+// - usa usuários e mídias efêmeros;
+// - limpa Auth, Firestore e Storage ao final;
+// - não imprime credenciais, tokens nem URLs assinadas.
+// -----------------------------------------------------------------------------
+
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  deleteApp as deleteClientApp,
+  initializeApp as initializeClientApp,
+} from 'firebase/app';
+import {
+  getAuth as getClientAuth,
+  signInWithCustomToken,
+  signOut,
+} from 'firebase/auth';
+import { getFunctions, httpsCallable } from 'firebase/functions';
+import {
+  getStorage as getClientStorage,
+  ref,
+  uploadBytes,
+} from 'firebase/storage';
+import {
+  applicationDefault,
+  deleteApp as deleteAdminApp,
+  initializeApp as initializeAdminApp,
+} from 'firebase-admin/app';
+import { getAuth as getAdminAuth } from 'firebase-admin/auth';
+import { getFirestore as getAdminFirestore } from 'firebase-admin/firestore';
+import { getStorage as getAdminStorage } from 'firebase-admin/storage';
+
+const DISPATCH_COLLECTION = 'media_video_processing_dispatches';
+const DEAD_LETTER_COLLECTION = 'media_video_processing_dead_letters';
+const JOB_COLLECTION = 'media_video_processing_jobs';
+const RESERVATION_COLLECTION = 'media_private_video_upload_reservations';
+const CAPACITY_COLLECTION = 'media_private_video_upload_capacity';
+const TERMINAL_JOB_STATES = new Set(['SUCCEEDED', 'FAILED', 'CANCELLED']);
+const SUCCESS_JOB_STATE = 'SUCCEEDED';
+const DEFAULT_TIMEOUT_MS = 20 * 60 * 1000;
+const DEFAULT_INTERVAL_MS = 5_000;
+const REPORT_DIRECTORY = path.resolve(
+  process.env.VIDEO_STAGING_REPORT_DIR || 'artifacts/video-staging'
+);
+const REPORT_PATH = path.join(REPORT_DIRECTORY, 'smoke.json');
+
+const FORMAT_CONFIG = {
+  mp4: {
+    environmentVariable: 'VIDEO_STAGING_MP4_PATH',
+    extension: 'mp4',
+    mimeType: 'video/mp4',
+  },
+  webm: {
+    environmentVariable: 'VIDEO_STAGING_WEBM_PATH',
+    extension: 'webm',
+    mimeType: 'video/webm',
+  },
+  mov: {
+    environmentVariable: 'VIDEO_STAGING_MOV_PATH',
+    extension: 'mov',
+    mimeType: 'video/quicktime',
+  },
+};
+
+function requiredEnvironment(name, fallback = '') {
+  const value = String(process.env[name] ?? fallback).trim();
+
+  if (!value) {
+    throw new Error(`Variável obrigatória ausente: ${name}.`);
+  }
+
+  return value;
+}
+
+function positiveIntegerEnvironment(name, fallback) {
+  const value = Number(process.env[name] ?? fallback);
+
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`Variável ${name} deve ser um inteiro positivo.`);
+  }
+
+  return Math.trunc(value);
+}
+
+function safeError(error) {
+  const candidate = error && typeof error === 'object' ? error : {};
+  const code = String(candidate.code ?? 'UNKNOWN').slice(0, 160);
+  const message = String(candidate.message ?? error ?? 'Falha sem mensagem')
+    .replace(/https?:\/\/\S+/gi, '[URL_REMOVIDA]')
+    .slice(0, 700);
+
+  return { code, message };
+}
+
+function delay(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function waitFor(label, readValue, predicate, options = {}) {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
+  const deadline = Date.now() + timeoutMs;
+  let lastValue = null;
+
+  while (Date.now() < deadline) {
+    lastValue = await readValue();
+
+    if (predicate(lastValue)) {
+      return lastValue;
+    }
+
+    await delay(intervalMs);
+  }
+
+  throw new Error(
+    `Timeout aguardando ${label}. Último estado: ${JSON.stringify(lastValue)}`
+  );
+}
+
+async function readDocument(reference) {
+  const snapshot = await reference.get();
+  return snapshot.exists ? snapshot.data() : null;
+}
+
+async function deleteQuery(query) {
+  const snapshot = await query.get();
+  await Promise.all(snapshot.docs.map((document) => document.ref.delete()));
+  return snapshot.size;
+}
+
+function parseFormats() {
+  const requested = String(process.env.VIDEO_STAGING_FORMATS ?? 'mp4')
+    .split(',')
+    .map((value) => value.trim().toLowerCase())
+    .filter(Boolean);
+  const unique = [...new Set(requested)];
+
+  if (!unique.length) {
+    throw new Error('VIDEO_STAGING_FORMATS não contém formatos válidos.');
+  }
+
+  return unique.map((format) => {
+    const configuration = FORMAT_CONFIG[format];
+
+    if (!configuration) {
+      throw new Error(
+        `Formato desconhecido em VIDEO_STAGING_FORMATS: ${format}.`
+      );
+    }
+
+    const filePath = path.resolve(
+      requiredEnvironment(configuration.environmentVariable)
+    );
+
+    if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile()) {
+      throw new Error(
+        `${configuration.environmentVariable} não aponta para um arquivo.`
+      );
+    }
+
+    return {
+      name: format,
+      filePath,
+      ...configuration,
+    };
+  });
+}
+
+function buildConfiguration() {
+  const projectId = requiredEnvironment(
+    'VIDEO_STAGING_PROJECT_ID',
+    'entretenimento-staging'
+  );
+  const confirmation = requiredEnvironment('VIDEO_STAGING_CONFIRM');
+  const storageBucket = requiredEnvironment(
+    'VIDEO_STAGING_STORAGE_BUCKET',
+    `${projectId}.appspot.com`
+  );
+  const posterPath = path.resolve(
+    requiredEnvironment('VIDEO_STAGING_POSTER_PATH')
+  );
+
+  assert.equal(
+    confirmation,
+    projectId,
+    'VIDEO_STAGING_CONFIRM deve ser exatamente igual ao projectId.'
+  );
+  assert.match(
+    projectId.toLowerCase(),
+    /staging/,
+    'Este script aceita somente projetos explicitamente identificados como staging.'
+  );
+  assert.notEqual(
+    projectId,
+    'entretenimento-sexual',
+    'O projeto de produção é proibido neste smoke test.'
+  );
+  assert.equal(
+    storageBucket.startsWith(`${projectId}.`),
+    true,
+    'O bucket deve pertencer ao projeto de staging confirmado.'
+  );
+  assert.equal(
+    fs.existsSync(posterPath) && fs.statSync(posterPath).isFile(),
+    true,
+    'VIDEO_STAGING_POSTER_PATH deve apontar para um JPEG existente.'
+  );
+
+  return {
+    projectId,
+    storageBucket,
+    posterPath,
+    apiKey: requiredEnvironment('VIDEO_STAGING_API_KEY'),
+    appId: requiredEnvironment('VIDEO_STAGING_APP_ID'),
+    authDomain: requiredEnvironment(
+      'VIDEO_STAGING_AUTH_DOMAIN',
+      `${projectId}.firebaseapp.com`
+    ),
+    functionsRegion: requiredEnvironment(
+      'VIDEO_STAGING_FUNCTIONS_REGION',
+      'us-central1'
+    ),
+    durationMs: positiveIntegerEnvironment(
+      'VIDEO_STAGING_DURATION_MS',
+      6_000
+    ),
+    timeoutMs: positiveIntegerEnvironment(
+      'VIDEO_STAGING_TIMEOUT_MS',
+      DEFAULT_TIMEOUT_MS
+    ),
+    intervalMs: positiveIntegerEnvironment(
+      'VIDEO_STAGING_INTERVAL_MS',
+      DEFAULT_INTERVAL_MS
+    ),
+    cleanup: process.env.VIDEO_STAGING_CLEANUP !== 'false',
+    keepOnFailure: process.env.VIDEO_STAGING_KEEP_ON_FAILURE === 'true',
+    formats: parseFormats(),
+  };
+}
+
+async function createAuthenticatedClient({
+  adminAuth,
+  firebaseConfig,
+  functionsRegion,
+  runId,
+  role,
+}) {
+  const email = `video-staging-${role}-${runId}@example.test`;
+  const userRecord = await adminAuth.createUser({
+    email,
+    emailVerified: true,
+    disabled: false,
+    displayName: `Video staging ${role}`,
+  });
+  const claims = role === 'admin'
+    ? { admin: true, role: 'admin', roles: ['admin'], stagingSmoke: true }
+    : { stagingSmoke: true };
+
+  await adminAuth.setCustomUserClaims(userRecord.uid, claims);
+  const customToken = await adminAuth.createCustomToken(userRecord.uid, claims);
+  const clientApp = initializeClientApp(
+    firebaseConfig,
+    `video-staging-${role}-${runId}`
+  );
+  const clientAuth = getClientAuth(clientApp);
+  const credential = await signInWithCustomToken(clientAuth, customToken);
+
+  return {
+    uid: userRecord.uid,
+    email,
+    clientApp,
+    clientAuth,
+    user: credential.user,
+    functions: getFunctions(clientApp, functionsRegion),
+    storage: getClientStorage(clientApp),
+  };
+}
+
+async function closeClient(client) {
+  if (!client) {
+    return;
+  }
+
+  await signOut(client.clientAuth).catch(() => undefined);
+  await deleteClientApp(client.clientApp).catch(() => undefined);
+}
+
+async function cleanupOwnerResources({ db, bucket, adminAuth, ownerUid, jobIds }) {
+  const deleted = {
+    storageObjects: 0,
+    dispatches: 0,
+    deadLetters: 0,
+    reservations: 0,
+  };
+
+  const [files] = await bucket.getFiles({ prefix: `users/${ownerUid}/` });
+  await Promise.all(files.map((file) => file.delete({ ignoreNotFound: true })));
+  deleted.storageObjects = files.length;
+
+  for (const jobId of jobIds) {
+    deleted.dispatches += await deleteQuery(
+      db.collection(DISPATCH_COLLECTION).where('jobId', '==', jobId)
+    );
+    deleted.deadLetters += await deleteQuery(
+      db.collection(DEAD_LETTER_COLLECTION).where('jobId', '==', jobId)
+    );
+    await db.collection(JOB_COLLECTION).doc(jobId).delete().catch(() => undefined);
+  }
+
+  deleted.reservations += await deleteQuery(
+    db.collection(RESERVATION_COLLECTION).where('ownerUid', '==', ownerUid)
+  );
+  await db.collection(CAPACITY_COLLECTION).doc(ownerUid).delete()
+    .catch(() => undefined);
+  await db.recursiveDelete(db.doc(`users/${ownerUid}`)).catch(() => undefined);
+  await db.recursiveDelete(db.doc(`public_profiles/${ownerUid}`))
+    .catch(() => undefined);
+  await adminAuth.deleteUser(ownerUid).catch(() => undefined);
+
+  return deleted;
+}
+
+async function runFormat({
+  format,
+  configuration,
+  adminAuth,
+  db,
+  bucket,
+  firebaseConfig,
+  report,
+}) {
+  const formatRunId = `${format.name}-${randomUUID()}`;
+  const startedAt = Date.now();
+  const sourceBuffer = fs.readFileSync(format.filePath);
+  const posterBuffer = fs.readFileSync(configuration.posterPath);
+  const client = await createAuthenticatedClient({
+    adminAuth,
+    firebaseConfig,
+    functionsRegion: configuration.functionsRegion,
+    runId: formatRunId,
+    role: 'owner',
+  });
+  const ownerUid = client.uid;
+  const videoId = `staging-${format.name}-${randomUUID()}`;
+  const jobId = `${ownerUid}_${videoId}`;
+  const sourcePath =
+    `users/${ownerUid}/uploads/videos/${videoId}.${format.extension}`;
+  const posterPath =
+    `users/${ownerUid}/uploads/video-posters/${videoId}/poster.jpg`;
+  const result = {
+    format: format.name,
+    mimeType: format.mimeType,
+    ownerUid,
+    videoId,
+    jobId,
+    startedAt: new Date(startedAt).toISOString(),
+    steps: [],
+    terminalState: null,
+    moderationStatus: null,
+    dispatchStates: [],
+  };
+  let failed = false;
+
+  const step = (name, details = null) => {
+    result.steps.push({
+      name,
+      at: new Date().toISOString(),
+      details,
+    });
+    console.log(`✔ [${format.name}] ${name}`);
+  };
+
+  try {
+    assert.ok(sourceBuffer.byteLength > 0, 'Arquivo de vídeo está vazio.');
+    assert.ok(sourceBuffer.byteLength <= 500 * 1024 * 1024);
+    assert.ok(posterBuffer.byteLength > 0, 'Poster está vazio.');
+    assert.ok(configuration.durationMs >= 5_000);
+
+    await db.doc(`users/${ownerUid}`).set({
+      uid: ownerUid,
+      email: client.email,
+      emailVerified: true,
+      profileCompleted: true,
+      accountStatus: 'active',
+      loginAllowed: true,
+      interactionBlocked: false,
+      suspended: false,
+      accountLocked: false,
+      stagingSmoke: true,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    }, { merge: true });
+    await db.doc(`public_profiles/${ownerUid}`).set({
+      uid: ownerUid,
+      nickname: `Homologação ${format.name.toUpperCase()}`,
+      publicVisibility: 'visible',
+      stagingSmoke: true,
+      updatedAt: Date.now(),
+    }, { merge: true });
+    step('Conta efêmera elegível e perfil público criados.');
+
+    const reservePrivateVideoUpload = httpsCallable(
+      client.functions,
+      'reservePrivateVideoUpload'
+    );
+    const reservationResponse = await reservePrivateVideoUpload({
+      clientRequestId: formatRunId,
+      ownerUid,
+      videoId,
+      videoStoragePath: sourcePath,
+      posterStoragePath: posterPath,
+      videoSizeBytes: sourceBuffer.byteLength,
+      posterSizeBytes: posterBuffer.byteLength,
+      mimeType: format.mimeType,
+    });
+    const reservation = reservationResponse.data;
+    const reservationId = String(reservation?.reservationId ?? '').trim();
+    assert.ok(reservationId, 'Reserva não retornou identificador.');
+    assert.equal(reservation?.ownerUid, ownerUid);
+    assert.equal(reservation?.videoId, videoId);
+    assert.ok(Number(reservation?.expiresAt ?? 0) > Date.now());
+    step('Quota reservada antes da transferência.', {
+      reservationId,
+      reservedBytes: Number(reservation?.reservedBytes ?? 0),
+    });
+
+    const uploadMetadata = {
+      cacheControl: 'private, max-age=0, no-store, no-transform',
+      customMetadata: {
+        videoReservationId: reservationId,
+        videoId,
+      },
+    };
+    await uploadBytes(ref(client.storage, sourcePath), sourceBuffer, {
+      ...uploadMetadata,
+      contentType: format.mimeType,
+    });
+    await uploadBytes(ref(client.storage, posterPath), posterBuffer, {
+      ...uploadMetadata,
+      contentType: 'image/jpeg',
+    });
+    step('Vídeo e poster enviados pelas Storage Rules com reserva.');
+
+    const registerPrivateVideoUpload = httpsCallable(
+      client.functions,
+      'registerPrivateVideoUpload'
+    );
+    const registrationResponse = await registerPrivateVideoUpload({
+      ownerUid,
+      videoId,
+      reservationId,
+      videoStoragePath: sourcePath,
+      posterStoragePath: posterPath,
+      fileName: path.basename(format.filePath),
+      mimeType: format.mimeType,
+      sizeBytes: sourceBuffer.byteLength,
+      durationMs: configuration.durationMs,
+      title: `Homologação ${format.name.toUpperCase()} ${formatRunId}`,
+      description: 'Conteúdo técnico efêmero para validar o pipeline de staging.',
+      reactionsEnabled: false,
+      commentsEnabled: false,
+      ratingsEnabled: false,
+      publishWhenReady: false,
+    });
+    assert.equal(registrationResponse.data?.ownerUid, ownerUid);
+    assert.equal(registrationResponse.data?.videoId, videoId);
+    step('Upload registrado com publicação obrigatória.');
+
+    const reservationRef = db.collection(RESERVATION_COLLECTION)
+      .doc(reservationId);
+    const privateVideoRef = db.doc(`users/${ownerUid}/videos/${videoId}`);
+    const publicationRef = db.doc(
+      `users/${ownerUid}/video_publications/${videoId}`
+    );
+    const publicVideoRef = db.doc(
+      `public_profiles/${ownerUid}/public_videos/${videoId}`
+    );
+    const jobRef = db.collection(JOB_COLLECTION).doc(jobId);
+
+    await waitFor(
+      'consumo da reserva e criação do job',
+      async () => ({
+        reservation: await readDocument(reservationRef),
+        video: await readDocument(privateVideoRef),
+        job: await readDocument(jobRef),
+      }),
+      (value) =>
+        value.reservation?.state === 'CONSUMED' &&
+        value.video?.videoReservationId === reservationId &&
+        !!value.job?.state,
+      configuration
+    );
+    step('Reserva consumida e job persistido.');
+
+    await waitFor(
+      'primeiro despacho do Cloud Tasks',
+      async () => {
+        const snapshot = await db.collection(DISPATCH_COLLECTION)
+          .where('jobId', '==', jobId)
+          .get();
+        return snapshot.docs.map((document) => document.data());
+      },
+      (items) => items.length > 0,
+      configuration
+    );
+    step('Dispatcher orientado a eventos criou registro técnico.');
+
+    const terminal = await waitFor(
+      'estado terminal do processamento real',
+      async () => ({
+        job: await readDocument(jobRef),
+        video: await readDocument(privateVideoRef),
+      }),
+      (value) => TERMINAL_JOB_STATES.has(String(value.job?.state ?? '')),
+      configuration
+    );
+    result.terminalState = String(terminal.job.state ?? '');
+
+    if (result.terminalState !== SUCCESS_JOB_STATE) {
+      const code = String(terminal.job.lastErrorCode ?? 'PROCESSING_FAILED');
+      const message = String(terminal.job.lastError ?? 'Falha sem detalhes.');
+      throw new Error(`Processamento terminou em ${result.terminalState}: ${code} - ${message}`);
+    }
+    step('Google Transcoder concluiu o processamento.', {
+      processingVersion: String(terminal.job.processingVersion ?? ''),
+    });
+
+    const published = await waitFor(
+      'derivado, publicação e projeção pública',
+      async () => ({
+        video: await readDocument(privateVideoRef),
+        publication: await readDocument(publicationRef),
+        publicVideo: await readDocument(publicVideoRef),
+      }),
+      (value) =>
+        value.video?.status === 'ready' &&
+        !!value.video?.processedStoragePath &&
+        value.publication?.isPublished === true &&
+        ['PENDING_REVIEW', 'APPROVED'].includes(
+          String(value.publicVideo?.moderationStatus ?? '')
+        ),
+      configuration
+    );
+    const processedStoragePath = String(
+      published.video.processedStoragePath ?? ''
+    );
+    const processedMimeType = String(
+      published.video.processedMimeType ?? published.video.mimeType ?? ''
+    );
+    assert.match(
+      processedStoragePath,
+      new RegExp(`^users/${ownerUid}/processed/videos/${videoId}/`)
+    );
+    assert.equal(
+      ['video/mp4', 'video/webm'].includes(processedMimeType),
+      true,
+      `Derivado recebeu MIME inesperado: ${processedMimeType}.`
+    );
+    result.moderationStatus = String(
+      published.publicVideo.moderationStatus ?? ''
+    );
+    step('Derivado reproduzível e publicação automática confirmados.', {
+      processedMimeType,
+      moderationStatus: result.moderationStatus,
+    });
+
+    const dispatchSnapshot = await db.collection(DISPATCH_COLLECTION)
+      .where('jobId', '==', jobId)
+      .get();
+    result.dispatchStates = dispatchSnapshot.docs
+      .map((document) => String(document.data().state ?? ''))
+      .filter(Boolean);
+    assert.equal(
+      result.dispatchStates.includes('COMPLETED'),
+      true,
+      'Nenhum despacho COMPLETED foi registrado.'
+    );
+    step('Despacho COMPLETED confirmado.', {
+      states: result.dispatchStates,
+    });
+
+    const deadLetterSnapshot = await db.collection(DEAD_LETTER_COLLECTION)
+      .where('jobId', '==', jobId)
+      .get();
+    assert.equal(deadLetterSnapshot.empty, true, 'Job bem-sucedido apareceu na DLQ.');
+    step('Ausência indevida de DLQ confirmada.');
+
+    result.finishedAt = new Date().toISOString();
+    result.durationMs = Date.now() - startedAt;
+    result.status = 'PASS';
+    return result;
+  } catch (error) {
+    failed = true;
+    result.status = 'FAIL';
+    result.error = safeError(error);
+    result.finishedAt = new Date().toISOString();
+    result.durationMs = Date.now() - startedAt;
+    throw Object.assign(error instanceof Error ? error : new Error(String(error)), {
+      smokeResult: result,
+    });
+  } finally {
+    await closeClient(client);
+
+    const shouldCleanup = configuration.cleanup &&
+      !(failed && configuration.keepOnFailure);
+
+    if (shouldCleanup) {
+      result.cleanup = await cleanupOwnerResources({
+        db,
+        bucket,
+        adminAuth,
+        ownerUid,
+        jobIds: [jobId],
+      });
+      console.log(`✔ [${format.name}] Recursos efêmeros removidos.`);
+    } else {
+      result.cleanup = { skipped: true };
+      console.warn(
+        `⚠ [${format.name}] Limpeza ignorada por configuração explícita.`
+      );
+    }
+  }
+}
+
+async function main() {
+  const configuration = buildConfiguration();
+  const runId = randomUUID();
+  const startedAt = Date.now();
+  const report = {
+    runId,
+    projectId: configuration.projectId,
+    storageBucket: configuration.storageBucket,
+    functionsRegion: configuration.functionsRegion,
+    startedAt: new Date(startedAt).toISOString(),
+    formats: [],
+    operationalStatus: null,
+    cleanup: null,
+    status: 'RUNNING',
+  };
+  const firebaseConfig = {
+    apiKey: configuration.apiKey,
+    appId: configuration.appId,
+    authDomain: configuration.authDomain,
+    projectId: configuration.projectId,
+    storageBucket: configuration.storageBucket,
+  };
+  const adminApp = initializeAdminApp({
+    credential: applicationDefault(),
+    projectId: configuration.projectId,
+    storageBucket: configuration.storageBucket,
+  }, `video-staging-admin-sdk-${runId}`);
+  const adminAuth = getAdminAuth(adminApp);
+  const db = getAdminFirestore(adminApp);
+  const bucket = getAdminStorage(adminApp).bucket(configuration.storageBucket);
+  let observer = null;
+
+  fs.mkdirSync(REPORT_DIRECTORY, { recursive: true });
+  console.log(
+    `[video:staging] Projeto confirmado: ${configuration.projectId}. ` +
+      `Formatos: ${configuration.formats.map((item) => item.name).join(', ')}.`
+  );
+
+  try {
+    observer = await createAuthenticatedClient({
+      adminAuth,
+      firebaseConfig,
+      functionsRegion: configuration.functionsRegion,
+      runId,
+      role: 'admin',
+    });
+
+    for (const format of configuration.formats) {
+      try {
+        const formatResult = await runFormat({
+          format,
+          configuration,
+          adminAuth,
+          db,
+          bucket,
+          firebaseConfig,
+          report,
+        });
+        report.formats.push(formatResult);
+      } catch (error) {
+        if (error?.smokeResult) {
+          report.formats.push(error.smokeResult);
+        }
+        throw error;
+      }
+    }
+
+    const getOperationalStatus = httpsCallable(
+      observer.functions,
+      'getVideoProcessingOperationalStatus'
+    );
+    const operationalResponse = await getOperationalStatus({});
+    const operational = operationalResponse.data;
+    assert.notEqual(operational?.state, 'EMULATOR');
+    assert.equal(
+      operational?.provider?.status,
+      'READY',
+      `Provider não está READY: ${JSON.stringify(operational?.provider ?? {})}`
+    );
+    assert.ok(Number(operational?.checkedAt ?? 0) > 0);
+    assert.ok(Number(operational?.dispatch?.latencySampleSize ?? 0) > 0);
+    report.operationalStatus = {
+      state: operational.state,
+      providerStatus: operational.provider.status,
+      activeJobs: Number(operational.queue?.activeTotal ?? 0),
+      staleJobs: Number(operational.queue?.staleSampledJobs ?? 0),
+      pendingDispatches: Number(operational.dispatch?.pendingTotal ?? 0),
+      p50LatencyMs: operational.dispatch?.p50LatencyMs ?? null,
+      p95LatencyMs: operational.dispatch?.p95LatencyMs ?? null,
+      recentDeadLetters: Number(operational.deadLetters?.recentTotal ?? 0),
+      alertCodes: Array.isArray(operational.alerts)
+        ? operational.alerts.map((alert) => String(alert.code ?? ''))
+        : [],
+    };
+    console.log('✔ Painel operacional respondeu com provider READY.');
+
+    report.status = 'PASS';
+  } catch (error) {
+    report.status = 'FAIL';
+    report.error = safeError(error);
+    throw error;
+  } finally {
+    if (observer) {
+      await closeClient(observer);
+      await adminAuth.deleteUser(observer.uid).catch(() => undefined);
+      report.cleanup = { observerUserDeleted: true };
+    }
+
+    report.finishedAt = new Date().toISOString();
+    report.durationMs = Date.now() - startedAt;
+    fs.writeFileSync(REPORT_PATH, `${JSON.stringify(report, null, 2)}\n`);
+    await deleteAdminApp(adminApp).catch(() => undefined);
+    console.log(`[video:staging] Relatório: ${REPORT_PATH}`);
+  }
+}
+
+main().catch((error) => {
+  console.error('[video:staging] Smoke test falhou.', safeError(error));
+  process.exitCode = 1;
+});

--- a/scripts/tests/video-staging-smoke.mjs
+++ b/scripts/tests/video-staging-smoke.mjs
@@ -6,6 +6,7 @@
 // - exige confirmação explícita do projectId;
 // - rejeita projeto sem a palavra staging;
 // - usa um usuário efêmero por formato;
+// - inicializa App Check no Node com CustomProvider e token Admin efêmero;
 // - valida o painel antes de remover a telemetria do teste;
 // - limpa Auth, Firestore e Storage ao final;
 // - não imprime credenciais, tokens nem URLs assinadas.
@@ -20,6 +21,11 @@ import {
   deleteApp as deleteClientApp,
   initializeApp as initializeClientApp,
 } from 'firebase/app';
+import {
+  CustomProvider,
+  getToken as getClientAppCheckToken,
+  initializeAppCheck,
+} from 'firebase/app-check';
 import {
   getAuth as getClientAuth,
   signInWithCustomToken,
@@ -36,6 +42,7 @@ import {
   deleteApp as deleteAdminApp,
   initializeApp as initializeAdminApp,
 } from 'firebase-admin/app';
+import { getAppCheck as getAdminAppCheck } from 'firebase-admin/app-check';
 import { getAuth as getAdminAuth } from 'firebase-admin/auth';
 import { getFirestore as getAdminFirestore } from 'firebase-admin/firestore';
 import { getStorage as getAdminStorage } from 'firebase-admin/storage';
@@ -48,6 +55,7 @@ const CAPACITY_COLLECTION = 'media_private_video_upload_capacity';
 const TERMINAL_JOB_STATES = new Set(['SUCCEEDED', 'FAILED', 'CANCELLED']);
 const DEFAULT_TIMEOUT_MS = 20 * 60 * 1000;
 const DEFAULT_INTERVAL_MS = 5_000;
+const APP_CHECK_TOKEN_TTL_MS = 30 * 60 * 1000;
 const REPORT_DIRECTORY = path.resolve(
   process.env.VIDEO_STAGING_REPORT_DIR || 'artifacts/video-staging'
 );
@@ -232,42 +240,82 @@ function buildConfiguration() {
   };
 }
 
+function createNodeAppCheckProvider(adminAppCheck, appId) {
+  return new CustomProvider({
+    getToken: async () => {
+      const issuedAt = Date.now();
+      const token = await adminAppCheck.createToken(appId, {
+        ttlMillis: APP_CHECK_TOKEN_TTL_MS,
+      });
+
+      return {
+        token: token.token,
+        expireTimeMillis: issuedAt + token.ttlMillis,
+      };
+    },
+  });
+}
+
 async function createAuthenticatedClient({
   adminAuth,
+  adminAppCheck,
   firebaseConfig,
   functionsRegion,
   runId,
   role,
 }) {
   const email = `video-staging-${role}-${runId}@example.test`;
-  const userRecord = await adminAuth.createUser({
-    email,
-    emailVerified: true,
-    disabled: false,
-    displayName: `Video staging ${role}`,
-  });
-  const claims = role === 'admin'
-    ? { admin: true, role: 'admin', roles: ['admin'], stagingSmoke: true }
-    : { stagingSmoke: true };
+  let userRecord = null;
+  let clientApp = null;
 
-  await adminAuth.setCustomUserClaims(userRecord.uid, claims);
-  const customToken = await adminAuth.createCustomToken(userRecord.uid, claims);
-  const clientApp = initializeClientApp(
-    firebaseConfig,
-    `video-staging-${role}-${runId}`
-  );
-  const clientAuth = getClientAuth(clientApp);
-  const credential = await signInWithCustomToken(clientAuth, customToken);
+  try {
+    userRecord = await adminAuth.createUser({
+      email,
+      emailVerified: true,
+      disabled: false,
+      displayName: `Video staging ${role}`,
+    });
+    const claims = role === 'admin'
+      ? { admin: true, role: 'admin', roles: ['admin'], stagingSmoke: true }
+      : { stagingSmoke: true };
 
-  return {
-    uid: userRecord.uid,
-    email,
-    clientApp,
-    clientAuth,
-    functions: getFunctions(clientApp, functionsRegion),
-    storage: getClientStorage(clientApp),
-    user: credential.user,
-  };
+    await adminAuth.setCustomUserClaims(userRecord.uid, claims);
+    const customToken = await adminAuth.createCustomToken(userRecord.uid, claims);
+    clientApp = initializeClientApp(
+      firebaseConfig,
+      `video-staging-${role}-${runId}`
+    );
+    const clientAppCheck = initializeAppCheck(clientApp, {
+      provider: createNodeAppCheckProvider(adminAppCheck, firebaseConfig.appId),
+      isTokenAutoRefreshEnabled: true,
+    });
+
+    await getClientAppCheckToken(clientAppCheck, true);
+
+    const clientAuth = getClientAuth(clientApp);
+    const credential = await signInWithCustomToken(clientAuth, customToken);
+
+    return {
+      uid: userRecord.uid,
+      email,
+      clientApp,
+      clientAppCheck,
+      clientAuth,
+      functions: getFunctions(clientApp, functionsRegion),
+      storage: getClientStorage(clientApp),
+      user: credential.user,
+    };
+  } catch (error) {
+    if (clientApp) {
+      await deleteClientApp(clientApp).catch(() => undefined);
+    }
+
+    if (userRecord?.uid) {
+      await adminAuth.deleteUser(userRecord.uid).catch(() => undefined);
+    }
+
+    throw error;
+  }
 }
 
 async function closeClient(client) {
@@ -324,6 +372,7 @@ async function runFormat({
   format,
   configuration,
   adminAuth,
+  adminAppCheck,
   db,
   firebaseConfig,
   resources,
@@ -334,6 +383,7 @@ async function runFormat({
   const posterBuffer = fs.readFileSync(configuration.posterPath);
   const client = await createAuthenticatedClient({
     adminAuth,
+    adminAppCheck,
     firebaseConfig,
     functionsRegion: configuration.functionsRegion,
     runId: formatRunId,
@@ -724,6 +774,7 @@ async function main() {
     storageBucket: configuration.storageBucket,
   }, `video-staging-admin-sdk-${runId}`);
   const adminAuth = getAdminAuth(adminApp);
+  const adminAppCheck = getAdminAppCheck(adminApp);
   const db = getAdminFirestore(adminApp);
   const bucket = getAdminStorage(adminApp).bucket(configuration.storageBucket);
   let observer = null;
@@ -738,6 +789,7 @@ async function main() {
   try {
     observer = await createAuthenticatedClient({
       adminAuth,
+      adminAppCheck,
       firebaseConfig,
       functionsRegion: configuration.functionsRegion,
       runId,
@@ -750,6 +802,7 @@ async function main() {
           format,
           configuration,
           adminAuth,
+          adminAppCheck,
           db,
           firebaseConfig,
           resources,


### PR DESCRIPTION
## Dependência

Este PR é empilhado sobre o **#72** (`agent/video-processing-operations-dashboard`). Ele não deve ser integrado isoladamente nem promovido antes da cadeia funcional anterior.

## Objetivo

Transformar o pipeline de vídeos já validado por tipos, regras e testes unitários em uma homologação reproduzível contra o projeto real de staging, sem execução acidental no projeto de produção.

## Auditoria estática

Foi adicionado `scripts/tests/video-staging-readiness.mjs`, sem acesso externo, com dois modos:

- modo padrão de prontidão de deploy: placeholders externos são bloqueantes;
- modo `--contract`: valida o contrato do repositório em cada PR e registra pendências externas conhecidas como warnings.

A auditoria verifica:

- Node 22;
- isolamento entre `entretenimento-staging` e o projeto padrão;
- `environment.staging.ts`, projectId e bucket;
- App Check não-placeholder para o build real;
- exports do dispatcher, task worker, diagnóstico e recuperação;
- contrato MP4/M4V, MOV e WebM;
- Storage Rules com reserva obrigatória;
- fronteira efetiva da callable de registro;
- TTL de despachos e DLQ;
- índice da timeline administrativa;
- proteção do workflow manual e autenticação OIDC;
- proteção contra produção, ordem painel → limpeza e remoção das filas técnicas;
- descarte de credenciais e relatórios locais.

O resultado é gravado em `artifacts/video-staging/readiness.json`.

## Descoberta sobre a fronteira de registro

O primeiro run do novo gate falhou porque a auditoria examinava o handler interno `register-private-video-upload.handler.ts`. Esse core ainda mantém formatos legados por compatibilidade interna e não é a callable exportada.

A fronteira pública efetiva é:

```text
functions/src/media/index.ts
  -> register-private-video-upload-orchestrator.handler.ts
  -> reserva obrigatória
  -> elegibilidade
  -> publishWhenReady forçado
  -> core interno
  -> consumo da reserva
  -> fila de processamento
```

O boundary externo permanece restrito a MP4, WebM e QuickTime/MOV por:

- `private-video-upload-reservation.handler.ts`;
- Storage Rules;
- política Angular.

O auditor foi corrigido para validar a callable exportada e suas barreiras reais. Não foi alterado nem exposto o handler interno.

## Smoke test real

Foi adicionado `scripts/tests/video-staging-smoke.mjs` para validar, com dados efêmeros:

```text
conta elegível
  -> App Check válido
  -> reserva de quota
  -> upload autorizado pelas Storage Rules
  -> registro privado
  -> job Firestore
  -> dispatcher
  -> Cloud Tasks
  -> Google Transcoder
  -> derivado processado
  -> publicação automática
  -> moderação
  -> painel operacional
  -> limpeza integral
```

O script:

- exige confirmação textual exata do projectId;
- aceita somente projeto cujo identificador contenha `staging`;
- bloqueia explicitamente `entretenimento-sexual`;
- cria um usuário por formato para não falsear a quota Free;
- suporta MP4, WebM e MOV;
- exige job `SUCCEEDED`;
- exige derivado MP4 ou WebM no namespace processado;
- exige despacho `COMPLETED`;
- rejeita entrada indevida na DLQ;
- consulta `getVideoProcessingOperationalStatus` antes da limpeza;
- exige provider `READY` e amostra de latência;
- remove Auth, documentos, objetos e filas técnicas ao final;
- transforma falha de limpeza em falha do smoke;
- não imprime tokens, credenciais ou URLs assinadas.

A limpeza cobre:

```text
media_private_video_upload_cleanup_jobs
media_video_processing_output_cleanup_jobs
media_published_video_asset_cleanup_jobs
media_video_processing_dispatches
media_video_processing_dead_letters
media_video_processing_jobs
media_private_video_upload_reservations
media_private_video_upload_capacity
users/{uid}
public_profiles/{uid}
Storage users/{uid}/
Firebase Auth
```

O relatório é gravado em `artifacts/video-staging/smoke.json`.

## App Check no runtime Node

O smoke não tenta executar reCAPTCHA no Node. Ele usa:

```text
Firebase Admin AppCheck.createToken(appId)
  -> Firebase Web CustomProvider
  -> initializeAppCheck(clientApp)
  -> Auth, Functions e Storage com App Check
```

O token é efêmero, renovável pelo provider, não é impresso e não é salvo no artifact. A inicialização parcial também remove usuário e app cliente caso falhe antes do fluxo principal.

Esse mecanismo é exclusivo do workflow protegido. Não foi adicionado ao bundle Angular nem exposto por endpoint público.

## Workflows

### `Video Staging Contract`

Executa automaticamente em push e pull request:

- sintaxe dos dois scripts;
- auditoria em modo `--contract`;
- publicação do relatório como artifact.

Esse gate não acessa staging nem exige credenciais.

### `Video Staging Smoke`

Executa somente por `workflow_dispatch` e usa:

- GitHub Environment protegido `video-staging`;
- confirmação manual `entretenimento-staging`;
- Workload Identity Federation;
- `google-github-actions/auth@v3`;
- App Check customizado;
- vídeos sintéticos de seis segundos gerados por FFmpeg;
- artifact dos relatórios por 30 dias.

O workflow não faz deploy.

## Configuração externa necessária

Environment `video-staging`:

### Secrets

```text
GCP_WORKLOAD_IDENTITY_PROVIDER
GCP_VIDEO_STAGING_SERVICE_ACCOUNT
FIREBASE_STAGING_API_KEY
```

### Variables

```text
FIREBASE_STAGING_PROJECT_ID
FIREBASE_STAGING_STORAGE_BUCKET
FIREBASE_STAGING_AUTH_DOMAIN
FIREBASE_STAGING_APP_ID
```

A service account do smoke deve ser separada da identidade de deploy e possuir somente acesso suficiente para criar usuários efêmeros, assinar custom tokens, manipular os dados de teste e removê-los.

## Bloqueios externos conhecidos

`environment.staging.ts` ainda contém:

```text
siteKey: staging-recaptcha-v3-site-key
apiEndpoint: https://api.staging.seuprojeto.com
```

No gate `--contract`, ambos aparecem como warnings explícitos.

A site key real continua necessária para homologar e publicar o Angular de staging. O smoke Node usa App Check customizado, mas a auditoria padrão de prontidão permanece bloqueante enquanto o environment da aplicação estiver incompleto.

O endpoint auxiliar não participa deste smoke Firebase, mas bloqueia a homologação integral do aplicativo.

Também ainda precisam ser configurados fora do repositório:

- faturamento e APIs do projeto de staging;
- índices implantados e em estado READY;
- TTL `cleanupAfter` ativo;
- IAM das Functions, Cloud Tasks e Transcoder;
- Workload Identity Federation;
- GitHub Environment e aprovação obrigatória;
- secrets e variables listados acima.

## Preparação da pilha

A cadeia funcional confirmada é:

```text
#68 publicação automática
  -> #69 ciclo de vida
  -> #70 quota + contrato de formatos
  -> #71 Cloud Tasks
  -> #72 painel operacional
  -> #73 homologação
```

O conteúdo funcional do **#67** foi absorvido pelo **#70** em política Angular, testes, backend e Storage Rules. Não foi realizado cherry-pick cego. Depois da validação final da pilha, o #67 pode ser encerrado como substituído pelo #70.

## Ordem de deploy documentada

```text
1. Firestore indexes
2. Firestore Rules e Storage Rules
3. Functions
4. Angular staging
5. smoke real
```

Também foram documentados APIs, IAM, TTL, GitHub Environment, execução local, critérios de aprovação e rollback.

## Validação final do head atual

- **Video Staging Contract: aprovado**;
- **Quality Gate: aprovado**;
- **Angular CI Validation: aprovado**;
- sintaxe dos scripts: aprovada;
- fronteira efetiva de registro: aprovada;
- Functions lint/build/tests: aprovados;
- Angular tests: aprovados;
- Angular safe build: aprovado;
- build de emuladores: aprovado;
- Firestore Rules tests: aprovados;
- Firestore indexes: aprovados.

## Supressões e alterações existentes

- nenhuma lógica funcional existente foi removida, ocultada ou reduzida;
- nenhum método Angular ou backend foi renomeado;
- nenhum deploy automático foi adicionado;
- o handler interno amplo foi preservado e identificado explicitamente como core não exportado;
- `.gitignore` passou a ignorar `gha-creds-*.json` e `artifacts/video-staging/`;
- `package.json` recebeu apenas os comandos de readiness e smoke.

## Limites da validação

Não houve deploy em staging nem execução do `Video Staging Smoke`. Os workflows validaram contratos, sintaxe, builds, regras e proteções. A comprovação real de Cloud Tasks, Transcoder, App Check, IAM, publicação, painel e limpeza depende da configuração externa e do deploy controlado descritos acima.