### PR TITLE
feat(video): refine and stabilize editor ui

### DIFF
--- a/src/app/media/videos/profile-videos/video-simple-editor-controls.component.css
+++ b/src/app/media/videos/profile-videos/video-simple-editor-controls.component.css
@@ -5,16 +5,31 @@
 
 .video-simple-editor {
   display: grid;
-  gap: 1rem;
+  gap: 0.9rem;
   min-width: 0;
 }
 
 .video-simple-editor__heading,
-.video-simple-editor__cover-tools {
+.video-simple-editor__panel-heading,
+.video-simple-editor__panel-title,
+.video-simple-editor__cover-tools,
+.video-simple-editor__option-row,
+.video-simple-editor__trim-footer,
+.video-simple-editor__note {
   display: flex;
   align-items: center;
+}
+
+.video-simple-editor__heading,
+.video-simple-editor__panel-heading,
+.video-simple-editor__cover-tools,
+.video-simple-editor__option-row,
+.video-simple-editor__trim-footer {
   justify-content: space-between;
-  gap: 0.75rem;
+}
+
+.video-simple-editor__heading {
+  gap: 1rem;
 }
 
 .video-simple-editor__heading h3 {
@@ -22,21 +37,38 @@
   font-size: 1rem;
 }
 
+.video-simple-editor__heading p {
+  margin: 0.25rem 0 0;
+  color: var(--text-muted, #aab3c2);
+  font-size: 0.76rem;
+}
+
 .video-simple-editor__eyebrow {
   color: var(--color-primary, #ff6f76);
-  font-size: 0.72rem;
+  font-size: 0.7rem;
   font-weight: 800;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
 .video-simple-editor__duration {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  min-height: 2rem;
+  border: 1px solid color-mix(in srgb, var(--color-primary, #ff6f76) 36%, transparent);
   border-radius: 999px;
+  background: rgba(255, 111, 118, 0.12);
   background: color-mix(in srgb, var(--color-primary, #ff6f76) 14%, transparent);
   padding: 0.35rem 0.65rem;
   font-size: 0.78rem;
-  font-weight: 700;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
   white-space: nowrap;
+}
+
+.video-simple-editor__duration i {
+  color: var(--color-primary, #ff6f76);
 }
 
 .video-simple-editor__stage {
@@ -45,9 +77,12 @@
   overflow: hidden;
   width: 100%;
   min-height: 16rem;
-  border: 1px solid var(--border-color, #2d3748);
-  border-radius: 0.9rem;
+  border: 1px solid color-mix(in srgb, var(--border-color, #2d3748) 84%, transparent);
+  border-radius: 1rem;
   background: #000;
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.015),
+    0 0.85rem 2.2rem rgba(0, 0, 0, 0.18);
 }
 
 .video-simple-editor__stage video {
@@ -75,46 +110,141 @@
   object-fit: cover;
 }
 
+.video-simple-editor__status {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0.75rem 0.85rem;
+  border: 1px solid color-mix(in srgb, var(--border-color, #2d3748) 72%, transparent);
+  border-radius: 0.75rem;
+  background: color-mix(in srgb, var(--surface-muted, #111923) 74%, transparent);
+  color: var(--text-muted, #aab3c2);
+  font-size: 0.76rem;
+  line-height: 1.45;
+}
+
 .video-simple-editor__controls {
   display: grid;
-  gap: 1rem;
+  gap: 0.72rem;
 }
 
 .video-simple-editor__controls fieldset {
-  display: grid;
-  gap: 0.8rem;
+  min-width: 0;
   margin: 0;
-  padding: 0;
-  border: 0;
 }
 
-.video-simple-editor__controls legend {
-  margin-bottom: 0.55rem;
+.video-simple-editor__panel {
+  display: grid;
+  gap: 0.85rem;
+  padding: 0.9rem;
+  border: 1px solid color-mix(in srgb, var(--border-color, #2d3748) 82%, transparent);
+  border-radius: 0.9rem;
+  background: rgba(17, 25, 35, 0.56);
+  background: color-mix(in srgb, var(--surface-muted, #111923) 62%, transparent);
+  transition:
+    border-color 160ms ease,
+    background-color 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.video-simple-editor__panel:focus-within {
+  border-color: color-mix(in srgb, var(--color-primary, #ff6f76) 52%, var(--border-color, #2d3748));
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-primary, #ff6f76) 10%, transparent);
+}
+
+.video-simple-editor__panel-heading,
+.video-simple-editor__panel-title,
+.video-simple-editor__cover-tools,
+.video-simple-editor__option-row,
+.video-simple-editor__trim-footer {
+  gap: 0.75rem;
+}
+
+.video-simple-editor__panel-title {
+  min-width: 0;
+}
+
+.video-simple-editor__panel-title > span:last-child {
+  display: grid;
+  gap: 0.12rem;
+  min-width: 0;
+}
+
+.video-simple-editor__panel-title strong {
   font-size: 0.84rem;
-  font-weight: 800;
 }
 
-.video-simple-editor__trim-fieldset {
-  padding: 0.85rem !important;
-  border: 1px solid color-mix(in srgb, var(--border-color, #2d3748) 80%, transparent) !important;
-  border-radius: 0.8rem;
-  background: color-mix(in srgb, var(--surface-muted, #111923) 55%, transparent);
+.video-simple-editor__panel-title small {
+  color: var(--text-muted, #aab3c2);
+  font-size: 0.72rem;
+  line-height: 1.35;
 }
 
-.video-simple-editor__trim-fieldset legend {
-  padding: 0 0.35rem;
+.video-simple-editor__step {
+  display: grid;
+  flex: 0 0 auto;
+  place-items: center;
+  width: 1.7rem;
+  height: 1.7rem;
+  border: 1px solid color-mix(in srgb, var(--color-primary, #ff6f76) 40%, transparent);
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--color-primary, #ff6f76) 12%, transparent);
+  color: var(--color-primary, #ff6f76);
+  font-size: 0.72rem;
+  font-weight: 900;
+}
+
+.video-simple-editor__reset-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.38rem;
+  min-height: 2rem;
+  border: 1px solid var(--border-color, #2d3748);
+  border-radius: 0.62rem;
+  background: transparent;
+  padding: 0.36rem 0.58rem;
+  color: inherit;
+  font: inherit;
+  font-size: 0.7rem;
+  font-weight: 750;
+  cursor: pointer;
+  transition:
+    border-color 150ms ease,
+    background-color 150ms ease,
+    opacity 150ms ease;
+}
+
+.video-simple-editor__reset-button:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--color-primary, #ff6f76) 58%, var(--border-color, #2d3748));
+  background: color-mix(in srgb, var(--color-primary, #ff6f76) 8%, transparent);
+}
+
+.video-simple-editor__reset-button:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--color-primary, #ff6f76) 38%, #fff);
+  outline-offset: 2px;
+}
+
+.video-simple-editor__reset-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.42;
 }
 
 .video-simple-editor__trim-summary {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0.5rem;
+  gap: 0.45rem;
 }
 
 .video-simple-editor__trim-summary span {
   display: grid;
-  gap: 0.15rem;
+  gap: 0.1rem;
   min-width: 0;
+  padding: 0.52rem 0.6rem;
+  border: 1px solid color-mix(in srgb, var(--border-color, #2d3748) 72%, transparent);
+  border-radius: 0.66rem;
+  background: color-mix(in srgb, var(--surface-color, #111923) 72%, transparent);
 }
 
 .video-simple-editor__trim-summary span:last-child {
@@ -122,41 +252,55 @@
 }
 
 .video-simple-editor__trim-summary-result {
+  border-color: color-mix(in srgb, var(--color-primary, #ff6f76) 34%, transparent) !important;
+  background: color-mix(in srgb, var(--color-primary, #ff6f76) 9%, transparent) !important;
   text-align: center;
 }
 
 .video-simple-editor__trim-summary small {
   color: var(--text-muted, #aab3c2);
-  font-size: 0.7rem;
+  font-size: 0.66rem;
 }
 
 .video-simple-editor__trim-summary strong {
-  font-size: 0.86rem;
+  font-size: 0.84rem;
   font-variant-numeric: tabular-nums;
+}
+
+.video-simple-editor__trim-summary-result strong {
+  color: var(--color-primary, #ff6f76);
 }
 
 .video-simple-editor__trim-timeline {
   position: relative;
-  min-height: 3.2rem;
-  touch-action: none;
+  min-height: 3.7rem;
+  touch-action: pan-y;
 }
 
 .video-simple-editor__trim-track {
   position: absolute;
-  inset-inline: 0.75rem;
+  inset-inline: 0.8rem;
   top: 50%;
-  height: 0.5rem;
+  height: 0.58rem;
   overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--border-color, #2d3748) 72%, transparent);
   border-radius: 999px;
-  background: color-mix(in srgb, var(--text-muted, #aab3c2) 24%, transparent);
+  background: color-mix(in srgb, var(--text-muted, #aab3c2) 18%, transparent);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.28);
   transform: translateY(-50%);
 }
 
 .video-simple-editor__trim-selection {
   position: absolute;
-  inset-block: 0;
+  inset-block: -1px;
+  min-width: 0.2rem;
   border-radius: inherit;
-  background: var(--color-primary, #ff6f76);
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--color-primary, #ff6f76) 78%, #fff),
+    var(--color-primary, #ff6f76)
+  );
+  box-shadow: 0 0 0.75rem color-mix(in srgb, var(--color-primary, #ff6f76) 22%, transparent);
 }
 
 .video-simple-editor__trim-range {
@@ -164,7 +308,7 @@
   inset: 0;
   z-index: 2;
   width: 100%;
-  height: 3.2rem;
+  height: 3.7rem;
   margin: 0;
   padding: 0;
   border: 0;
@@ -177,43 +321,51 @@
   z-index: 3;
 }
 
+.video-simple-editor__trim-range--active {
+  z-index: 5;
+}
+
 .video-simple-editor__trim-range::-webkit-slider-runnable-track {
-  height: 0.5rem;
+  height: 0.58rem;
   border: 0;
   background: transparent;
 }
 
 .video-simple-editor__trim-range::-webkit-slider-thumb {
-  width: 1.45rem;
-  height: 2.35rem;
-  margin-top: -0.92rem;
+  width: 1.38rem;
+  height: 2.7rem;
+  margin-top: -1.08rem;
   border: 2px solid var(--surface-color, #111923);
-  border-radius: 0.45rem;
+  border-radius: 0.5rem;
   background: var(--color-primary, #ff6f76);
-  box-shadow: 0 0 0 1px color-mix(in srgb, var(--color-primary, #ff6f76) 68%, #fff);
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--color-primary, #ff6f76) 68%, #fff),
+    0 0.35rem 0.8rem rgba(0, 0, 0, 0.32);
   appearance: none;
   cursor: grab;
   pointer-events: auto;
 }
 
 .video-simple-editor__trim-range::-moz-range-track {
-  height: 0.5rem;
+  height: 0.58rem;
   border: 0;
   background: transparent;
 }
 
 .video-simple-editor__trim-range::-moz-range-progress {
-  height: 0.5rem;
+  height: 0.58rem;
   background: transparent;
 }
 
 .video-simple-editor__trim-range::-moz-range-thumb {
-  width: 1.45rem;
-  height: 2.35rem;
+  width: 1.38rem;
+  height: 2.7rem;
   border: 2px solid var(--surface-color, #111923);
-  border-radius: 0.45rem;
+  border-radius: 0.5rem;
   background: var(--color-primary, #ff6f76);
-  box-shadow: 0 0 0 1px color-mix(in srgb, var(--color-primary, #ff6f76) 68%, #fff);
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--color-primary, #ff6f76) 68%, #fff),
+    0 0.35rem 0.8rem rgba(0, 0, 0, 0.32);
   cursor: grab;
   pointer-events: auto;
 }
@@ -224,12 +376,12 @@
 }
 
 .video-simple-editor__trim-range:focus-visible::-webkit-slider-thumb {
-  outline: 3px solid color-mix(in srgb, var(--color-primary, #ff6f76) 44%, #fff);
+  outline: 3px solid color-mix(in srgb, var(--color-primary, #ff6f76) 46%, #fff);
   outline-offset: 3px;
 }
 
 .video-simple-editor__trim-range:focus-visible::-moz-range-thumb {
-  outline: 3px solid color-mix(in srgb, var(--color-primary, #ff6f76) 44%, #fff);
+  outline: 3px solid color-mix(in srgb, var(--color-primary, #ff6f76) 46%, #fff);
   outline-offset: 3px;
 }
 
@@ -242,8 +394,262 @@
 .video-simple-editor__trim-help {
   margin: 0;
   color: var(--text-muted, #aab3c2);
+  font-size: 0.7rem;
+  line-height: 1.4;
+}
+
+.video-simple-editor__minimum-badge {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--text-muted, #aab3c2) 10%, transparent);
+  padding: 0.22rem 0.45rem;
+  color: var(--text-muted, #aab3c2);
+  font-size: 0.65rem;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.video-simple-editor__aspect-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.52rem;
+}
+
+.video-simple-editor__aspect-option {
+  position: relative;
+  display: grid;
+  grid-template-columns: 2rem minmax(0, 1fr);
+  align-items: center;
+  gap: 0.58rem;
+  min-height: 3.8rem;
+  padding: 0.65rem;
+  border: 1px solid color-mix(in srgb, var(--border-color, #2d3748) 84%, transparent);
+  border-radius: 0.72rem;
+  background: color-mix(in srgb, var(--surface-color, #111923) 64%, transparent);
+  cursor: pointer;
+  transition:
+    border-color 150ms ease,
+    background-color 150ms ease,
+    transform 150ms ease,
+    box-shadow 150ms ease;
+}
+
+.video-simple-editor__aspect-option:hover {
+  border-color: color-mix(in srgb, var(--color-primary, #ff6f76) 38%, var(--border-color, #2d3748));
+  transform: translateY(-1px);
+}
+
+.video-simple-editor__aspect-option:focus-within {
+  outline: 3px solid color-mix(in srgb, var(--color-primary, #ff6f76) 34%, #fff);
+  outline-offset: 2px;
+}
+
+.video-simple-editor__aspect-option input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.video-simple-editor__aspect-option--selected {
+  border-color: var(--color-primary, #ff6f76);
+  background: color-mix(in srgb, var(--color-primary, #ff6f76) 9%, transparent);
+  box-shadow: 0 0 0 1px var(--color-primary, #ff6f76);
+}
+
+.video-simple-editor__aspect-preview {
+  display: grid;
+  place-items: center;
+  width: 1.85rem;
+  height: 1.85rem;
+}
+
+.video-simple-editor__aspect-preview::before {
+  content: '';
+  display: block;
+  border: 2px solid currentColor;
+  border-radius: 0.2rem;
+  color: var(--text-muted, #aab3c2);
+}
+
+.video-simple-editor__aspect-preview[data-ratio='ORIGINAL']::before {
+  width: 1.65rem;
+  height: 1.05rem;
+}
+
+.video-simple-editor__aspect-preview[data-ratio='VERTICAL_9_16']::before {
+  width: 0.78rem;
+  height: 1.45rem;
+}
+
+.video-simple-editor__aspect-preview[data-ratio='PORTRAIT_4_5']::before {
+  width: 1.05rem;
+  height: 1.35rem;
+}
+
+.video-simple-editor__aspect-preview[data-ratio='SQUARE_1_1']::before {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.video-simple-editor__aspect-option--selected .video-simple-editor__aspect-preview::before {
+  color: var(--color-primary, #ff6f76);
+}
+
+.video-simple-editor__aspect-copy {
+  display: grid;
+  gap: 0.08rem;
+  min-width: 0;
+}
+
+.video-simple-editor__aspect-copy strong {
+  font-size: 0.78rem;
+}
+
+.video-simple-editor__aspect-copy small {
+  overflow: hidden;
+  color: var(--text-muted, #aab3c2);
+  font-size: 0.66rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.video-simple-editor__aspect-option > i {
+  position: absolute;
+  top: 0.42rem;
+  right: 0.42rem;
+  display: grid;
+  place-items: center;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  background: var(--color-primary, #ff6f76);
+  color: #111923;
+  font-size: 0.55rem;
+  opacity: 0;
+  transform: scale(0.72);
+  transition:
+    opacity 150ms ease,
+    transform 150ms ease;
+}
+
+.video-simple-editor__aspect-option--selected > i {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.video-simple-editor__option-row {
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.video-simple-editor__switch {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+}
+
+.video-simple-editor__switch input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+}
+
+.video-simple-editor__switch-track {
+  position: relative;
+  display: block;
+  width: 2.8rem;
+  height: 1.55rem;
+  border: 1px solid var(--border-color, #2d3748);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--text-muted, #aab3c2) 18%, transparent);
+  transition:
+    border-color 160ms ease,
+    background-color 160ms ease;
+}
+
+.video-simple-editor__switch-thumb {
+  position: absolute;
+  top: 50%;
+  left: 0.18rem;
+  width: 1.05rem;
+  height: 1.05rem;
+  border-radius: 50%;
+  background: var(--text-muted, #aab3c2);
+  box-shadow: 0 0.18rem 0.45rem rgba(0, 0, 0, 0.34);
+  transform: translateY(-50%);
+  transition:
+    left 160ms ease,
+    background-color 160ms ease;
+}
+
+.video-simple-editor__switch input:checked + .video-simple-editor__switch-track {
+  border-color: var(--color-primary, #ff6f76);
+  background: color-mix(in srgb, var(--color-primary, #ff6f76) 34%, transparent);
+}
+
+.video-simple-editor__switch input:checked + .video-simple-editor__switch-track .video-simple-editor__switch-thumb {
+  left: 1.47rem;
+  background: var(--color-primary, #ff6f76);
+}
+
+.video-simple-editor__switch input:focus-visible + .video-simple-editor__switch-track {
+  outline: 3px solid color-mix(in srgb, var(--color-primary, #ff6f76) 38%, #fff);
+  outline-offset: 3px;
+}
+
+.video-simple-editor__switch input:disabled + .video-simple-editor__switch-track {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.video-simple-editor__cover-tools {
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.video-simple-editor__cover-tools button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  min-height: 2.35rem;
+  white-space: nowrap;
+}
+
+.video-simple-editor__error {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin: 0;
+  color: var(--color-danger, #ff6b7a);
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.video-simple-editor__note {
+  gap: 0.6rem;
+  margin: 0;
+  padding: 0.72rem 0.78rem;
+  border-radius: 0.72rem;
+  background: color-mix(in srgb, var(--surface-muted, #111923) 78%, transparent);
+  color: var(--text-muted, #aab3c2);
+  font-size: 0.72rem;
+  line-height: 1.4;
+}
+
+.video-simple-editor__note i {
+  color: var(--color-primary, #ff6f76);
+}
+
+.video-simple-editor__note span {
+  display: grid;
+  gap: 0.05rem;
+}
+
+.video-simple-editor__note strong {
+  color: inherit;
   font-size: 0.73rem;
-  line-height: 1.45;
 }
 
 .video-simple-editor__sr-only {
@@ -258,126 +664,97 @@
   white-space: nowrap;
 }
 
-.video-simple-editor__aspect-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.55rem;
-}
-
-.video-simple-editor__aspect-option {
-  position: relative;
-  display: grid;
-  gap: 0.12rem;
-  min-height: 3.7rem;
-  padding: 0.7rem;
-  border: 1px solid var(--border-color, #2d3748);
-  border-radius: 0.75rem;
-  cursor: pointer;
-}
-
-.video-simple-editor__aspect-option input {
-  position: absolute;
-  inset: 0;
-  opacity: 0;
-  cursor: pointer;
-}
-
-.video-simple-editor__aspect-option--selected {
-  border-color: var(--color-primary, #ff6f76);
-  box-shadow: 0 0 0 1px var(--color-primary, #ff6f76);
-}
-
-.video-simple-editor__aspect-option strong,
-.video-simple-editor__aspect-option small {
-  pointer-events: none;
-}
-
-.video-simple-editor__aspect-option small,
-.video-simple-editor__cover-tools small,
-.video-simple-editor__note,
-.video-simple-editor__status {
-  color: var(--text-muted, #aab3c2);
-  font-size: 0.76rem;
-  line-height: 1.45;
-}
-
-.video-simple-editor__toggles label {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.65rem;
-  cursor: pointer;
-}
-
-.video-simple-editor__toggles input {
-  margin-top: 0.2rem;
-  accent-color: var(--color-primary, #ff6f76);
-}
-
-.video-simple-editor__toggles span,
-.video-simple-editor__cover-tools > div {
-  display: grid;
-  gap: 0.12rem;
-}
-
-.video-simple-editor__cover-tools {
-  align-items: flex-end;
-  padding-top: 0.25rem;
-}
-
-.video-simple-editor__error,
-.video-simple-editor__status,
-.video-simple-editor__note {
-  margin: 0;
-}
-
-.video-simple-editor__error {
-  display: flex;
-  align-items: center;
-  gap: 0.45rem;
-  color: var(--color-danger, #ff6b7a);
-  font-size: 0.8rem;
-  font-weight: 700;
-}
-
-.video-simple-editor__note {
-  padding: 0.75rem;
-  border-radius: 0.7rem;
-  background: color-mix(in srgb, var(--surface-muted, #111923) 82%, transparent);
-}
-
 @media (min-width: 44rem) {
   .video-simple-editor__aspect-grid {
     grid-template-columns: repeat(4, minmax(0, 1fr));
   }
+
+  .video-simple-editor__aspect-option {
+    grid-template-columns: 1fr;
+    justify-items: center;
+    min-height: 5.3rem;
+    text-align: center;
+  }
 }
 
-@media (max-width: 32rem) {
-  .video-simple-editor__heading,
+@media (max-width: 40rem) {
+  .video-simple-editor__panel-heading,
   .video-simple-editor__cover-tools {
     align-items: stretch;
     flex-direction: column;
   }
 
-  .video-simple-editor__duration {
-    width: fit-content;
+  .video-simple-editor__reset-button,
+  .video-simple-editor__cover-tools button {
+    width: 100%;
+  }
+}
+
+@media (max-width: 32rem) {
+  .video-simple-editor__heading {
+    align-items: flex-start;
   }
 
-  .video-simple-editor__trim-fieldset {
-    padding-inline: 0.7rem !important;
+  .video-simple-editor__duration {
+    min-height: 1.8rem;
+    padding-inline: 0.52rem;
+  }
+
+  .video-simple-editor__panel {
+    padding: 0.78rem;
+  }
+
+  .video-simple-editor__trim-summary {
+    gap: 0.32rem;
+  }
+
+  .video-simple-editor__trim-summary span {
+    padding: 0.45rem;
   }
 
   .video-simple-editor__trim-range::-webkit-slider-thumb {
-    width: 1.65rem;
-    height: 2.55rem;
-    margin-top: -1.02rem;
+    width: 1.6rem;
+    height: 2.9rem;
+    margin-top: -1.18rem;
   }
 
   .video-simple-editor__trim-range::-moz-range-thumb {
-    width: 1.65rem;
-    height: 2.55rem;
+    width: 1.6rem;
+    height: 2.9rem;
   }
 
-  .video-simple-editor__cover-tools button {
-    width: 100%;
+  .video-simple-editor__trim-footer {
+    align-items: flex-start;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .video-simple-editor__panel,
+  .video-simple-editor__reset-button,
+  .video-simple-editor__aspect-option,
+  .video-simple-editor__aspect-option > i,
+  .video-simple-editor__switch-track,
+  .video-simple-editor__switch-thumb {
+    transition: none;
+  }
+}
+
+@media (forced-colors: active) {
+  .video-simple-editor__panel,
+  .video-simple-editor__trim-summary span,
+  .video-simple-editor__aspect-option,
+  .video-simple-editor__switch-track,
+  .video-simple-editor__trim-track {
+    border: 1px solid CanvasText;
+  }
+
+  .video-simple-editor__trim-selection,
+  .video-simple-editor__trim-range::-webkit-slider-thumb,
+  .video-simple-editor__trim-range::-moz-range-thumb,
+  .video-simple-editor__switch input:checked + .video-simple-editor__switch-track,
+  .video-simple-editor__aspect-option--selected > i {
+    forced-color-adjust: none;
+    background: Highlight;
+    color: HighlightText;
   }
 }

--- a/src/app/media/videos/profile-videos/video-simple-editor-controls.component.html
+++ b/src/app/media/videos/profile-videos/video-simple-editor-controls.component.html
@@ -14,10 +14,15 @@
     <div>
       <span class="video-simple-editor__eyebrow">Edição básica</span>
       <h3 id="video-simple-editor-title">Prepare o vídeo</h3>
+      <p>Faça ajustes rápidos antes do envio.</p>
     </div>
-    @if (metadata?.durationMs) {
-      <span class="video-simple-editor__duration">
-        Resultado: {{ editedDurationLabel$ | async }}
+    @if (timeline?.durationMs) {
+      <span
+        class="video-simple-editor__duration"
+        [attr.aria-label]="'Duração selecionada: ' + formatTime(timeline!.editedDurationMs)"
+      >
+        <i class="fas fa-scissors" aria-hidden="true"></i>
+        {{ formatTime(timeline!.editedDurationMs) }}
       </span>
     }
   </div>
@@ -42,10 +47,12 @@
 
     @if (loading) {
       <p class="video-simple-editor__status" role="status" aria-live="polite">
+        <i class="fas fa-spinner fa-spin" aria-hidden="true"></i>
         Lendo duração e dimensões do arquivo...
       </p>
     } @else if (!editorReady) {
       <p class="video-simple-editor__status" role="status" aria-live="polite">
+        <i class="fas fa-circle-info" aria-hidden="true"></i>
         A prévia não está disponível neste navegador. O arquivo original ainda pode ser enviado e convertido no backend, sem edição local.
       </p>
     } @else {
@@ -54,23 +61,39 @@
         [formGroup]="form"
         [attr.aria-disabled]="disabled ? 'true' : null"
       >
-        <fieldset class="video-simple-editor__trim-fieldset">
-          <legend>Cortar vídeo</legend>
+        <fieldset class="video-simple-editor__panel video-simple-editor__trim-fieldset">
+          <legend class="video-simple-editor__sr-only">Cortar vídeo</legend>
+
+          <div class="video-simple-editor__panel-heading">
+            <div class="video-simple-editor__panel-title">
+              <span class="video-simple-editor__step" aria-hidden="true">1</span>
+              <span>
+                <strong>Cortar vídeo</strong>
+                <small>Escolha o trecho que será publicado.</small>
+              </span>
+            </div>
+            <button
+              type="button"
+              class="video-simple-editor__reset-button"
+              [disabled]="disabled || (hasTrim$ | async) !== true"
+              (click)="resetTrim(uploadPreview)"
+            >
+              <i class="fas fa-rotate-left" aria-hidden="true"></i>
+              Usar vídeo inteiro
+            </button>
+          </div>
 
           @if (timeline) {
             <div
               id="video-trim-summary"
               class="video-simple-editor__trim-summary"
-              role="status"
-              aria-live="polite"
-              aria-atomic="true"
             >
               <span>
                 <small>Início</small>
                 <strong>{{ formatTime(timeline.startMs) }}</strong>
               </span>
               <span class="video-simple-editor__trim-summary-result">
-                <small>Resultado</small>
+                <small>Trecho final</small>
                 <strong>{{ formatTime(timeline.editedDurationMs) }}</strong>
               </span>
               <span>
@@ -79,7 +102,11 @@
               </span>
             </div>
 
-            <div class="video-simple-editor__trim-timeline">
+            <div
+              class="video-simple-editor__trim-timeline"
+              [class.video-simple-editor__trim-timeline--start-active]="activeTrimHandle === 'start'"
+              [class.video-simple-editor__trim-timeline--end-active]="activeTrimHandle === 'end'"
+            >
               <div class="video-simple-editor__trim-track" aria-hidden="true">
                 <span
                   class="video-simple-editor__trim-selection"
@@ -94,6 +121,7 @@
               <input
                 id="video-trim-start"
                 class="video-simple-editor__trim-range video-simple-editor__trim-range--start"
+                [class.video-simple-editor__trim-range--active]="activeTrimHandle === 'start'"
                 type="range"
                 formControlName="trimStartMs"
                 min="0"
@@ -101,6 +129,8 @@
                 [max]="metadata!.durationMs! - minimumEditedDurationMs"
                 [attr.aria-valuetext]="'Início em ' + formatTime(timeline.startMs)"
                 aria-describedby="video-trim-summary video-trim-help"
+                (pointerdown)="setActiveTrimHandle('start')"
+                (focus)="setActiveTrimHandle('start')"
                 (input)="onTrimStartInput(uploadPreview)"
               />
 
@@ -110,6 +140,7 @@
               <input
                 id="video-trim-end"
                 class="video-simple-editor__trim-range video-simple-editor__trim-range--end"
+                [class.video-simple-editor__trim-range--active]="activeTrimHandle === 'end'"
                 type="range"
                 formControlName="trimEndMs"
                 [min]="minimumEditedDurationMs"
@@ -117,18 +148,40 @@
                 [max]="metadata!.durationMs!"
                 [attr.aria-valuetext]="'Fim em ' + formatTime(timeline.endMs)"
                 aria-describedby="video-trim-summary video-trim-help"
+                (pointerdown)="setActiveTrimHandle('end')"
+                (focus)="setActiveTrimHandle('end')"
                 (input)="onTrimEndInput(uploadPreview)"
               />
             </div>
 
-            <p id="video-trim-help" class="video-simple-editor__trim-help">
-              Arraste as duas alças na mesma linha. O trecho destacado será publicado e terá no mínimo 5 segundos.
-            </p>
+            <div class="video-simple-editor__trim-footer">
+              <p id="video-trim-help" class="video-simple-editor__trim-help">
+                Arraste as alças. O trecho destacado será publicado.
+              </p>
+              <span class="video-simple-editor__minimum-badge">Mín. 5 s</span>
+            </div>
+
+            @if (trimAnnouncement$ | async; as trimAnnouncement) {
+              <p class="video-simple-editor__sr-only" aria-live="polite" aria-atomic="true">
+                {{ trimAnnouncement }}
+              </p>
+            }
           }
         </fieldset>
 
-        <fieldset>
-          <legend>Enquadramento</legend>
+        <fieldset class="video-simple-editor__panel">
+          <legend class="video-simple-editor__sr-only">Formato do vídeo</legend>
+
+          <div class="video-simple-editor__panel-heading">
+            <div class="video-simple-editor__panel-title">
+              <span class="video-simple-editor__step" aria-hidden="true">2</span>
+              <span>
+                <strong>Formato</strong>
+                <small>Escolha como o vídeo ocupará a tela.</small>
+              </span>
+            </div>
+          </div>
+
           <div class="video-simple-editor__aspect-grid">
             @for (option of aspectOptions; track option.value) {
               <label
@@ -140,30 +193,46 @@
                   formControlName="aspectRatio"
                   [value]="option.value"
                 />
-                <strong>{{ option.label }}</strong>
-                <small>{{ option.hint }}</small>
+                <span
+                  class="video-simple-editor__aspect-preview"
+                  [attr.data-ratio]="option.value"
+                  aria-hidden="true"
+                ></span>
+                <span class="video-simple-editor__aspect-copy">
+                  <strong>{{ option.label }}</strong>
+                  <small>{{ option.hint }}</small>
+                </span>
+                <i class="fas fa-check" aria-hidden="true"></i>
               </label>
             }
           </div>
         </fieldset>
 
-        <div class="video-simple-editor__toggles">
-          <label>
-            <input
-              type="checkbox"
-              formControlName="muteAudio"
-            />
+        <div class="video-simple-editor__panel video-simple-editor__option-row">
+          <div class="video-simple-editor__panel-title">
+            <span class="video-simple-editor__step" aria-hidden="true">3</span>
             <span>
-              <strong>Remover áudio</strong>
-              <small>O vídeo será publicado sem faixa sonora.</small>
+              <strong>Áudio</strong>
+              <small>Retire o som do vídeo final.</small>
+            </span>
+          </div>
+
+          <label class="video-simple-editor__switch">
+            <span class="video-simple-editor__sr-only">Remover áudio</span>
+            <input type="checkbox" formControlName="muteAudio" />
+            <span class="video-simple-editor__switch-track" aria-hidden="true">
+              <span class="video-simple-editor__switch-thumb"></span>
             </span>
           </label>
         </div>
 
-        <div class="video-simple-editor__cover-tools">
-          <div>
-            <strong>Capa</strong>
-            <small>Posicione a reprodução no quadro desejado.</small>
+        <div class="video-simple-editor__panel video-simple-editor__cover-tools">
+          <div class="video-simple-editor__panel-title">
+            <span class="video-simple-editor__step" aria-hidden="true">4</span>
+            <span>
+              <strong>Capa do vídeo</strong>
+              <small>Pause no quadro que deverá representar o vídeo.</small>
+            </span>
           </div>
           <button
             type="button"
@@ -172,7 +241,14 @@
             [attr.aria-busy]="capturingPoster ? 'true' : 'false'"
             (click)="capturePoster(uploadPreview)"
           >
-            {{ capturingPoster ? 'Gerando...' : 'Usar quadro atual' }}
+            <i
+              class="fas"
+              [class.fa-spinner]="capturingPoster"
+              [class.fa-spin]="capturingPoster"
+              [class.fa-camera]="!capturingPoster"
+              aria-hidden="true"
+            ></i>
+            {{ capturingPoster ? 'Gerando capa...' : 'Usar quadro atual' }}
           </button>
         </div>
       </form>
@@ -187,6 +263,10 @@
   }
 
   <p class="video-simple-editor__note">
-    A edição é não destrutiva. O arquivo original permanece privado e o corte, o enquadramento e o áudio são aplicados durante o processamento.
+    <i class="fas fa-shield-halved" aria-hidden="true"></i>
+    <span>
+      <strong>Edição não destrutiva</strong>
+      Seu arquivo original permanece privado e sem alterações.
+    </span>
   </p>
 </section>

--- a/src/app/media/videos/profile-videos/video-simple-editor-controls.component.spec.ts
+++ b/src/app/media/videos/profile-videos/video-simple-editor-controls.component.spec.ts
@@ -100,6 +100,7 @@ describe('VideoSimpleEditorControlsComponent', () => {
     component.onTrimStartInput(video);
 
     expect(component.form.controls.trimStartMs.value).toBe(25_000);
+    expect(component.activeTrimHandle).toBe('start');
 
     component.form.patchValue({
       trimStartMs: 20_000,
@@ -108,6 +109,7 @@ describe('VideoSimpleEditorControlsComponent', () => {
     component.onTrimEndInput(video);
 
     expect(component.form.controls.trimEndMs.value).toBe(25_000);
+    expect(component.activeTrimHandle).toBe('end');
   });
 
   it('calcula a faixa destacada e a duração resultante', async () => {
@@ -123,6 +125,31 @@ describe('VideoSimpleEditorControlsComponent', () => {
     expect(timeline.editedDurationMs).toBe(15_000);
     expect(timeline.startPercent).toBeCloseTo(16.666, 2);
     expect(timeline.endPercent).toBeCloseTo(66.666, 2);
+  });
+
+  it('informa quando existe corte e restaura o vídeo inteiro', async () => {
+    const video = document.createElement('video');
+    component.form.patchValue({
+      trimStartMs: 5_000,
+      trimEndMs: 20_000,
+    });
+
+    expect(await firstValueFrom(component.hasTrim$)).toBe(true);
+
+    component.resetTrim(video);
+
+    expect(component.form.controls.trimStartMs.value).toBe(0);
+    expect(component.form.controls.trimEndMs.value).toBe(30_000);
+    expect(component.activeTrimHandle).toBe('end');
+    expect(component.buildRecipe().trimEndMs).toBeNull();
+  });
+
+  it('mantém a alça focada acima da outra quando elas ficam próximas', () => {
+    component.setActiveTrimHandle('start');
+    expect(component.activeTrimHandle).toBe('start');
+
+    component.setActiveTrimHandle('end');
+    expect(component.activeTrimHandle).toBe('end');
   });
 
   it('captura a capa usando a proporção selecionada', () => {

--- a/src/app/media/videos/profile-videos/video-simple-editor-controls.component.ts
+++ b/src/app/media/videos/profile-videos/video-simple-editor-controls.component.ts
@@ -17,6 +17,7 @@ import {
   of,
 } from 'rxjs';
 import {
+  auditTime,
   catchError,
   distinctUntilChanged,
   finalize,
@@ -53,6 +54,8 @@ interface IVideoTrimTimelineState {
   readonly endPercent: number;
 }
 
+type TVideoTrimHandle = 'start' | 'end';
+
 const MIN_EDITED_DURATION_MS = 5_000;
 
 @Component({
@@ -75,6 +78,7 @@ export class VideoSimpleEditorControlsComponent {
   private readonly loadingSubject = new BehaviorSubject(false);
   private readonly capturingPosterSubject = new BehaviorSubject(false);
   private disabledValue = false;
+  private activeTrimHandleValue: TVideoTrimHandle = 'end';
 
   @Input()
   set file(value: File | null) {
@@ -111,6 +115,10 @@ export class VideoSimpleEditorControlsComponent {
     return this.disabledValue;
   }
 
+  get activeTrimHandle(): TVideoTrimHandle {
+    return this.activeTrimHandleValue;
+  }
+
   @Output() readonly posterChange = new EventEmitter<Blob | null>();
   @Output() readonly stateChange =
     new EventEmitter<IVideoSimpleEditorState>();
@@ -128,7 +136,8 @@ export class VideoSimpleEditorControlsComponent {
   readonly capturingPoster$ = this.capturingPosterSubject.asObservable();
 
   private readonly formValue$ = this.form.valueChanges.pipe(
-    startWith(this.form.getRawValue())
+    startWith(this.form.getRawValue()),
+    shareReplay({ bufferSize: 1, refCount: true })
   );
 
   readonly editorReady$: Observable<boolean> = this.metadata$.pipe(
@@ -166,6 +175,24 @@ export class VideoSimpleEditorControlsComponent {
 
   readonly editedDurationLabel$: Observable<string> = this.trimTimeline$.pipe(
     map((timeline) => this.formatTime(timeline.editedDurationMs)),
+    distinctUntilChanged()
+  );
+
+  readonly hasTrim$: Observable<boolean> = this.trimTimeline$.pipe(
+    map((timeline) =>
+      timeline.durationMs > 0 &&
+      (timeline.startMs > 0 || timeline.endMs < timeline.durationMs)
+    ),
+    distinctUntilChanged()
+  );
+
+  readonly trimAnnouncement$: Observable<string> = this.trimTimeline$.pipe(
+    auditTime(250),
+    map((timeline) =>
+      `Trecho selecionado de ${this.formatTime(timeline.startMs)} até ` +
+      `${this.formatTime(timeline.endMs)}, com ` +
+      `${this.formatTime(timeline.editedDurationMs)} de duração.`
+    ),
     distinctUntilChanged()
   );
 
@@ -264,7 +291,13 @@ export class VideoSimpleEditorControlsComponent {
     };
   }
 
+  setActiveTrimHandle(handle: TVideoTrimHandle): void {
+    this.activeTrimHandleValue = handle;
+  }
+
   onTrimStartInput(video: HTMLVideoElement): void {
+    this.setActiveTrimHandle('start');
+
     const durationMs = this.metadataSubject.value?.durationMs ?? 0;
     if (!durationMs) {
       return;
@@ -291,6 +324,8 @@ export class VideoSimpleEditorControlsComponent {
   }
 
   onTrimEndInput(video: HTMLVideoElement): void {
+    this.setActiveTrimHandle('end');
+
     const durationMs = this.metadataSubject.value?.durationMs ?? 0;
     if (!durationMs) {
       return;
@@ -314,6 +349,20 @@ export class VideoSimpleEditorControlsComponent {
     }
 
     this.seekPreview(video, nextEndMs);
+  }
+
+  resetTrim(video: HTMLVideoElement): void {
+    const durationMs = this.metadataSubject.value?.durationMs ?? 0;
+    if (!durationMs || this.disabled) {
+      return;
+    }
+
+    this.activeTrimHandleValue = 'end';
+    this.form.patchValue({
+      trimStartMs: 0,
+      trimEndMs: durationMs,
+    });
+    this.seekPreview(video, 0);
   }
 
   capturePoster(video: HTMLVideoElement): void {
@@ -390,6 +439,9 @@ export class VideoSimpleEditorControlsComponent {
 
   private seekPreview(video: HTMLVideoElement, milliseconds: number): void {
     try {
+      if (!video.paused) {
+        video.pause();
+      }
       video.currentTime = milliseconds / 1000;
     } catch {
       // Alguns navegadores recusam seek antes de concluir a leitura dos metadados.
@@ -470,6 +522,7 @@ export class VideoSimpleEditorControlsComponent {
   }
 
   private resetForm(): void {
+    this.activeTrimHandleValue = 'end';
     this.metadataSubject.next(null);
     this.form.reset({
       trimStartMs: 0,


### PR DESCRIPTION
## Dependência

Este PR é empilhado sobre o **#81** (`agent/simplify-video-trim-timeline`). Não deve ser integrado isoladamente.

## Objetivo

Refinar a interface do editor básico e estabilizar o comportamento da linha do tempo sem alterar a receita de edição, upload, quota, publicação ou processamento.

## Melhorias de estabilidade

- prioriza visualmente a alça que recebeu foco ou toque quando as duas ficam próximas;
- pausa a prévia no quadro correspondente durante o ajuste;
- preserva o scroll vertical no mobile com `touch-action: pan-y`;
- limita anúncios para leitores de tela a quatro atualizações por segundo;
- adiciona `Usar vídeo inteiro` sem recriar arquivo, prévia ou formulário;
- compartilha o stream de valores do formulário para evitar assinaturas redundantes;
- mantém o limite mínimo de cinco segundos durante o arraste.

## Refinamento visual

- organiza a edição em quatro etapas: corte, formato, áudio e capa;
- reduz ruído e melhora hierarquia de títulos e textos auxiliares;
- apresenta início, trecho final e fim em cartões compactos;
- representa proporções com miniaturas visuais;
- transforma remoção de áudio em switch acessível;
- melhora estados de foco, hover, seleção, bloqueio e carregamento;
- adapta ações e alças para telas pequenas;
- adiciona suporte a `prefers-reduced-motion` e `forced-colors`;
- reduz a nota de edição não destrutiva a um aviso compacto.

## Acessibilidade

- mantém os dois ranges nativos e sua navegação por teclado;
- preserva `aria-valuetext` e descrições do corte;
- remove anúncios excessivos da área visível e usa uma região viva controlada;
- mantém foco evidente em controles, opções de formato e switch;
- não usa cor como único indicador de formato selecionado.

## Supressões conscientes

Foram substituídos os blocos visuais simples de formato, áudio, capa e nota pelo novo conjunto de painéis. Nenhuma funcionalidade foi removida. Os mesmos `FormControl`s, métodos públicos e campos da receita continuam ativos.

Também foi suprimido `touch-action: none` da linha do tempo, pois bloqueava a rolagem vertical da página em celulares. Foi substituído por `touch-action: pan-y`.

## Validação concluída

Head validado: `45364fcbad54ef62cc56d8afaaaefd45c2fac1ae`.

- testes de prioridade das alças: aprovados;
- teste de restauração do vídeo inteiro: aprovado;
- testes de corte mínimo e receita: aprovados;
- Angular tests: aprovados;
- Angular safe build: aprovado;
- build `dev-emu`: aprovado;
- Functions lint, build e testes: aprovados;
- Firestore Rules: aprovadas;
- Firestore indexes: aprovados;
- Angular CI Validation: aprovado;
- Quality Gate agregado: aprovado;
- Video Staging Contract: aprovado.

## Fora do escopo

- mudança no Transcoder;
- alteração da receita de edição;
- upload, quota ou publicação;
- edição de vídeos publicados;
- merge ou deploy.

O PR permanece em rascunho, sem merge e sem deploy.