### PR TITLE
fix(dev): isolate local compliance runtime from cloud

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -94,12 +94,6 @@
               "namedChunks": false
             },
             "development": {
-              "fileReplacements": [
-                {
-                  "replace": "src/environments/environment.ts",
-                  "with": "src/environments/environment.dev-emu.ts"
-                }
-              ],
               "optimization": false,
               "outputHashing": "none",
               "extractLicenses": false,
@@ -163,7 +157,7 @@
               "buildTarget": "entretenimento:build:production"
             },
             "development": {
-              "buildTarget": "entretenimento:build:development"
+              "buildTarget": "entretenimento:build:dev-emu"
             },
             "dev-cloud": {
               "buildTarget": "entretenimento:build:dev-cloud"

--- a/angular.json
+++ b/angular.json
@@ -94,7 +94,14 @@
               "namedChunks": false
             },
             "development": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.dev-emu.ts"
+                }
+              ],
               "optimization": false,
+              "outputHashing": "none",
               "extractLicenses": false,
               "sourceMap": true,
               "namedChunks": true

--- a/angular.json
+++ b/angular.json
@@ -99,6 +99,19 @@
               "sourceMap": true,
               "namedChunks": true
             },
+            "dev-cloud": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.dev-cloud.ts"
+                }
+              ],
+              "optimization": false,
+              "outputHashing": "none",
+              "sourceMap": true,
+              "extractLicenses": false,
+              "namedChunks": true
+            },
             "staging": {
               "fileReplacements": [
                 {
@@ -144,6 +157,9 @@
             },
             "development": {
               "buildTarget": "entretenimento:build:development"
+            },
+            "dev-cloud": {
+              "buildTarget": "entretenimento:build:dev-cloud"
             },
             "staging": {
               "buildTarget": "entretenimento:build:staging"
@@ -198,9 +214,6 @@
       "typeSeparator": "."
     },
     "@schematics/angular:pipe": {
-      "typeSeparator": "."
-    },
-    "@schematics/angular:resolver": {
       "typeSeparator": "."
     }
   }

--- a/docs/local-development-runtime.md
+++ b/docs/local-development-runtime.md
@@ -27,15 +27,33 @@ O launcher existente:
 5. inicia o Angular com a configuração `dev-emu`;
 6. aguarda os serviços ficarem disponíveis antes de abrir o navegador.
 
-## Ambiente padrão
+## Ambiente local padrão
 
-`src/environments/environment.ts` referencia `environment.dev-emu.ts`.
+O `angular.json` aplica o replacement:
 
-Assim, `ng serve`, `npm start` e a configuração Angular `development` não apontam para a cloud por padrão.
+```text
+development → environment.dev-emu.ts
+```
+
+Por isso, os comandos abaixo usam os emuladores:
+
+```powershell
+npm start
+npm run start:dev
+ng serve
+```
+
+`environment.ts` permanece como configuração-base de compilação e testes. Ele não é usado diretamente pelo servidor local porque a configuração `development` o substitui antes do build servido.
 
 ## Ambiente cloud explícito
 
-A configuração `dev-cloud` usa `environment.dev-cloud.ts` e deve ser tratada como operação consciente. Ela não implanta Functions, Rules, índices ou qualquer outro recurso.
+A configuração `dev-cloud` usa `environment.dev-cloud.ts` e precisa ser selecionada conscientemente:
+
+```powershell
+ng serve -c dev-cloud
+```
+
+Ela não implanta Functions, Rules, índices ou qualquer outro recurso.
 
 Não use `dev-cloud` para testar código cujo backend ainda não foi implantado. A ausência de uma callable na cloud pode aparecer no navegador como CORS porque a requisição termina antes de produzir uma resposta callable válida.
 
@@ -47,7 +65,7 @@ O desenvolvimento local não ignora os requisitos jurídicos.
 - o registro é feito pelas callables emuladas;
 - o navegador não grava aceite diretamente no Firestore;
 - a persistência local é mantida pelo export dos emuladores;
-- uma falha de infraestrutura não deve ser reinterpretada como aceite válido.
+- uma falha de infraestrutura não é reinterpretada como aceite válido.
 
 Se o usuário local ainda não aceitou a versão vigente, a tela será exibida uma vez e o aceite será persistido no ambiente emulado.
 

--- a/docs/local-development-runtime.md
+++ b/docs/local-development-runtime.md
@@ -1,0 +1,58 @@
+# Runtime local isolado
+
+## Objetivo
+
+O desenvolvimento executado em `localhost` não deve acessar silenciosamente o projeto Firebase cloud `entretenimento-sexual`.
+
+Esse isolamento evita:
+
+- chamadas para Functions ainda não implantadas;
+- falhas CORS interpretadas como falhas de domínio;
+- alterações acidentais em Auth, Firestore ou Storage cloud;
+- dependência de deploy para testar uma branch em desenvolvimento;
+- repetição falsa de etapas como aceite de termos, consentimento adulto ou recuperação de conta.
+
+## Comando recomendado no Windows
+
+```powershell
+npm run dev:auth:win
+```
+
+O launcher existente:
+
+1. verifica as portas antes de iniciar;
+2. recupera apenas processos locais reconhecidos;
+3. inicia Auth, Firestore, Storage, Functions e demais emuladores necessários;
+4. preserva os dados em `.emulator-data`;
+5. inicia o Angular com a configuração `dev-emu`;
+6. aguarda os serviços ficarem disponíveis antes de abrir o navegador.
+
+## Ambiente padrão
+
+`src/environments/environment.ts` referencia `environment.dev-emu.ts`.
+
+Assim, `ng serve`, `npm start` e a configuração Angular `development` não apontam para a cloud por padrão.
+
+## Ambiente cloud explícito
+
+A configuração `dev-cloud` usa `environment.dev-cloud.ts` e deve ser tratada como operação consciente. Ela não implanta Functions, Rules, índices ou qualquer outro recurso.
+
+Não use `dev-cloud` para testar código cujo backend ainda não foi implantado. A ausência de uma callable na cloud pode aparecer no navegador como CORS porque a requisição termina antes de produzir uma resposta callable válida.
+
+## Termos e consentimentos
+
+O desenvolvimento local não ignora os requisitos jurídicos.
+
+- aceite e consentimentos continuam fail-closed;
+- o registro é feito pelas callables emuladas;
+- o navegador não grava aceite diretamente no Firestore;
+- a persistência local é mantida pelo export dos emuladores;
+- uma falha de infraestrutura não deve ser reinterpretada como aceite válido.
+
+Se o usuário local ainda não aceitou a versão vigente, a tela será exibida uma vez e o aceite será persistido no ambiente emulado.
+
+## Produção e staging
+
+Nada neste fluxo altera os environments de produção ou staging. Ambos continuam usando file replacements próprios no `angular.json`.
+
+Nenhum deploy é executado por esses comandos.

--- a/docs/local-development-runtime.md
+++ b/docs/local-development-runtime.md
@@ -29,10 +29,10 @@ O launcher existente:
 
 ## Ambiente local padrão
 
-O `angular.json` aplica o replacement:
+O servidor Angular usa esta cadeia:
 
 ```text
-development → environment.dev-emu.ts
+serve:development → build:dev-emu → environment.dev-emu.ts
 ```
 
 Por isso, os comandos abaixo usam os emuladores:
@@ -43,7 +43,7 @@ npm run start:dev
 ng serve
 ```
 
-`environment.ts` permanece como configuração-base de compilação e testes. Ele não é usado diretamente pelo servidor local porque a configuração `development` o substitui antes do build servido.
+`environment.ts` permanece como configuração-base de compilação e testes. A suíte unitária não herda as flags funcionais específicas do emulador. O isolamento é aplicado ao build servido pelo navegador, que é o ponto que poderia acessar Firebase cloud.
 
 ## Ambiente cloud explícito
 

--- a/src/environments/environment.dev-cloud.ts
+++ b/src/environments/environment.dev-cloud.ts
@@ -5,6 +5,10 @@
 // Este ambiente acessa o projeto Firebase cloud `entretenimento-sexual`.
 // Não deve ser usado pelo comando local padrão e não substitui deploy de
 // Functions, Rules, índices ou demais dependências de backend.
+//
+// O identificador interno permanece `dev-real` por compatibilidade com o
+// contrato tipado já usado em telemetria e políticas de runtime. O nome
+// operacional explícito desta configuração é `dev-cloud` no angular.json.
 // -----------------------------------------------------------------------------
 
 import type { AppEnvironment } from './environment.model';
@@ -12,7 +16,7 @@ import type { AppEnvironment } from './environment.model';
 export const environment: AppEnvironment = {
   production: false,
   stage: false,
-  env: 'dev-cloud-explicit',
+  env: 'dev-real',
   useEmulators: false,
   emulators: undefined,
 

--- a/src/environments/environment.dev-cloud.ts
+++ b/src/environments/environment.dev-cloud.ts
@@ -1,0 +1,76 @@
+// src/environments/environment.dev-cloud.ts
+// -----------------------------------------------------------------------------
+// DESENVOLVIMENTO CONECTADO À CLOUD — USO EXPLÍCITO
+// -----------------------------------------------------------------------------
+// Este ambiente acessa o projeto Firebase cloud `entretenimento-sexual`.
+// Não deve ser usado pelo comando local padrão e não substitui deploy de
+// Functions, Rules, índices ou demais dependências de backend.
+// -----------------------------------------------------------------------------
+
+import type { AppEnvironment } from './environment.model';
+
+export const environment: AppEnvironment = {
+  production: false,
+  stage: false,
+  env: 'dev-cloud-explicit',
+  useEmulators: false,
+  emulators: undefined,
+
+  firebase: {
+    apiKey: 'AIzaSyAtk-mc6oVZOqu9u7_2KIpk570q8O8Jrl0',
+    authDomain: 'entretenimento-sexual.firebaseapp.com',
+    databaseURL: 'https://entretenimento-sexual-default-rtdb.firebaseio.com',
+    projectId: 'entretenimento-sexual',
+    storageBucket: 'entretenimento-sexual.appspot.com',
+    messagingSenderId: '668950141209',
+    appId: '1:668950141209:web:73e27794c51e493cf44d88',
+    measurementId: 'G-GWTPJVK044',
+  },
+
+  apiEndpoint: 'http://localhost:3000',
+  enableDebugTools: true,
+
+  privacyLogging: {
+    enabled: true,
+    allowSensitiveConsoleData: false,
+    allowCacheTrace: false,
+    includeStackTrace: false,
+  },
+
+  monitoring: {
+    sentry: {
+      enabled: false,
+      dsn: undefined,
+      tracesSampleRate: 0,
+    },
+  },
+
+  appCheck: {
+    enabled: false,
+    provider: 'reCaptchaV3',
+    siteKey: 'dev-recaptcha-v3-site-key',
+  },
+
+  integrations: {
+    virusTotal: {
+      enabled: false,
+      apiKey: undefined,
+      useProxy: false,
+      region: 'us-central1',
+    },
+  },
+
+  features: {
+    enforceEmailVerified: false,
+    showGuestBanner: true,
+    restrictedRoutesWhenUnverified: [
+      '/dashboard/chat',
+      '/dashboard/featured-profiles',
+    ],
+    subscriberExperiencesPreview: false,
+    communityPreview: false,
+  },
+
+  friendsPageSize: 24,
+  dashboardFriendsLimit: 12,
+};

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,71 +1,17 @@
 // src/environments/environment.ts
-// Dev usando recursos reais (Cloud)
-import type { AppEnvironment } from './environment.model';
+// -----------------------------------------------------------------------------
+// PADRÃO SEGURO DE DESENVOLVIMENTO LOCAL
+// -----------------------------------------------------------------------------
+// `ng serve`, `npm start` e a configuração `development` não podem apontar
+// silenciosamente para Auth, Firestore, Storage ou Functions do projeto cloud.
+//
+// O ambiente local usa a suíte Firebase Emulator. Para uma sessão completa no
+// Windows, execute `npm run dev:auth:win`, que inicia os emuladores e o Angular
+// na configuração `dev-emu`, preservando os dados locais exportados.
+//
+// Uma futura execução conectada a cloud deve usar um environment e um comando
+// explicitamente nomeados, com autorização consciente. Não reutilize este
+// arquivo para contornar Functions ainda não implantadas.
+// -----------------------------------------------------------------------------
 
-export const environment: AppEnvironment = {
-  production: false,
-  stage: false,
-  env: 'dev-real',
-  useEmulators: false,
-  emulators: undefined,
-
-  firebase: {
-    apiKey: 'AIzaSyAtk-mc6oVZOqu9u7_2KIpk570q8O8Jrl0',
-    authDomain: 'entretenimento-sexual.firebaseapp.com',
-    databaseURL: 'https://entretenimento-sexual-default-rtdb.firebaseio.com',
-    projectId: 'entretenimento-sexual',
-    storageBucket: 'entretenimento-sexual.appspot.com',
-    messagingSenderId: '668950141209',
-    appId: '1:668950141209:web:73e27794c51e493cf44d88',
-    measurementId: 'G-GWTPJVK044',
-  },
-
-  apiEndpoint: 'http://localhost:3000',
-  enableDebugTools: true,
-
-  privacyLogging: {
-    enabled: true,
-    allowSensitiveConsoleData: false,
-    allowCacheTrace: false,
-    includeStackTrace: false,
-  },
-
-  monitoring: {
-    sentry: {
-      enabled: false,
-      dsn: undefined,
-      tracesSampleRate: 0,
-    },
-  },
-
-  appCheck: {
-    enabled: false,
-    provider: 'reCaptchaV3',
-    siteKey: 'dev-recaptcha-v3-site-key',
-  },
-
-  // 🔐 Integrações externas
-  integrations: {
-    virusTotal: {
-      enabled: false,
-      // ⚠️ Só para DESENVOLVIMENTO local. Em produção NÃO exponha a chave no front.
-      apiKey: undefined,
-      useProxy: false, // direto no browser (pode falhar por CORS)
-      region: 'us-central1',
-    },
-  },
-
-  features: {
-    enforceEmailVerified: false,
-    showGuestBanner: true,
-    restrictedRoutesWhenUnverified: [
-      '/dashboard/chat',
-      '/dashboard/featured-profiles',
-    ],
-    subscriberExperiencesPreview: false,
-    communityPreview: false,
-  },
-
-  friendsPageSize: 24,
-  dashboardFriendsLimit: 12,
-};
+export { environment } from './environment.dev-emu';

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,17 +1,12 @@
 // src/environments/environment.ts
 // -----------------------------------------------------------------------------
-// PADRÃO SEGURO DE DESENVOLVIMENTO LOCAL
+// CONFIGURAÇÃO-BASE DE COMPILAÇÃO E TESTES
 // -----------------------------------------------------------------------------
-// `ng serve`, `npm start` e a configuração `development` não podem apontar
-// silenciosamente para Auth, Firestore, Storage ou Functions do projeto cloud.
+// O servidor local não usa este arquivo diretamente: as configurações Angular
+// `development` e `dev-emu` o substituem por `environment.dev-emu.ts`.
 //
-// O ambiente local usa a suíte Firebase Emulator. Para uma sessão completa no
-// Windows, execute `npm run dev:auth:win`, que inicia os emuladores e o Angular
-// na configuração `dev-emu`, preservando os dados locais exportados.
-//
-// Uma futura execução conectada a cloud deve usar um environment e um comando
-// explicitamente nomeados, com autorização consciente. Não reutilize este
-// arquivo para contornar Functions ainda não implantadas.
+// A configuração conectada à cloud permanece isolada em
+// `environment.dev-cloud.ts` e exige seleção explícita de `dev-cloud`.
 // -----------------------------------------------------------------------------
 
-export { environment } from './environment.dev-emu';
+export { environment } from './environment.dev-cloud';

--- a/src/environments/local-development-runtime.spec.ts
+++ b/src/environments/local-development-runtime.spec.ts
@@ -9,7 +9,7 @@ interface AngularWorkspaceContract {
       architect?: {
         build?: {
           configurations?: {
-            development?: {
+            'dev-emu'?: {
               fileReplacements?: ReadonlyArray<{
                 replace?: string;
                 with?: string;
@@ -31,18 +31,18 @@ interface AngularWorkspaceContract {
 }
 
 describe('contrato do runtime local', () => {
-  it('serve development com o environment emulado', () => {
+  it('serve development pelo build emulado sem alterar o contrato dos testes', () => {
     const workspace = JSON.parse(
       readFileSync(resolve(process.cwd(), 'angular.json'), 'utf8')
     ) as AngularWorkspaceContract;
     const architect = workspace.projects?.entretenimento?.architect;
-    const developmentBuild = architect?.build?.configurations?.development;
-    const replacements = developmentBuild?.fileReplacements ?? [];
+    const emulatorBuild = architect?.build?.configurations?.['dev-emu'];
+    const replacements = emulatorBuild?.fileReplacements ?? [];
 
     expect(architect?.serve?.defaultConfiguration).toBe('development');
     expect(
       architect?.serve?.configurations?.development?.buildTarget
-    ).toBe('entretenimento:build:development');
+    ).toBe('entretenimento:build:dev-emu');
     expect(replacements).toContainEqual({
       replace: 'src/environments/environment.ts',
       with: 'src/environments/environment.dev-emu.ts',

--- a/src/environments/local-development-runtime.spec.ts
+++ b/src/environments/local-development-runtime.spec.ts
@@ -1,0 +1,75 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { environment as emulatorEnvironment } from './environment.dev-emu';
+
+interface AngularWorkspaceContract {
+  projects?: {
+    entretenimento?: {
+      architect?: {
+        build?: {
+          configurations?: {
+            development?: {
+              fileReplacements?: ReadonlyArray<{
+                replace?: string;
+                with?: string;
+              }>;
+            };
+          };
+        };
+        serve?: {
+          defaultConfiguration?: string;
+          configurations?: {
+            development?: {
+              buildTarget?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+}
+
+describe('contrato do runtime local', () => {
+  it('serve development com o environment emulado', () => {
+    const workspace = JSON.parse(
+      readFileSync(resolve(process.cwd(), 'angular.json'), 'utf8')
+    ) as AngularWorkspaceContract;
+    const architect = workspace.projects?.entretenimento?.architect;
+    const developmentBuild = architect?.build?.configurations?.development;
+    const replacements = developmentBuild?.fileReplacements ?? [];
+
+    expect(architect?.serve?.defaultConfiguration).toBe('development');
+    expect(
+      architect?.serve?.configurations?.development?.buildTarget
+    ).toBe('entretenimento:build:development');
+    expect(replacements).toContainEqual({
+      replace: 'src/environments/environment.ts',
+      with: 'src/environments/environment.dev-emu.ts',
+    });
+  });
+
+  it('mantém todos os serviços Firebase locais conectados aos emuladores', () => {
+    expect(emulatorEnvironment.useEmulators).toBe(true);
+    expect(emulatorEnvironment.emulators?.auth).toEqual({
+      host: '127.0.0.1',
+      port: 9099,
+    });
+    expect(emulatorEnvironment.emulators?.firestore).toEqual({
+      host: '127.0.0.1',
+      port: 8080,
+    });
+    expect(emulatorEnvironment.emulators?.storage).toEqual({
+      host: '127.0.0.1',
+      port: 9199,
+    });
+    expect(emulatorEnvironment.emulators?.functions).toEqual({
+      host: '127.0.0.1',
+      port: 5001,
+    });
+    expect(emulatorEnvironment.emulators?.database).toEqual({
+      host: '127.0.0.1',
+      port: 9000,
+    });
+  });
+});


### PR DESCRIPTION
## Dependência

Este PR é empilhado sobre o **#78** (`agent/integrate-video-simple-editor`). Não deve ser integrado isoladamente.

## Problema observado

Ao recarregar a aplicação em `localhost:4200`, o Angular chamou diretamente as Functions cloud:

- `ensureCurrentLegalNotice`;
- `acceptPlatformTerms`.

Essas callables ainda não estão implantadas no backend cloud correspondente à branch. O preflight terminou sem cabeçalhos CORS, a callable não executou e o aceite não foi persistido.

O efeito visual era uma solicitação repetida dos Termos. Não houve evidência de expiração do aceite; houve falha de infraestrutura anterior à gravação.

## Correção final

O isolamento foi aplicado ao **build servido pelo navegador**, sem alterar o contrato-base dos testes:

```text
serve:development → build:dev-emu → environment.dev-emu.ts
```

Assim, estes comandos usam Firebase Emulator por padrão:

```powershell
npm start
npm run start:dev
ng serve
```

O acesso cloud ficou explicitamente isolado:

```powershell
ng serve -c dev-cloud
```

Também foram adicionados:

- `environment.dev-cloud.ts`, contendo a antiga configuração cloud de desenvolvimento;
- documentação em `docs/local-development-runtime.md`;
- teste de contrato que valida o target servido e as portas dos emuladores de Auth, Firestore, Storage, Functions e Database.

Produção e staging continuam usando seus próprios file replacements.

## Política jurídica preservada

O aceite não foi ignorado, presumido ou gravado diretamente pelo navegador.

- termos e consentimentos continuam fail-closed;
- o registro continua passando pela callable;
- falha de infraestrutura não é convertida em aceite;
- localmente, a callable é executada pelo Functions Emulator;
- o estado emulado é preservado em `.emulator-data` pelo launcher existente.

Uma conta local sem aceite vigente poderá ver a tela uma vez. Depois da callable emulada concluir com sucesso, a confirmação deve permanecer no ambiente local.

## Execução recomendada no Windows

```powershell
npm run dev:auth:win
```

Esse launcher inicia os emuladores necessários, aguarda os serviços, preserva os dados locais e inicia o Angular em `dev-emu`.

## Falhas intermediárias detectadas pelo CI

### Identificador de environment inválido

A primeira versão usou `dev-cloud-explicit`, fora do union type existente. Foi corrigida mantendo `env: 'dev-real'` internamente e `dev-cloud` apenas como nome operacional da configuração Angular.

### Flags de produto alteradas nos testes

Uma tentativa colocou o replacement em `build:development`. Como a suíte Angular herda essa configuração, quatro testes passaram a receber flags específicas do emulador.

A solução não relaxou os testes: o replacement foi retirado do build de testes e aplicado somente ao target servido (`serve:development → build:dev-emu`).

## Supressão consciente

Foi suprimido o comportamento anterior em que `ng serve` e `npm start` apontavam silenciosamente para o projeto cloud.

A configuração cloud não foi removida. Ela foi movida para `environment.dev-cloud.ts` e exige seleção explícita por `dev-cloud`.

Nenhum handler de Termos, versão jurídica, guard, persistência de aceite ou tratamento centralizado de erro foi suprimido.

## Validação concluída

Head validado: `b73ee1cda9d256b32b7791499e17b2a857567d1a`.

- Video Staging Contract: aprovado;
- Functions lint, build e testes: aprovados;
- Angular tests: aprovados;
- teste de contrato do runtime local: aprovado;
- Angular safe build: aprovado;
- build `dev-emu`: aprovado;
- Firestore Rules: aprovadas;
- Firestore indexes: aprovados;
- Angular CI Validation: aprovado;
- Quality Gate agregado: aprovado.

## Fora do escopo

- deploy de Functions;
- alteração dos Termos ou de suas versões;
- bypass de aceite;
- migração de dados cloud para os emuladores;
- merge da pilha.

O PR permanece em rascunho, sem merge e sem deploy.