### PR TITLE
feat(video): simplify trim with dual-handle timeline

### DIFF
--- a/src/app/media/videos/profile-videos/video-simple-editor-controls.component.css
+++ b/src/app/media/videos/profile-videos/video-simple-editor-controls.component.css
@@ -10,8 +10,7 @@
 }
 
 .video-simple-editor__heading,
-.video-simple-editor__cover-tools,
-.video-simple-editor__range-row label {
+.video-simple-editor__cover-tools {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -95,21 +94,168 @@
   font-weight: 800;
 }
 
-.video-simple-editor__range-row {
+.video-simple-editor__trim-fieldset {
+  padding: 0.85rem !important;
+  border: 1px solid color-mix(in srgb, var(--border-color, #2d3748) 80%, transparent) !important;
+  border-radius: 0.8rem;
+  background: color-mix(in srgb, var(--surface-muted, #111923) 55%, transparent);
+}
+
+.video-simple-editor__trim-fieldset legend {
+  padding: 0 0.35rem;
+}
+
+.video-simple-editor__trim-summary {
   display: grid;
-  gap: 0.45rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.5rem;
 }
 
-.video-simple-editor__range-row label,
-.video-simple-editor__range-row output {
-  font-size: 0.8rem;
-  font-weight: 700;
+.video-simple-editor__trim-summary span {
+  display: grid;
+  gap: 0.15rem;
+  min-width: 0;
 }
 
-.video-simple-editor__range-row input[type='range'] {
+.video-simple-editor__trim-summary span:last-child {
+  text-align: right;
+}
+
+.video-simple-editor__trim-summary-result {
+  text-align: center;
+}
+
+.video-simple-editor__trim-summary small {
+  color: var(--text-muted, #aab3c2);
+  font-size: 0.7rem;
+}
+
+.video-simple-editor__trim-summary strong {
+  font-size: 0.86rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.video-simple-editor__trim-timeline {
+  position: relative;
+  min-height: 3.2rem;
+  touch-action: none;
+}
+
+.video-simple-editor__trim-track {
+  position: absolute;
+  inset-inline: 0.75rem;
+  top: 50%;
+  height: 0.5rem;
+  overflow: hidden;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--text-muted, #aab3c2) 24%, transparent);
+  transform: translateY(-50%);
+}
+
+.video-simple-editor__trim-selection {
+  position: absolute;
+  inset-block: 0;
+  border-radius: inherit;
+  background: var(--color-primary, #ff6f76);
+}
+
+.video-simple-editor__trim-range {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
   width: 100%;
-  min-height: 2rem;
-  accent-color: var(--color-primary, #ff6f76);
+  height: 3.2rem;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  appearance: none;
+  pointer-events: none;
+}
+
+.video-simple-editor__trim-range--end {
+  z-index: 3;
+}
+
+.video-simple-editor__trim-range::-webkit-slider-runnable-track {
+  height: 0.5rem;
+  border: 0;
+  background: transparent;
+}
+
+.video-simple-editor__trim-range::-webkit-slider-thumb {
+  width: 1.45rem;
+  height: 2.35rem;
+  margin-top: -0.92rem;
+  border: 2px solid var(--surface-color, #111923);
+  border-radius: 0.45rem;
+  background: var(--color-primary, #ff6f76);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--color-primary, #ff6f76) 68%, #fff);
+  appearance: none;
+  cursor: grab;
+  pointer-events: auto;
+}
+
+.video-simple-editor__trim-range::-moz-range-track {
+  height: 0.5rem;
+  border: 0;
+  background: transparent;
+}
+
+.video-simple-editor__trim-range::-moz-range-progress {
+  height: 0.5rem;
+  background: transparent;
+}
+
+.video-simple-editor__trim-range::-moz-range-thumb {
+  width: 1.45rem;
+  height: 2.35rem;
+  border: 2px solid var(--surface-color, #111923);
+  border-radius: 0.45rem;
+  background: var(--color-primary, #ff6f76);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--color-primary, #ff6f76) 68%, #fff);
+  cursor: grab;
+  pointer-events: auto;
+}
+
+.video-simple-editor__trim-range:active::-webkit-slider-thumb,
+.video-simple-editor__trim-range:active::-moz-range-thumb {
+  cursor: grabbing;
+}
+
+.video-simple-editor__trim-range:focus-visible::-webkit-slider-thumb {
+  outline: 3px solid color-mix(in srgb, var(--color-primary, #ff6f76) 44%, #fff);
+  outline-offset: 3px;
+}
+
+.video-simple-editor__trim-range:focus-visible::-moz-range-thumb {
+  outline: 3px solid color-mix(in srgb, var(--color-primary, #ff6f76) 44%, #fff);
+  outline-offset: 3px;
+}
+
+.video-simple-editor__trim-range:disabled::-webkit-slider-thumb,
+.video-simple-editor__trim-range:disabled::-moz-range-thumb {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.video-simple-editor__trim-help {
+  margin: 0;
+  color: var(--text-muted, #aab3c2);
+  font-size: 0.73rem;
+  line-height: 1.45;
+}
+
+.video-simple-editor__sr-only {
+  position: absolute;
+  overflow: hidden;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
 }
 
 .video-simple-editor__aspect-grid {
@@ -214,6 +360,21 @@
 
   .video-simple-editor__duration {
     width: fit-content;
+  }
+
+  .video-simple-editor__trim-fieldset {
+    padding-inline: 0.7rem !important;
+  }
+
+  .video-simple-editor__trim-range::-webkit-slider-thumb {
+    width: 1.65rem;
+    height: 2.55rem;
+    margin-top: -1.02rem;
+  }
+
+  .video-simple-editor__trim-range::-moz-range-thumb {
+    width: 1.65rem;
+    height: 2.55rem;
   }
 
   .video-simple-editor__cover-tools button {

--- a/src/app/media/videos/profile-videos/video-simple-editor-controls.component.html
+++ b/src/app/media/videos/profile-videos/video-simple-editor-controls.component.html
@@ -3,6 +3,7 @@
 @let editorReady = (editorReady$ | async) === true;
 @let recipeError = (recipeError$ | async);
 @let capturingPoster = (capturingPoster$ | async) === true;
+@let timeline = (trimTimeline$ | async);
 
 <section
   class="video-simple-editor"
@@ -53,40 +54,77 @@
         [formGroup]="form"
         [attr.aria-disabled]="disabled ? 'true' : null"
       >
-        <fieldset>
-          <legend>Corte</legend>
+        <fieldset class="video-simple-editor__trim-fieldset">
+          <legend>Cortar vídeo</legend>
 
-          <div class="video-simple-editor__range-row">
-            <label for="video-trim-start">
-              <span>Início</span>
-              <output>{{ formatTime(form.controls.trimStartMs.value) }}</output>
-            </label>
-            <input
-              id="video-trim-start"
-              type="range"
-              formControlName="trimStartMs"
-              min="0"
-              step="100"
-              [max]="metadata!.durationMs! - 5000"
-              [attr.aria-valuetext]="formatTime(form.controls.trimStartMs.value)"
-            />
-          </div>
+          @if (timeline) {
+            <div
+              id="video-trim-summary"
+              class="video-simple-editor__trim-summary"
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+            >
+              <span>
+                <small>Início</small>
+                <strong>{{ formatTime(timeline.startMs) }}</strong>
+              </span>
+              <span class="video-simple-editor__trim-summary-result">
+                <small>Resultado</small>
+                <strong>{{ formatTime(timeline.editedDurationMs) }}</strong>
+              </span>
+              <span>
+                <small>Fim</small>
+                <strong>{{ formatTime(timeline.endMs) }}</strong>
+              </span>
+            </div>
 
-          <div class="video-simple-editor__range-row">
-            <label for="video-trim-end">
-              <span>Fim</span>
-              <output>{{ formatTime(form.controls.trimEndMs.value) }}</output>
-            </label>
-            <input
-              id="video-trim-end"
-              type="range"
-              formControlName="trimEndMs"
-              min="5000"
-              step="100"
-              [max]="metadata!.durationMs!"
-              [attr.aria-valuetext]="formatTime(form.controls.trimEndMs.value)"
-            />
-          </div>
+            <div class="video-simple-editor__trim-timeline">
+              <div class="video-simple-editor__trim-track" aria-hidden="true">
+                <span
+                  class="video-simple-editor__trim-selection"
+                  [style.left.%]="timeline.startPercent"
+                  [style.right.%]="100 - timeline.endPercent"
+                ></span>
+              </div>
+
+              <label class="video-simple-editor__sr-only" for="video-trim-start">
+                Início do corte
+              </label>
+              <input
+                id="video-trim-start"
+                class="video-simple-editor__trim-range video-simple-editor__trim-range--start"
+                type="range"
+                formControlName="trimStartMs"
+                min="0"
+                step="100"
+                [max]="metadata!.durationMs! - minimumEditedDurationMs"
+                [attr.aria-valuetext]="'Início em ' + formatTime(timeline.startMs)"
+                aria-describedby="video-trim-summary video-trim-help"
+                (input)="onTrimStartInput(uploadPreview)"
+              />
+
+              <label class="video-simple-editor__sr-only" for="video-trim-end">
+                Fim do corte
+              </label>
+              <input
+                id="video-trim-end"
+                class="video-simple-editor__trim-range video-simple-editor__trim-range--end"
+                type="range"
+                formControlName="trimEndMs"
+                [min]="minimumEditedDurationMs"
+                step="100"
+                [max]="metadata!.durationMs!"
+                [attr.aria-valuetext]="'Fim em ' + formatTime(timeline.endMs)"
+                aria-describedby="video-trim-summary video-trim-help"
+                (input)="onTrimEndInput(uploadPreview)"
+              />
+            </div>
+
+            <p id="video-trim-help" class="video-simple-editor__trim-help">
+              Arraste as duas alças na mesma linha. O trecho destacado será publicado e terá no mínimo 5 segundos.
+            </p>
+          }
         </fieldset>
 
         <fieldset>

--- a/src/app/media/videos/profile-videos/video-simple-editor-controls.component.spec.ts
+++ b/src/app/media/videos/profile-videos/video-simple-editor-controls.component.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { of } from 'rxjs';
+import { firstValueFrom, of } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ErrorNotificationService } from 'src/app/core/services/error-handler/error-notification.service';
@@ -88,6 +88,41 @@ describe('VideoSimpleEditorControlsComponent', () => {
     expect(() => component.buildRecipe()).toThrow(
       'O vídeo editado precisa ter pelo menos 5 segundos.'
     );
+  });
+
+  it('mantém cinco segundos entre as duas alças durante o arraste', () => {
+    const video = document.createElement('video');
+
+    component.form.patchValue({
+      trimStartMs: 29_000,
+      trimEndMs: 30_000,
+    });
+    component.onTrimStartInput(video);
+
+    expect(component.form.controls.trimStartMs.value).toBe(25_000);
+
+    component.form.patchValue({
+      trimStartMs: 20_000,
+      trimEndMs: 21_000,
+    });
+    component.onTrimEndInput(video);
+
+    expect(component.form.controls.trimEndMs.value).toBe(25_000);
+  });
+
+  it('calcula a faixa destacada e a duração resultante', async () => {
+    component.form.patchValue({
+      trimStartMs: 5_000,
+      trimEndMs: 20_000,
+    });
+
+    const timeline = await firstValueFrom(component.trimTimeline$);
+
+    expect(timeline.startMs).toBe(5_000);
+    expect(timeline.endMs).toBe(20_000);
+    expect(timeline.editedDurationMs).toBe(15_000);
+    expect(timeline.startPercent).toBeCloseTo(16.666, 2);
+    expect(timeline.endPercent).toBeCloseTo(66.666, 2);
   });
 
   it('captura a capa usando a proporção selecionada', () => {

--- a/src/app/media/videos/profile-videos/video-simple-editor-controls.component.ts
+++ b/src/app/media/videos/profile-videos/video-simple-editor-controls.component.ts
@@ -44,6 +44,15 @@ export interface IVideoSimpleEditorState {
   readonly error: string | null;
 }
 
+interface IVideoTrimTimelineState {
+  readonly durationMs: number;
+  readonly startMs: number;
+  readonly endMs: number;
+  readonly editedDurationMs: number;
+  readonly startPercent: number;
+  readonly endPercent: number;
+}
+
 const MIN_EDITED_DURATION_MS = 5_000;
 
 @Component({
@@ -113,9 +122,14 @@ export class VideoSimpleEditorControlsComponent {
     muteAudio: [false],
   });
 
+  readonly minimumEditedDurationMs = MIN_EDITED_DURATION_MS;
   readonly metadata$ = this.metadataSubject.asObservable();
   readonly loading$ = this.loadingSubject.asObservable();
   readonly capturingPoster$ = this.capturingPosterSubject.asObservable();
+
+  private readonly formValue$ = this.form.valueChanges.pipe(
+    startWith(this.form.getRawValue())
+  );
 
   readonly editorReady$: Observable<boolean> = this.metadata$.pipe(
     map((metadata) => !!(
@@ -130,24 +144,28 @@ export class VideoSimpleEditorControlsComponent {
 
   readonly recipeError$: Observable<string | null> = combineLatest([
     this.metadata$,
-    this.form.valueChanges.pipe(startWith(this.form.getRawValue())),
+    this.formValue$,
   ]).pipe(
     map(() => this.getValidationMessage()),
     distinctUntilChanged(),
     shareReplay({ bufferSize: 1, refCount: true })
   );
 
-  readonly editedDurationLabel$: Observable<string> = combineLatest([
+  readonly trimTimeline$: Observable<IVideoTrimTimelineState> = combineLatest([
     this.metadata$,
-    this.form.valueChanges.pipe(startWith(this.form.getRawValue())),
+    this.formValue$,
   ]).pipe(
-    map(([metadata]) => {
-      const durationMs = metadata?.durationMs ?? 0;
-      const raw = this.form.getRawValue();
-      const endMs = Math.min(durationMs, Number(raw.trimEndMs ?? durationMs));
-      const editedMs = Math.max(0, endMs - Number(raw.trimStartMs ?? 0));
-      return this.formatTime(editedMs);
-    }),
+    map(([metadata]) => this.buildTrimTimelineState(metadata?.durationMs ?? 0)),
+    distinctUntilChanged((previous, current) =>
+      previous.durationMs === current.durationMs &&
+      previous.startMs === current.startMs &&
+      previous.endMs === current.endMs
+    ),
+    shareReplay({ bufferSize: 1, refCount: true })
+  );
+
+  readonly editedDurationLabel$: Observable<string> = this.trimTimeline$.pipe(
+    map((timeline) => this.formatTime(timeline.editedDurationMs)),
     distinctUntilChanged()
   );
 
@@ -198,7 +216,7 @@ export class VideoSimpleEditorControlsComponent {
       this.fileSubject,
       this.metadataSubject,
       this.loadingSubject,
-      this.form.valueChanges.pipe(startWith(this.form.getRawValue())),
+      this.formValue$,
     ]).pipe(
       takeUntilDestroyed(this.destroyRef)
     ).subscribe(() => this.emitEditorState());
@@ -246,6 +264,58 @@ export class VideoSimpleEditorControlsComponent {
     };
   }
 
+  onTrimStartInput(video: HTMLVideoElement): void {
+    const durationMs = this.metadataSubject.value?.durationMs ?? 0;
+    if (!durationMs) {
+      return;
+    }
+
+    const requestedStartMs = this.normalizeMilliseconds(
+      this.form.controls.trimStartMs.value,
+      durationMs
+    );
+    const currentEndMs = this.normalizeMilliseconds(
+      this.form.controls.trimEndMs.value,
+      durationMs
+    );
+    const nextStartMs = Math.min(
+      requestedStartMs,
+      Math.max(0, currentEndMs - MIN_EDITED_DURATION_MS)
+    );
+
+    if (nextStartMs !== requestedStartMs) {
+      this.form.controls.trimStartMs.setValue(nextStartMs);
+    }
+
+    this.seekPreview(video, nextStartMs);
+  }
+
+  onTrimEndInput(video: HTMLVideoElement): void {
+    const durationMs = this.metadataSubject.value?.durationMs ?? 0;
+    if (!durationMs) {
+      return;
+    }
+
+    const currentStartMs = this.normalizeMilliseconds(
+      this.form.controls.trimStartMs.value,
+      durationMs
+    );
+    const requestedEndMs = this.normalizeMilliseconds(
+      this.form.controls.trimEndMs.value,
+      durationMs
+    );
+    const nextEndMs = Math.max(
+      requestedEndMs,
+      Math.min(durationMs, currentStartMs + MIN_EDITED_DURATION_MS)
+    );
+
+    if (nextEndMs !== requestedEndMs) {
+      this.form.controls.trimEndMs.setValue(nextEndMs);
+    }
+
+    this.seekPreview(video, nextEndMs);
+  }
+
   capturePoster(video: HTMLVideoElement): void {
     if (
       this.disabled ||
@@ -286,6 +356,44 @@ export class VideoSimpleEditorControlsComponent {
     const minutes = Math.floor(totalSeconds / 60);
     const seconds = totalSeconds % 60;
     return `${minutes}:${String(seconds).padStart(2, '0')}`;
+  }
+
+  private buildTrimTimelineState(durationMs: number): IVideoTrimTimelineState {
+    if (!durationMs) {
+      return {
+        durationMs: 0,
+        startMs: 0,
+        endMs: 0,
+        editedDurationMs: 0,
+        startPercent: 0,
+        endPercent: 100,
+      };
+    }
+
+    const raw = this.form.getRawValue();
+    const startMs = this.normalizeMilliseconds(raw.trimStartMs, durationMs);
+    const endMs = this.normalizeMilliseconds(raw.trimEndMs, durationMs);
+
+    return {
+      durationMs,
+      startMs,
+      endMs,
+      editedDurationMs: Math.max(0, endMs - startMs),
+      startPercent: (startMs / durationMs) * 100,
+      endPercent: (endMs / durationMs) * 100,
+    };
+  }
+
+  private normalizeMilliseconds(value: number, durationMs: number): number {
+    return Math.min(durationMs, Math.max(0, Math.trunc(Number(value))));
+  }
+
+  private seekPreview(video: HTMLVideoElement, milliseconds: number): void {
+    try {
+      video.currentTime = milliseconds / 1000;
+    } catch {
+      // Alguns navegadores recusam seek antes de concluir a leitura dos metadados.
+    }
   }
 
   private emitEditorState(): void {


### PR DESCRIPTION
## Dependência

Este PR é empilhado sobre o **#80** (`agent/fix-video-editor-disabled-state`). Não deve ser integrado isoladamente.

## Problema

O editor apresentava dois sliders separados para início e fim do corte. Embora funcional, esse desenho exigia mais leitura, ocupava mais espaço e era pouco intuitivo em telas pequenas.

## Solução

- substitui os dois sliders visuais por uma única linha do tempo com duas alças;
- destaca somente o trecho que será publicado;
- mostra início, duração resultante e fim em um único resumo;
- mantém o vídeo sincronizado com a alça arrastada;
- aplica o limite mínimo de 5 segundos durante o arraste;
- preserva navegação por teclado e `aria-valuetext` nos dois controles nativos;
- aumenta a área das alças em telas móveis;
- mantém a mesma receita de edição e o mesmo contrato de backend.

## Supressão consciente

Foram suprimidos apenas os dois blocos visuais independentes de slider (`Início` e `Fim`). Os dois `FormControl`s continuam existindo, agora sobrepostos na mesma linha do tempo. Nenhum campo da receita foi removido.

## Validação concluída

Head validado: `c360526547573b900dbc689a404af7482d8f7c41`.

- testes da linha do tempo e limite mínimo: aprovados;
- Angular tests: aprovados;
- Angular safe build: aprovado;
- build `dev-emu`: aprovado;
- Functions lint, build e testes: aprovados;
- Firestore Rules: aprovadas;
- Firestore indexes: aprovados;
- Angular CI Validation: aprovado;
- Quality Gate agregado: aprovado;
- Video Staging Contract: aprovado.

## Fora do escopo

- alteração do Transcoder;
- mudança de quota, upload ou publicação;
- edição de vídeos já publicados;
- merge ou deploy.

O PR permanece em rascunho, sem merge e sem deploy.