### PR TITLE
Aprimora hierarquia e uniformidade da biblioteca de vídeos

### DIFF
--- a/src/app/media/videos/profile-videos/profile-videos-settings.component.css
+++ b/src/app/media/videos/profile-videos/profile-videos-settings.component.css
@@ -1,5 +1,7 @@
 .profile-videos__description {
+  display: -webkit-box;
   margin: 0;
+  overflow: hidden;
   color: color-mix(
     in oklab,
     var(--text-color, #f5f7fb) 74%,
@@ -8,6 +10,12 @@
   font-size: 0.88rem;
   line-height: 1.5;
   overflow-wrap: anywhere;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.profile-videos__description-slot {
+  min-height: 2.64rem;
 }
 
 .profile-videos__settings-form {
@@ -121,6 +129,135 @@
   flex: 1 1 120px;
 }
 
+.profile-videos__header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
+}
+
+.profile-videos__upload-disclosure {
+  min-width: 0;
+  justify-self: end;
+}
+
+.profile-videos__upload-disclosure[open] {
+  display: grid;
+  grid-column: 1 / -1;
+  width: 100%;
+  justify-self: stretch;
+}
+
+.profile-videos__upload-summary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 9px;
+  min-height: 44px;
+  padding: 9px 13px;
+  border: 1px solid color-mix(
+    in oklab,
+    var(--surface-border, rgb(255 255 255 / 12%)) 88%,
+    transparent
+  );
+  border-radius: 999px;
+  background: color-mix(
+    in oklab,
+    var(--surface-color, #101923) 90%,
+    var(--text-color, #f5f7fb) 5%
+  );
+  color: var(--text-color, #f5f7fb);
+  font-size: 0.84rem;
+  font-weight: 800;
+  line-height: 1;
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.profile-videos__upload-summary::-webkit-details-marker {
+  display: none;
+}
+
+.profile-videos__upload-summary:hover {
+  border-color: color-mix(
+    in oklab,
+    var(--primary-color, #ff6b6b) 54%,
+    var(--surface-border, rgb(255 255 255 / 12%))
+  );
+  background: color-mix(
+    in oklab,
+    var(--primary-color, #ff6b6b) 10%,
+    var(--surface-color, #101923)
+  );
+}
+
+.profile-videos__upload-summary:focus-visible {
+  outline: var(--focus-ring, 3px solid rgb(255 112 112 / 92%));
+  outline-offset: 3px;
+}
+
+.profile-videos__upload-disclosure[open] .profile-videos__upload-summary {
+  margin: 4px 0 14px auto;
+}
+
+.profile-videos__upload-summary-icon {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: color-mix(
+    in oklab,
+    var(--primary-color, #ff6b6b) 14%,
+    transparent
+  );
+  color: var(--primary-color, #ff6b6b);
+}
+
+.profile-videos__upload-disclosure[open] .profile-videos__upload-summary-icon {
+  transform: rotate(45deg);
+}
+
+.profile-videos__upload-summary-progress {
+  min-width: 42px;
+  padding: 5px 7px;
+  border-radius: 999px;
+  background: color-mix(
+    in oklab,
+    var(--primary-color, #ff6b6b) 16%,
+    transparent
+  );
+  color: var(--primary-color, #ff6b6b);
+  font-size: 0.74rem;
+  font-variant-numeric: tabular-nums;
+  text-align: center;
+}
+
+.profile-videos__upload-disclosure .profile-videos__upload {
+  width: 100%;
+  box-shadow: none;
+}
+
+.profile-videos__grid {
+  align-items: stretch;
+}
+
+.profile-videos__card {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  height: 100%;
+}
+
+.profile-videos__body {
+  align-content: start;
+  height: 100%;
+}
+
+.profile-videos__actions {
+  margin-top: auto;
+}
+
 @media (max-width: 700px) {
   .profile-videos__settings-form {
     padding: 12px;
@@ -135,11 +272,39 @@
   .profile-videos__settings-options label {
     min-height: 40px;
   }
+
+  .profile-videos__header {
+    grid-template-columns: 1fr;
+    align-items: start;
+  }
+
+  .profile-videos__upload-disclosure,
+  .profile-videos__upload-disclosure[open] {
+    width: 100%;
+    justify-self: stretch;
+  }
+
+  .profile-videos__upload-summary,
+  .profile-videos__upload-disclosure[open] .profile-videos__upload-summary {
+    width: 100%;
+    margin: 4px 0 0;
+  }
+
+  .profile-videos__upload-disclosure[open] .profile-videos__upload-summary {
+    margin-bottom: 12px;
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .profile-videos__upload-summary-icon {
+    transition: transform 160ms ease;
+  }
 }
 
 html.high-contrast .profile-videos__settings-form,
 html.high-contrast .profile-videos__settings-form input,
-html.high-contrast .profile-videos__settings-form textarea {
+html.high-contrast .profile-videos__settings-form textarea,
+html.high-contrast .profile-videos__upload-summary {
   border-color: currentColor !important;
   background: var(--background-color) !important;
   color: var(--text-color) !important;

--- a/src/app/media/videos/profile-videos/profile-videos.component.html
+++ b/src/app/media/videos/profile-videos/profile-videos.component.html
@@ -11,142 +11,179 @@
 
 <section class="profile-videos" aria-label="Vídeos">
   @if (isOwner$ | async) {
-    <section
-      class="profile-videos__upload app-card"
-      aria-labelledby="video-upload-title"
-      [attr.aria-busy]="isUploadActive() ? 'true' : 'false'"
-    >
-      <div class="profile-videos__upload-copy">
-        <h2 id="video-upload-title">Enviar vídeo</h2>
-      </div>
-
-      @if (!canUpload) {
-        <div class="profile-videos__policy-state" role="status" aria-live="polite">
-          <i class="fas fa-shield-halved" aria-hidden="true"></i>
-          <span>
-            Confirme o e-mail, conclua o perfil e mantenha a conta regular para
-            liberar o envio de vídeos.
-          </span>
-        </div>
-      }
-
-      <div class="profile-videos__picker">
-        <input
-          #videoInput
-          id="profile-video-file"
-          class="profile-videos__file-input"
-          type="file"
-          accept="video/mp4,video/webm,video/quicktime,.mp4,.webm,.mov"
-          aria-describedby="profile-video-file-help"
-          [disabled]="!canUpload || isUploadActive()"
-          (change)="onVideoSelected($event)"
-        />
-
-        <label
-          class="profile-videos__file-label app-action app-action--ghost"
-          for="profile-video-file"
-          [class.profile-videos__file-label--disabled]="!canUpload || isUploadActive()"
-        >
-          {{ selectedFileName ? 'Trocar vídeo' : 'Selecionar vídeo' }}
-        </label>
-
-        <p class="profile-videos__limits" id="profile-video-file-help">
-          MP4, WebM ou MOV · até 500 MB · mínimo de 5 segundos.
-        </p>
-
-        @if (selectedFileName) {
-          <div class="profile-videos__selected-file" role="status" aria-live="polite">
-            <i class="fas fa-circle-check" aria-hidden="true"></i>
-            <div>
-              <strong>{{ selectedFileName }}</strong>
-              <span>{{ selectedFileSize }}</span>
-            </div>
-          </div>
-
-          <p class="profile-videos__limits">
-            O original permanece privado. Só a versão processada pode ser publicada.
-          </p>
-        }
-      </div>
-
-      @if (previewUrl) {
-        <div class="profile-videos__preview">
-          <video
-            [src]="previewUrl"
-            aria-label="Prévia local do vídeo selecionado"
-            preload="metadata"
-            controls
-            playsinline
-            muted
-          ></video>
-        </div>
-      }
-
-      @if (uploadPhase !== 'IDLE' && uploadPhase !== 'READY') {
-        <div class="profile-videos__progress" aria-live="polite">
-          <div class="profile-videos__progress-copy">
-            <strong>{{ uploadStep }}</strong>
-            <span>{{ uploadProgress }}%</span>
-          </div>
-
-          <div
-            class="profile-videos__progress-track"
-            role="progressbar"
-            aria-label="Progresso do upload do vídeo"
-            aria-valuemin="0"
-            aria-valuemax="100"
-            [attr.aria-valuenow]="uploadProgress"
-          >
-            <span [style.width.%]="uploadProgress"></span>
-          </div>
-        </div>
-      } @else {
-        <p class="profile-videos__upload-status" role="status" aria-live="polite">
-          {{ uploadStep }}
-        </p>
-      }
-
-      <div class="profile-videos__upload-actions">
-        @if (uploadPhase === 'DONE') {
-          <button
-            type="button"
-            class="app-action app-action--primary"
-            (click)="resetSelection(videoInput)"
-          >
-            Enviar outro vídeo
-          </button>
-        } @else {
-          <button
-            type="button"
-            class="app-action app-action--primary"
-            [disabled]="!canUpload || !selectedFileName || isUploadActive()"
-            (click)="startUpload()"
-          >
-            {{ isUploadActive() ? 'Enviando...' : 'Enviar vídeo' }}
-          </button>
-
-          @if (canCancelUpload()) {
-            <button
-              type="button"
-              class="app-action app-action--ghost"
-              (click)="cancelUpload()"
-            >
-              Cancelar upload
-            </button>
-          } @else if (selectedFileName && !isUploadActive()) {
-            <button
-              type="button"
-              class="app-action app-action--ghost"
-              (click)="resetSelection(videoInput)"
-            >
-              Limpar seleção
-            </button>
-          }
-        }
-      </div>
-    </section>
-
     @if (viewItems$ | async; as items) {
+      <header class="profile-videos__header">
+        <div>
+          <span class="profile-videos__eyebrow">Biblioteca pessoal</span>
+          <h1>Meus vídeos</h1>
+          <p>
+            {{ items.length }} {{ items.length === 1 ? 'vídeo' : 'vídeos' }}.
+            Gerencie publicação, informações e processamento sem tirar o foco da galeria.
+          </p>
+        </div>
+
+        <details class="profile-videos__upload-disclosure">
+          <summary class="profile-videos__upload-summary">
+            <span class="profile-videos__upload-summary-icon" aria-hidden="true">
+              <i class="fas fa-plus"></i>
+            </span>
+            <span>
+              {{
+                isUploadActive()
+                  ? 'Acompanhar upload'
+                  : selectedFileName
+                    ? 'Continuar envio'
+                    : 'Adicionar vídeo'
+              }}
+            </span>
+            @if (isUploadActive()) {
+              <span class="profile-videos__upload-summary-progress">
+                {{ uploadProgress }}%
+              </span>
+            }
+          </summary>
+
+          <section
+            class="profile-videos__upload app-card"
+            aria-labelledby="video-upload-title"
+            [attr.aria-busy]="isUploadActive() ? 'true' : 'false'"
+          >
+            <div class="profile-videos__upload-copy">
+              <h2 id="video-upload-title">Enviar vídeo</h2>
+              <p>
+                O envio fica recolhido quando não está em uso para manter a biblioteca
+                como conteúdo principal desta página.
+              </p>
+            </div>
+
+            @if (!canUpload) {
+              <div class="profile-videos__policy-state" role="status" aria-live="polite">
+                <i class="fas fa-shield-halved" aria-hidden="true"></i>
+                <span>
+                  Confirme o e-mail, conclua o perfil e mantenha a conta regular para
+                  liberar o envio de vídeos.
+                </span>
+              </div>
+            }
+
+            <div class="profile-videos__picker">
+              <input
+                #videoInput
+                id="profile-video-file"
+                class="profile-videos__file-input"
+                type="file"
+                accept="video/mp4,video/webm,video/quicktime,.mp4,.webm,.mov"
+                aria-describedby="profile-video-file-help"
+                [disabled]="!canUpload || isUploadActive()"
+                (change)="onVideoSelected($event)"
+              />
+
+              <label
+                class="profile-videos__file-label app-action app-action--ghost"
+                for="profile-video-file"
+                [class.profile-videos__file-label--disabled]="!canUpload || isUploadActive()"
+              >
+                {{ selectedFileName ? 'Trocar vídeo' : 'Selecionar vídeo' }}
+              </label>
+
+              <p class="profile-videos__limits" id="profile-video-file-help">
+                MP4, WebM ou MOV · até 500 MB · mínimo de 5 segundos.
+              </p>
+
+              @if (selectedFileName) {
+                <div class="profile-videos__selected-file" role="status" aria-live="polite">
+                  <i class="fas fa-circle-check" aria-hidden="true"></i>
+                  <div>
+                    <strong>{{ selectedFileName }}</strong>
+                    <span>{{ selectedFileSize }}</span>
+                  </div>
+                </div>
+
+                <p class="profile-videos__limits">
+                  O original permanece privado. Só a versão processada pode ser publicada.
+                </p>
+              }
+            </div>
+
+            @if (previewUrl) {
+              <div class="profile-videos__preview">
+                <video
+                  [src]="previewUrl"
+                  aria-label="Prévia local do vídeo selecionado"
+                  preload="metadata"
+                  controls
+                  playsinline
+                  muted
+                ></video>
+              </div>
+            }
+
+            @if (uploadPhase !== 'IDLE' && uploadPhase !== 'READY') {
+              <div class="profile-videos__progress" aria-live="polite">
+                <div class="profile-videos__progress-copy">
+                  <strong>{{ uploadStep }}</strong>
+                  <span>{{ uploadProgress }}%</span>
+                </div>
+
+                <div
+                  class="profile-videos__progress-track"
+                  role="progressbar"
+                  aria-label="Progresso do upload do vídeo"
+                  aria-valuemin="0"
+                  aria-valuemax="100"
+                  [attr.aria-valuenow]="uploadProgress"
+                >
+                  <span [style.width.%]="uploadProgress"></span>
+                </div>
+              </div>
+            } @else {
+              <p class="profile-videos__upload-status" role="status" aria-live="polite">
+                {{ uploadStep }}
+              </p>
+            }
+
+            <div class="profile-videos__upload-actions">
+              @if (uploadPhase === 'DONE') {
+                <button
+                  type="button"
+                  class="app-action app-action--primary"
+                  (click)="resetSelection(videoInput)"
+                >
+                  Enviar outro vídeo
+                </button>
+              } @else {
+                <button
+                  type="button"
+                  class="app-action app-action--primary"
+                  [disabled]="!canUpload || !selectedFileName || isUploadActive()"
+                  (click)="startUpload()"
+                >
+                  {{ isUploadActive() ? 'Enviando...' : 'Enviar vídeo' }}
+                </button>
+
+                @if (canCancelUpload()) {
+                  <button
+                    type="button"
+                    class="app-action app-action--ghost"
+                    (click)="cancelUpload()"
+                  >
+                    Cancelar upload
+                  </button>
+                } @else if (selectedFileName && !isUploadActive()) {
+                  <button
+                    type="button"
+                    class="app-action app-action--ghost"
+                    (click)="resetSelection(videoInput)"
+                  >
+                    Limpar seleção
+                  </button>
+                }
+              }
+            </div>
+          </section>
+        </details>
+      </header>
+
       @if (items.length > 0) {
         <div class="profile-videos__grid" aria-label="Meus vídeos privados">
           @for (item of items; track trackByVideoId($index, item)) {
@@ -156,7 +193,7 @@
                   [src]="item.video.url"
                   [poster]="item.video.thumbnailUrl || null"
                   [attr.aria-label]="displayVideoTitle(item)"
-                  preload="metadata"
+                  preload="none"
                   controls
                   controlsList="nodownload"
                   playsinline
@@ -178,11 +215,13 @@
                   </span>
                 </div>
 
-                @if (item.publication?.description) {
-                  <p class="profile-videos__description">
-                    {{ item.publication?.description }}
-                  </p>
-                }
+                <div class="profile-videos__description-slot">
+                  @if (item.publication?.description) {
+                    <p class="profile-videos__description">
+                      {{ item.publication?.description }}
+                    </p>
+                  }
+                </div>
 
                 <div class="profile-videos__meta" aria-label="Informações do vídeo">
                   <span>{{ formatFileSize(item.video.sizeBytes) }}</span>
@@ -385,7 +424,7 @@
         </div>
       } @else {
         <p class="profile-videos__upload-status" role="status">
-          Nenhum vídeo enviado.
+          Nenhum vídeo enviado. Use “Adicionar vídeo” quando quiser publicar o primeiro.
         </p>
       }
     }

--- a/src/app/media/videos/public-profile-videos/public-profile-videos.component.html
+++ b/src/app/media/videos/public-profile-videos/public-profile-videos.component.html
@@ -106,11 +106,7 @@
             track trackByVideoId($index, item);
             let index = $index
           ) {
-            <article
-              class="video-card"
-              [class.video-card--featured]="index === 0"
-              role="listitem"
-            >
+            <article class="video-card" role="listitem">
               <button
                 type="button"
                 class="video-card__preview"
@@ -143,13 +139,6 @@
                 <span class="video-card__duration">
                   {{ formatDuration(item.durationMs) }}
                 </span>
-
-                @if (index === 0) {
-                  <span class="video-card__featured-label">
-                    <i class="fas fa-sparkles" aria-hidden="true"></i>
-                    Destaque
-                  </span>
-                }
               </button>
 
               <div class="video-card__body">


### PR DESCRIPTION
## O que mudou

- recolhe o fluxo de upload em um controle nativo e acessível, exibido apenas após interação do usuário;
- mantém política, prévia, progresso, cancelamento e feedbacks existentes dentro do painel;
- adiciona cabeçalho da biblioteca com contagem de vídeos e ação discreta de envio;
- reduz o carregamento inicial dos cards privados alterando o player da grade para `preload="none"`;
- reserva espaço uniforme para descrições e estica os cards da grade;
- remove o destaque automático do primeiro vídeo público, mantendo todos os cards com a mesma distribuição.

## Motivo

A página estava priorizando o formulário de upload antes do produto principal, que são os vídeos. A grade também criava players com carregamento de metadados para todos os itens e a galeria pública aplicava uma hierarquia editorial automática ao primeiro vídeo.

## Impacto

- biblioteca passa a aparecer imediatamente;
- upload continua disponível sem dominar a página;
- melhor comportamento em telas pequenas;
- menor custo inicial de rede e renderização;
- cards públicos visualmente uniformes.

## Validação

- diff revisado contra `feat/auth-password-recovery-polish`;
- fluxo funcional existente foi preservado;
- nenhuma função, serviço, regra de segurança ou tratamento centralizado de erros foi removido.

A validação de build e testes deve ser executada pelo CI do repositório, pois este ambiente não possui checkout local nem GitHub CLI.