### PR TITLE
fix(video): synchronize editor disabled state with reactive form

### DIFF
--- a/src/app/media/videos/profile-videos/video-simple-editor-controls.component.html
+++ b/src/app/media/videos/profile-videos/video-simple-editor-controls.component.html
@@ -48,8 +48,12 @@
         A prévia não está disponível neste navegador. O arquivo original ainda pode ser enviado e convertido no backend, sem edição local.
       </p>
     } @else {
-      <form class="video-simple-editor__controls" [formGroup]="form">
-        <fieldset [disabled]="disabled">
+      <form
+        class="video-simple-editor__controls"
+        [formGroup]="form"
+        [attr.aria-disabled]="disabled ? 'true' : null"
+      >
+        <fieldset>
           <legend>Corte</legend>
 
           <div class="video-simple-editor__range-row">
@@ -85,7 +89,7 @@
           </div>
         </fieldset>
 
-        <fieldset [disabled]="disabled">
+        <fieldset>
           <legend>Enquadramento</legend>
           <div class="video-simple-editor__aspect-grid">
             @for (option of aspectOptions; track option.value) {
@@ -110,7 +114,6 @@
             <input
               type="checkbox"
               formControlName="muteAudio"
-              [disabled]="disabled"
             />
             <span>
               <strong>Remover áudio</strong>

--- a/src/app/media/videos/profile-videos/video-simple-editor-controls.component.spec.ts
+++ b/src/app/media/videos/profile-videos/video-simple-editor-controls.component.spec.ts
@@ -108,4 +108,22 @@ describe('VideoSimpleEditorControlsComponent', () => {
       'Capa do vídeo atualizada.'
     );
   });
+
+  it('controla o bloqueio dos campos pelo FormGroup reativo', () => {
+    component.disabled = true;
+
+    expect(component.form.disabled).toBe(true);
+    expect(component.form.controls.trimStartMs.disabled).toBe(true);
+    expect(component.form.controls.trimEndMs.disabled).toBe(true);
+    expect(component.form.controls.aspectRatio.disabled).toBe(true);
+    expect(component.form.controls.muteAudio.disabled).toBe(true);
+
+    component.disabled = false;
+
+    expect(component.form.enabled).toBe(true);
+    expect(component.form.controls.trimStartMs.enabled).toBe(true);
+    expect(component.form.controls.trimEndMs.enabled).toBe(true);
+    expect(component.form.controls.aspectRatio.enabled).toBe(true);
+    expect(component.form.controls.muteAudio.enabled).toBe(true);
+  });
 });

--- a/src/app/media/videos/profile-videos/video-simple-editor-controls.component.ts
+++ b/src/app/media/videos/profile-videos/video-simple-editor-controls.component.ts
@@ -83,7 +83,19 @@ export class VideoSimpleEditorControlsComponent {
 
   @Input()
   set disabled(value: boolean) {
-    this.disabledValue = value === true;
+    const next = value === true;
+    if (this.disabledValue === next) {
+      return;
+    }
+
+    this.disabledValue = next;
+
+    if (next) {
+      this.form.disable({ emitEvent: false });
+      return;
+    }
+
+    this.form.enable({ emitEvent: false });
   }
 
   get disabled(): boolean {


### PR DESCRIPTION
## Dependência

Este PR é empilhado sobre o **#79** (`agent/fix-local-compliance-runtime`). Não deve ser integrado isoladamente.

## Problema observado

Durante o teste manual do editor, o Angular exibiu o aviso de que um controle com `formControlName` também recebia `[disabled]` diretamente no template.

O checkbox `muteAudio` misturava as duas estratégias e os `fieldset` desabilitavam apenas o DOM, enquanto o `FormGroup` permanecia habilitado internamente. Isso poderia gerar divergência de estado e erros de change detection em fluxos de upload.

## Correção

- o setter `disabled` agora chama `form.disable({ emitEvent: false })` e `form.enable({ emitEvent: false })`;
- foram removidos os bindings `[disabled]` dos controles gerenciados por Reactive Forms;
- os `fieldset` deixaram de controlar o estado de bloqueio no DOM;
- o formulário expõe `aria-disabled` para tecnologia assistiva;
- o botão de captura de capa preserva `[disabled]`, pois não pertence ao `FormGroup`;
- foi adicionada cobertura para todos os controles do editor ao bloquear e reabilitar.

## Supressão consciente

Foram suprimidos apenas os bindings de template que duplicavam o estado `disabled` dos controles reativos. A capacidade de bloquear o editor não foi removida; foi centralizada no `FormGroup`, conforme o contrato recomendado pelo Angular.

## Validação concluída

Head validado: `95c3db9da11afe4d0e18abae5e2e0d5c4bd29cbe`.

- teste do estado reativo `disabled`: aprovado;
- Angular tests: aprovados;
- Angular safe build: aprovado;
- build `dev-emu`: aprovado;
- Functions lint, build e testes: aprovados;
- Firestore Rules: aprovadas;
- Firestore indexes: aprovados;
- Angular CI Validation: aprovado;
- Quality Gate agregado: aprovado;
- Video Staging Contract: aprovado.

## Fora do escopo

- alteração visual do editor;
- mudança na receita de edição;
- upload, quota ou processamento;
- termos e runtime local;
- merge ou deploy.

O PR permanece em rascunho, sem merge e sem deploy.