### PR TITLE
feat(community): add reactive feed cache

### DIFF
--- a/src/app/community/feed/community-feed-attachment-source.spec.ts
+++ b/src/app/community/feed/community-feed-attachment-source.spec.ts
@@ -10,6 +10,7 @@ import { StorageService } from 'src/app/core/services/image-handling/storage.ser
 import { CameraCaptureService } from 'src/app/core/services/media/camera-capture.service';
 import { CommunityFeedCommentRepository } from '../data-access/community-feed-comment.repository';
 import { CommunityFeedRepository } from '../data-access/community-feed.repository';
+import { provideCommunityFeedCacheTestDouble } from './community-feed-cache.testing';
 import { CommunityFeedComponent } from './community-feed.component';
 
 describe('CommunityFeedComponent attachment sources', () => {
@@ -65,6 +66,7 @@ describe('CommunityFeedComponent attachment sources', () => {
     TestBed.configureTestingModule({
       imports: [CommunityFeedComponent],
       providers: [
+        provideCommunityFeedCacheTestDouble(),
         { provide: CommunityFeedRepository, useValue: repositoryMock },
         { provide: CommunityFeedCommentRepository, useValue: commentRepositoryMock },
         { provide: StorageService, useValue: { uploadFile: vi.fn() } },

--- a/src/app/community/feed/community-feed-cache.model.spec.ts
+++ b/src/app/community/feed/community-feed-cache.model.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  COMMUNITY_FEED_CACHE_HARD_TTL_MS,
+  COMMUNITY_FEED_CACHE_SOFT_TTL_MS,
+  buildCommunityFeedCacheKey,
+  buildCommunityFeedCacheQuery,
+  isCommunityFeedCacheHardExpired,
+  isCommunityFeedCacheSoftFresh,
+} from './community-feed-cache.model';
+
+describe('community feed cache scope', () => {
+  it('isola a mesma Comunidade por viewer e visualização', () => {
+    const feedA = buildCommunityFeedCacheQuery('user-a', 'community-1', 'feed');
+    const feedB = buildCommunityFeedCacheQuery('user-b', 'community-1', 'feed');
+    const photosA = buildCommunityFeedCacheQuery('user-a', 'community-1', 'photos');
+
+    expect(feedA).not.toBeNull();
+    expect(feedB).not.toBeNull();
+    expect(photosA).not.toBeNull();
+    expect(buildCommunityFeedCacheKey(feedA!)).not.toBe(
+      buildCommunityFeedCacheKey(feedB!)
+    );
+    expect(buildCommunityFeedCacheKey(feedA!)).not.toBe(
+      buildCommunityFeedCacheKey(photosA!)
+    );
+  });
+
+  it('rejeita viewer ou communityId inseguros', () => {
+    expect(buildCommunityFeedCacheQuery('../user', 'community-1', 'feed')).toBeNull();
+    expect(buildCommunityFeedCacheQuery('user-1', '../community', 'feed')).toBeNull();
+    expect(buildCommunityFeedCacheQuery(null, 'community-1', 'feed')).toBeNull();
+  });
+
+  it('aplica soft TTL sem ultrapassar o hard TTL', () => {
+    const now = 1_800_000_000_000;
+
+    expect(isCommunityFeedCacheSoftFresh(now, now)).toBe(true);
+    expect(isCommunityFeedCacheSoftFresh(
+      now - COMMUNITY_FEED_CACHE_SOFT_TTL_MS + 1,
+      now
+    )).toBe(true);
+    expect(isCommunityFeedCacheSoftFresh(
+      now - COMMUNITY_FEED_CACHE_SOFT_TTL_MS,
+      now
+    )).toBe(false);
+
+    expect(isCommunityFeedCacheHardExpired(
+      now - COMMUNITY_FEED_CACHE_HARD_TTL_MS + 1,
+      now
+    )).toBe(false);
+    expect(isCommunityFeedCacheHardExpired(
+      now - COMMUNITY_FEED_CACHE_HARD_TTL_MS,
+      now
+    )).toBe(true);
+  });
+});

--- a/src/app/community/feed/community-feed-cache.model.ts
+++ b/src/app/community/feed/community-feed-cache.model.ts
@@ -1,0 +1,93 @@
+// src/app/community/feed/community-feed-cache.model.ts
+// -----------------------------------------------------------------------------
+// COMMUNITY FEED CACHE SCOPE
+// -----------------------------------------------------------------------------
+// O Mural hidratado é específico do viewer: capabilities, viewerReacted e URLs
+// temporárias não podem atravessar sessões. A chave inclui UID + Comunidade + view.
+// -----------------------------------------------------------------------------
+
+import type { CommunityFeedView } from '../data-access/community-feed.model';
+
+export interface CommunityFeedCacheQuery {
+  readonly viewerUid: string;
+  readonly communityId: string;
+  readonly view: CommunityFeedView;
+}
+
+export const COMMUNITY_FEED_CACHE_SOFT_TTL_MS = 30_000;
+export const COMMUNITY_FEED_CACHE_HARD_TTL_MS = 5 * 60_000;
+export const COMMUNITY_FEED_CACHE_MAX_SCOPES = 6;
+
+const SAFE_ID_PATTERN = /^[A-Za-z0-9:_-]{1,128}$/;
+const COMMUNITY_FEED_CACHE_PREFIX = 'community:feed:v1';
+
+function normalizeSafeId(value: unknown): string {
+  const normalized = String(value ?? '').trim();
+  return SAFE_ID_PATTERN.test(normalized) ? normalized : '';
+}
+
+export function buildCommunityFeedCacheQuery(
+  viewerUidValue: unknown,
+  communityIdValue: unknown,
+  viewValue: unknown
+): CommunityFeedCacheQuery | null {
+  const viewerUid = normalizeSafeId(viewerUidValue);
+  const communityId = normalizeSafeId(communityIdValue);
+  const view: CommunityFeedView = viewValue === 'photos' ? 'photos' : 'feed';
+
+  return viewerUid && communityId
+    ? { viewerUid, communityId, view }
+    : null;
+}
+
+export function buildCommunityFeedCacheKey(
+  query: CommunityFeedCacheQuery
+): string {
+  const normalized = buildCommunityFeedCacheQuery(
+    query.viewerUid,
+    query.communityId,
+    query.view
+  );
+
+  if (!normalized) {
+    return `${COMMUNITY_FEED_CACHE_PREFIX}|scope=invalid`;
+  }
+
+  return [
+    COMMUNITY_FEED_CACHE_PREFIX,
+    `viewer=${normalized.viewerUid}`,
+    `community=${normalized.communityId}`,
+    `view=${normalized.view}`,
+  ].join('|');
+}
+
+export function communityFeedCacheAgeMs(
+  lastLoadedAt: number,
+  now = Date.now()
+): number | null {
+  if (
+    !Number.isFinite(lastLoadedAt)
+    || lastLoadedAt <= 0
+    || !Number.isFinite(now)
+  ) {
+    return null;
+  }
+
+  return Math.max(0, Math.trunc(now) - Math.trunc(lastLoadedAt));
+}
+
+export function isCommunityFeedCacheSoftFresh(
+  lastLoadedAt: number,
+  now = Date.now()
+): boolean {
+  const age = communityFeedCacheAgeMs(lastLoadedAt, now);
+  return age !== null && age < COMMUNITY_FEED_CACHE_SOFT_TTL_MS;
+}
+
+export function isCommunityFeedCacheHardExpired(
+  lastLoadedAt: number,
+  now = Date.now()
+): boolean {
+  const age = communityFeedCacheAgeMs(lastLoadedAt, now);
+  return age !== null && age >= COMMUNITY_FEED_CACHE_HARD_TTL_MS;
+}

--- a/src/app/community/feed/community-feed-cache.model.ts
+++ b/src/app/community/feed/community-feed-cache.model.ts
@@ -26,12 +26,16 @@ function normalizeSafeId(value: unknown): string {
   return SAFE_ID_PATTERN.test(normalized) ? normalized : '';
 }
 
+export function normalizeCommunityFeedViewerUid(value: unknown): string {
+  return normalizeSafeId(value);
+}
+
 export function buildCommunityFeedCacheQuery(
   viewerUidValue: unknown,
   communityIdValue: unknown,
   viewValue: unknown
 ): CommunityFeedCacheQuery | null {
-  const viewerUid = normalizeSafeId(viewerUidValue);
+  const viewerUid = normalizeCommunityFeedViewerUid(viewerUidValue);
   const communityId = normalizeSafeId(communityIdValue);
   const view: CommunityFeedView = viewValue === 'photos' ? 'photos' : 'feed';
 

--- a/src/app/community/feed/community-feed-cache.service.ts
+++ b/src/app/community/feed/community-feed-cache.service.ts
@@ -23,6 +23,7 @@ import {
   buildCommunityFeedCacheQuery,
   communityFeedCacheAgeMs,
   isCommunityFeedCacheHardExpired,
+  normalizeCommunityFeedViewerUid,
 } from './community-feed-cache.model';
 import {
   CommunityFeedLoadEvent,
@@ -48,8 +49,7 @@ export class CommunityFeedCacheService {
     this.session.readyUid$
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((uid) => {
-        const query = buildCommunityFeedCacheQuery(uid, 'placeholder', 'feed');
-        const viewerUid = query?.viewerUid ?? null;
+        const viewerUid = normalizeCommunityFeedViewerUid(uid) || null;
         this.activeViewerUid = viewerUid;
         this.store.dispatch(
           CommunityFeedCacheActions.activateCommunityFeedViewer({ viewerUid })

--- a/src/app/community/feed/community-feed-cache.service.ts
+++ b/src/app/community/feed/community-feed-cache.service.ts
@@ -1,0 +1,133 @@
+// src/app/community/feed/community-feed-cache.service.ts
+// -----------------------------------------------------------------------------
+// COMMUNITY FEED CACHE FACADE
+// -----------------------------------------------------------------------------
+// Isola o componente dos detalhes do NgRx e vincula todo snapshot ao viewer atual.
+// Firebase/callables permanecem no repository; este serviço guarda somente estado
+// serializável já autorizado e normalizado.
+// -----------------------------------------------------------------------------
+
+import { DestroyRef, Injectable, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Store } from '@ngrx/store';
+import { Observable, map, of, switchMap, take } from 'rxjs';
+
+import { AuthSessionService } from 'src/app/core/services/autentication/auth/auth-session.service';
+import * as CommunityFeedCacheActions from 'src/app/store/actions/actions.community/community-feed-cache.actions';
+import { selectCommunityFeedCacheSlice } from 'src/app/store/selectors/selectors.community/community-feed-cache.selectors';
+import type { AppState } from 'src/app/store/states/app.state';
+import type { CommunityFeedView } from '../data-access/community-feed.model';
+import {
+  COMMUNITY_FEED_CACHE_SOFT_TTL_MS,
+  CommunityFeedCacheQuery,
+  buildCommunityFeedCacheQuery,
+  communityFeedCacheAgeMs,
+  isCommunityFeedCacheHardExpired,
+} from './community-feed-cache.model';
+import {
+  CommunityFeedLoadEvent,
+  CommunityFeedState,
+  INITIAL_COMMUNITY_FEED_STATE,
+} from './community-feed-state.model';
+
+export interface CommunityFeedCacheSnapshot {
+  readonly query: CommunityFeedCacheQuery;
+  readonly state: CommunityFeedState;
+  readonly fresh: boolean;
+  readonly revalidateAfterMs: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class CommunityFeedCacheService {
+  private readonly store = inject(Store<AppState>);
+  private readonly session = inject(AuthSessionService);
+  private readonly destroyRef = inject(DestroyRef);
+  private activeViewerUid: string | null = null;
+
+  constructor() {
+    this.session.readyUid$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((uid) => {
+        const query = buildCommunityFeedCacheQuery(uid, 'placeholder', 'feed');
+        const viewerUid = query?.viewerUid ?? null;
+        this.activeViewerUid = viewerUid;
+        this.store.dispatch(
+          CommunityFeedCacheActions.activateCommunityFeedViewer({ viewerUid })
+        );
+      });
+  }
+
+  readSnapshot$(
+    communityId: string,
+    view: CommunityFeedView
+  ): Observable<CommunityFeedCacheSnapshot | null> {
+    return this.session.readyUid$.pipe(
+      take(1),
+      switchMap((uid) => {
+        const query = buildCommunityFeedCacheQuery(uid, communityId, view);
+        if (!query) return of(null);
+
+        const now = Date.now();
+        this.store.dispatch(
+          CommunityFeedCacheActions.touchCommunityFeedScope({
+            query,
+            accessedAt: now,
+          })
+        );
+
+        return this.store.select(selectCommunityFeedCacheSlice(query)).pipe(
+          take(1),
+          map((slice): CommunityFeedCacheSnapshot => {
+            if (!slice || isCommunityFeedCacheHardExpired(slice.lastLoadedAt, now)) {
+              return {
+                query,
+                state: INITIAL_COMMUNITY_FEED_STATE,
+                fresh: false,
+                revalidateAfterMs: 0,
+              };
+            }
+
+            const age = communityFeedCacheAgeMs(slice.lastLoadedAt, now);
+            const fresh = age !== null && age < COMMUNITY_FEED_CACHE_SOFT_TTL_MS;
+
+            return {
+              query,
+              state: slice.state,
+              fresh,
+              revalidateAfterMs: fresh && age !== null
+                ? Math.max(0, COMMUNITY_FEED_CACHE_SOFT_TTL_MS - age)
+                : 0,
+            };
+          })
+        );
+      })
+    );
+  }
+
+  state$(query: CommunityFeedCacheQuery): Observable<CommunityFeedState> {
+    return this.store.select(selectCommunityFeedCacheSlice(query)).pipe(
+      map((slice) => slice?.state ?? INITIAL_COMMUNITY_FEED_STATE)
+    );
+  }
+
+  applyEvent(query: CommunityFeedCacheQuery, event: CommunityFeedLoadEvent): void {
+    this.store.dispatch(
+      CommunityFeedCacheActions.applyCommunityFeedEvent({
+        query,
+        event,
+        occurredAt: Date.now(),
+      })
+    );
+  }
+
+  currentQuery(
+    communityId: string,
+    view: CommunityFeedView
+  ): CommunityFeedCacheQuery | null {
+    return buildCommunityFeedCacheQuery(
+      this.activeViewerUid || this.session.currentAuthUser?.uid,
+      communityId,
+      view
+    );
+  }
+}

--- a/src/app/community/feed/community-feed-cache.service.ts
+++ b/src/app/community/feed/community-feed-cache.service.ts
@@ -2,7 +2,7 @@
 // -----------------------------------------------------------------------------
 // COMMUNITY FEED CACHE FACADE
 // -----------------------------------------------------------------------------
-// Isola o componente dos detalhes do NgRx e vincula todo snapshot ao viewer atual.
+// Isola consumidores dos detalhes do NgRx e vincula todo snapshot ao viewer atual.
 // Firebase/callables permanecem no repository; este serviço guarda somente estado
 // serializável já autorizado e normalizado.
 // -----------------------------------------------------------------------------
@@ -34,6 +34,7 @@ import {
 export interface CommunityFeedCacheSnapshot {
   readonly query: CommunityFeedCacheQuery;
   readonly state: CommunityFeedState;
+  readonly lastLoadedAt: number;
   readonly fresh: boolean;
   readonly revalidateAfterMs: number;
 }
@@ -82,6 +83,7 @@ export class CommunityFeedCacheService {
               return {
                 query,
                 state: INITIAL_COMMUNITY_FEED_STATE,
+                lastLoadedAt: 0,
                 fresh: false,
                 revalidateAfterMs: 0,
               };
@@ -93,6 +95,7 @@ export class CommunityFeedCacheService {
             return {
               query,
               state: slice.state,
+              lastLoadedAt: slice.lastLoadedAt,
               fresh,
               revalidateAfterMs: fresh && age !== null
                 ? Math.max(0, COMMUNITY_FEED_CACHE_SOFT_TTL_MS - age)

--- a/src/app/community/feed/community-feed-cache.service.ts
+++ b/src/app/community/feed/community-feed-cache.service.ts
@@ -47,7 +47,7 @@ export class CommunityFeedCacheService {
   private activeViewerUid: string | null = null;
 
   constructor() {
-    this.session.readyUid$
+    this.session.uid$
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((uid) => {
         const viewerUid = normalizeCommunityFeedViewerUid(uid) || null;
@@ -62,7 +62,7 @@ export class CommunityFeedCacheService {
     communityId: string,
     view: CommunityFeedView
   ): Observable<CommunityFeedCacheSnapshot | null> {
-    return this.session.readyUid$.pipe(
+    return this.session.uid$.pipe(
       take(1),
       switchMap((uid) => {
         const query = buildCommunityFeedCacheQuery(uid, communityId, view);

--- a/src/app/community/feed/community-feed-cache.testing.ts
+++ b/src/app/community/feed/community-feed-cache.testing.ts
@@ -9,23 +9,24 @@
 // -----------------------------------------------------------------------------
 
 import type { Provider } from '@angular/core';
-import { BehaviorSubject, Observable, of } from 'rxjs';
+import { BehaviorSubject, of } from 'rxjs';
+import type { Observable } from 'rxjs';
 
 import type { CommunityFeedView } from '../data-access/community-feed.model';
 import {
-  CommunityFeedCacheQuery,
   buildCommunityFeedCacheKey,
   buildCommunityFeedCacheQuery,
 } from './community-feed-cache.model';
+import type { CommunityFeedCacheQuery } from './community-feed-cache.model';
+import { CommunityFeedCacheService } from './community-feed-cache.service';
+import type { CommunityFeedCacheSnapshot } from './community-feed-cache.service';
 import {
-  CommunityFeedCacheService,
-  CommunityFeedCacheSnapshot,
-} from './community-feed-cache.service';
-import {
-  CommunityFeedLoadEvent,
-  CommunityFeedState,
   INITIAL_COMMUNITY_FEED_STATE,
   reduceCommunityFeedState,
+} from './community-feed-state.model';
+import type {
+  CommunityFeedLoadEvent,
+  CommunityFeedState,
 } from './community-feed-state.model';
 
 class CommunityFeedCacheTestDouble {

--- a/src/app/community/feed/community-feed-cache.testing.ts
+++ b/src/app/community/feed/community-feed-cache.testing.ts
@@ -1,0 +1,100 @@
+// src/app/community/feed/community-feed-cache.testing.ts
+// -----------------------------------------------------------------------------
+// COMMUNITY FEED CACHE TEST DOUBLE
+// -----------------------------------------------------------------------------
+// Mantém os testes de componente desacoplados da infraestrutura NgRx sem
+// enfraquecer o runtime. O double preserva a mesma redução reativa de eventos
+// usada pelo cache real; a integração NgRx permanece coberta nos testes do
+// reducer/cache.
+// -----------------------------------------------------------------------------
+
+import type { Provider } from '@angular/core';
+import { BehaviorSubject, Observable, of } from 'rxjs';
+
+import type { CommunityFeedView } from '../data-access/community-feed.model';
+import {
+  CommunityFeedCacheQuery,
+  buildCommunityFeedCacheKey,
+  buildCommunityFeedCacheQuery,
+} from './community-feed-cache.model';
+import {
+  CommunityFeedCacheService,
+  CommunityFeedCacheSnapshot,
+} from './community-feed-cache.service';
+import {
+  CommunityFeedLoadEvent,
+  CommunityFeedState,
+  INITIAL_COMMUNITY_FEED_STATE,
+  reduceCommunityFeedState,
+} from './community-feed-state.model';
+
+class CommunityFeedCacheTestDouble {
+  private readonly states = new Map<
+    string,
+    BehaviorSubject<CommunityFeedState>
+  >();
+
+  constructor(private readonly viewerUid: string) {}
+
+  readSnapshot$(
+    communityId: string,
+    view: CommunityFeedView
+  ): Observable<CommunityFeedCacheSnapshot | null> {
+    const query = buildCommunityFeedCacheQuery(
+      this.viewerUid,
+      communityId,
+      view
+    );
+    if (!query) return of(null);
+
+    return of({
+      query,
+      state: this.stateSubject(query).value,
+      lastLoadedAt: 0,
+      fresh: false,
+      revalidateAfterMs: 0,
+    });
+  }
+
+  state$(query: CommunityFeedCacheQuery): Observable<CommunityFeedState> {
+    return this.stateSubject(query).asObservable();
+  }
+
+  applyEvent(
+    query: CommunityFeedCacheQuery,
+    event: CommunityFeedLoadEvent
+  ): void {
+    const state = this.stateSubject(query);
+    state.next(reduceCommunityFeedState(state.value, event));
+  }
+
+  currentQuery(
+    communityId: string,
+    view: CommunityFeedView
+  ): CommunityFeedCacheQuery | null {
+    return buildCommunityFeedCacheQuery(this.viewerUid, communityId, view);
+  }
+
+  private stateSubject(
+    query: CommunityFeedCacheQuery
+  ): BehaviorSubject<CommunityFeedState> {
+    const key = buildCommunityFeedCacheKey(query);
+    let state = this.states.get(key);
+    if (!state) {
+      state = new BehaviorSubject<CommunityFeedState>(
+        INITIAL_COMMUNITY_FEED_STATE
+      );
+      this.states.set(key, state);
+    }
+    return state;
+  }
+}
+
+export function provideCommunityFeedCacheTestDouble(
+  viewerUid = 'community-feed-test-viewer'
+): Provider {
+  return {
+    provide: CommunityFeedCacheService,
+    useFactory: () => new CommunityFeedCacheTestDouble(viewerUid),
+  };
+}

--- a/src/app/community/feed/community-feed-legacy-comments-access.spec.ts
+++ b/src/app/community/feed/community-feed-legacy-comments-access.spec.ts
@@ -8,6 +8,7 @@ import { GlobalErrorHandlerService } from 'src/app/core/services/error-handler/g
 import { StorageService } from 'src/app/core/services/image-handling/storage.service';
 import { CommunityFeedCommentRepository } from '../data-access/community-feed-comment.repository';
 import { CommunityFeedRepository } from '../data-access/community-feed.repository';
+import { provideCommunityFeedCacheTestDouble } from './community-feed-cache.testing';
 import { CommunityFeedComponent } from './community-feed.component';
 import { CommunityFeedTimeTickerService } from './community-feed-time-ticker.service';
 
@@ -43,6 +44,7 @@ describe('CommunityFeedComponent legacy comments access', () => {
     TestBed.configureTestingModule({
       imports: [CommunityFeedComponent],
       providers: [
+        provideCommunityFeedCacheTestDouble(),
         { provide: CommunityFeedRepository, useValue: feedRepository },
         { provide: CommunityFeedCommentRepository, useValue: commentRepository },
         { provide: CommunityFeedTimeTickerService, useValue: { now$: of(Date.now()) } },

--- a/src/app/community/feed/community-feed-reply-entry.spec.ts
+++ b/src/app/community/feed/community-feed-reply-entry.spec.ts
@@ -8,6 +8,7 @@ import { GlobalErrorHandlerService } from 'src/app/core/services/error-handler/g
 import { StorageService } from 'src/app/core/services/image-handling/storage.service';
 import { CommunityFeedCommentRepository } from '../data-access/community-feed-comment.repository';
 import { CommunityFeedRepository } from '../data-access/community-feed.repository';
+import { provideCommunityFeedCacheTestDouble } from './community-feed-cache.testing';
 import { CommunityFeedComponent } from './community-feed.component';
 import { CommunityFeedTimeTickerService } from './community-feed-time-ticker.service';
 
@@ -79,6 +80,7 @@ describe('CommunityFeedComponent conversation entry points', () => {
     TestBed.configureTestingModule({
       imports: [CommunityFeedComponent],
       providers: [
+        provideCommunityFeedCacheTestDouble(),
         { provide: CommunityFeedRepository, useValue: feedRepository },
         { provide: CommunityFeedCommentRepository, useValue: commentRepository },
         { provide: CommunityFeedTimeTickerService, useValue: { now$: of(Date.now()) } },

--- a/src/app/community/feed/community-feed-smart-follow.spec.ts
+++ b/src/app/community/feed/community-feed-smart-follow.spec.ts
@@ -9,6 +9,7 @@ import { StorageService } from 'src/app/core/services/image-handling/storage.ser
 import { CommunityFeedCommentRepository } from '../data-access/community-feed-comment.repository';
 import type { CommunityFeedRealtimeChange } from '../data-access/community-feed-realtime.model';
 import { CommunityFeedRepository } from '../data-access/community-feed.repository';
+import { provideCommunityFeedCacheTestDouble } from './community-feed-cache.testing';
 import { CommunityFeedComponent } from './community-feed.component';
 import { CommunityFeedTimeTickerService } from './community-feed-time-ticker.service';
 
@@ -54,6 +55,7 @@ describe('CommunityFeedComponent smart follow', () => {
     TestBed.configureTestingModule({
       imports: [CommunityFeedComponent],
       providers: [
+        provideCommunityFeedCacheTestDouble(),
         { provide: CommunityFeedRepository, useValue: feedRepository },
         { provide: CommunityFeedCommentRepository, useValue: commentRepository },
         { provide: CommunityFeedTimeTickerService, useValue: { now$: of(Date.now()) } },

--- a/src/app/community/feed/community-feed.component.spec.ts
+++ b/src/app/community/feed/community-feed.component.spec.ts
@@ -6,6 +6,7 @@ import { AuthSessionService } from 'src/app/core/services/autentication/auth/aut
 import { ErrorNotificationService } from 'src/app/core/services/error-handler/error-notification.service';
 import { GlobalErrorHandlerService } from 'src/app/core/services/error-handler/global-error-handler.service';
 import { StorageService } from 'src/app/core/services/image-handling/storage.service';
+import { provideCommunityFeedCacheTestDouble } from './community-feed-cache.testing';
 import {
   CommunityFeedComponent,
   INITIAL_COMMUNITY_FEED_STATE,
@@ -108,6 +109,7 @@ describe('CommunityFeedComponent', () => {
     TestBed.configureTestingModule({
       imports: [CommunityFeedComponent],
       providers: [
+        provideCommunityFeedCacheTestDouble(),
         { provide: CommunityFeedRepository, useValue: repositoryMock },
         {
           provide: CommunityFeedCommentRepository,

--- a/src/app/community/feed/community-feed.component.ts
+++ b/src/app/community/feed/community-feed.component.ts
@@ -38,10 +38,10 @@ import {
   exhaustMap,
   filter,
   finalize,
+  ignoreElements,
   map,
   merge,
   of,
-  scan,
   shareReplay,
   startWith,
   Subject,
@@ -74,6 +74,7 @@ import {
   CommunityPreviewViewerRole,
 } from '../data-access/community-preview.model';
 import { CommunityCameraCaptureComponent } from './community-camera-capture.component';
+import { CommunityFeedCacheService } from './community-feed-cache.service';
 import {
   CommunityComposerAttachment,
   validateCommunityComposerImage,
@@ -82,7 +83,6 @@ import {
   CommunityFeedLoadEvent,
   CommunityFeedLoadRequest,
   INITIAL_COMMUNITY_FEED_STATE,
-  reduceCommunityFeedState,
 } from './community-feed-state.model';
 import { CommunityFeedTimeTickerService } from './community-feed-time-ticker.service';
 import {
@@ -151,6 +151,7 @@ const MAX_UNSEEN_NEW_POSTS = 99;
 })
 export class CommunityFeedComponent implements OnDestroy {
   private readonly repository = inject(CommunityFeedRepository);
+  private readonly feedCache = inject(CommunityFeedCacheService);
   private readonly errorNotifier = inject(ErrorNotificationService);
   private readonly globalError = inject(GlobalErrorHandlerService);
   private readonly timeTicker = inject(CommunityFeedTimeTickerService);
@@ -266,86 +267,98 @@ export class CommunityFeedComponent implements OnDestroy {
   );
 
   readonly state$ = this.feedScope$.pipe(
-    switchMap(([communityId, view]) => {
-      const pageEvents$ = this.loadRequests$.pipe(
-        startWith<CommunityFeedLoadRequest>({
-          cursor: null,
-          append: false,
-          preserve: true,
-        }),
-        exhaustMap((request) =>
-          this.repository
-            .getPage$({
-              communityId,
-              view,
-              limit: 10,
-              cursor: request.cursor,
-            })
-            .pipe(
-              map(
-                (page): CommunityFeedLoadEvent => ({
-                  type: 'success',
-                  request,
-                  page,
+    switchMap(([communityId, view]) =>
+      this.feedCache.readSnapshot$(communityId, view).pipe(
+        switchMap((snapshot) => {
+          if (!snapshot) return of(INITIAL_COMMUNITY_FEED_STATE);
+
+          const pageEvents$ = this.loadRequests$.pipe(
+            startWith<CommunityFeedLoadRequest>({
+              cursor: null,
+              append: false,
+              preserve: true,
+            }),
+            exhaustMap((request) =>
+              this.repository
+                .getPage$({
+                  communityId,
+                  view,
+                  limit: 10,
+                  cursor: request.cursor,
                 })
-              ),
-              startWith<CommunityFeedLoadEvent>({
-                type: 'loading',
-                request,
-              }),
-              catchError((error: unknown) => {
-                this.reportLoadError(error, view);
-                return of<CommunityFeedLoadEvent>({ type: 'error', request });
-              })
+                .pipe(
+                  map(
+                    (page): CommunityFeedLoadEvent => ({
+                      type: 'success',
+                      request,
+                      page,
+                    })
+                  ),
+                  startWith<CommunityFeedLoadEvent>({
+                    type: 'loading',
+                    request,
+                  }),
+                  catchError((error: unknown) => {
+                    this.reportLoadError(error, view);
+                    return of<CommunityFeedLoadEvent>({ type: 'error', request });
+                  })
+                )
             )
-        )
-      );
+          );
 
-      const realtimeEvents$ = this.repository
-        .watchLatestChanges$(communityId, 20)
-        .pipe(
-          tap((changes) => this.reconcileRealtimeOverrides(changes)),
-          // Cada diff precisa concluir sua hidratação. Cancelar a chamada anterior
-          // em uma rajada pode fazer um post já sinalizado nunca entrar no estado.
-          concatMap((changes) =>
-            this.buildRealtimeEvent$(communityId, view, changes)
-          ),
-          catchError((error: unknown) => {
-            this.reportTechnicalError(error, 'watchRealtime', view);
-            return EMPTY;
-          })
-        );
+          const realtimeEvents$ = this.repository
+            .watchLatestChanges$(communityId, 20)
+            .pipe(
+              tap((changes) => this.reconcileRealtimeOverrides(changes)),
+              // Cada diff precisa concluir sua hidratação. Cancelar a chamada anterior
+              // em uma rajada pode fazer um post já sinalizado nunca entrar no estado.
+              concatMap((changes) =>
+                this.buildRealtimeEvent$(communityId, view, changes)
+              ),
+              catchError((error: unknown) => {
+                this.reportTechnicalError(error, 'watchRealtime', view);
+                return EMPTY;
+              })
+            );
 
-      const directedHydrationEvents$ = this.realtimeHydrationRequests$.pipe(
-        concatMap((postId) =>
-          this.repository.getItems$({
-            communityId,
-            view,
-            postIds: [postId],
-          }).pipe(
-            map((page): CommunityFeedLoadEvent => ({
-              type: 'realtime',
-              upserts: page.items,
-              metricPatches: [],
-              removedIds: [],
-            })),
-            catchError((error: unknown) => {
-              this.reportTechnicalError(error, 'hydrateRealtimeItem', view);
-              return EMPTY;
-            })
-          )
-        )
-      );
+          const directedHydrationEvents$ = this.realtimeHydrationRequests$.pipe(
+            concatMap((postId) =>
+              this.repository.getItems$({
+                communityId,
+                view,
+                postIds: [postId],
+              }).pipe(
+                map((page): CommunityFeedLoadEvent => ({
+                  type: 'realtime',
+                  upserts: page.items,
+                  metricPatches: [],
+                  removedIds: [],
+                })),
+                catchError((error: unknown) => {
+                  this.reportTechnicalError(error, 'hydrateRealtimeItem', view);
+                  return EMPTY;
+                })
+              )
+            )
+          );
 
-      return merge(
-        pageEvents$,
-        realtimeEvents$,
-        directedHydrationEvents$,
-        this.localFeedEvents$
-      ).pipe(
-        scan(reduceCommunityFeedState, INITIAL_COMMUNITY_FEED_STATE)
-      );
-    }),
+          const stateUpdates$ = merge(
+            pageEvents$,
+            realtimeEvents$,
+            directedHydrationEvents$,
+            this.localFeedEvents$
+          ).pipe(
+            tap((event) => this.feedCache.applyEvent(snapshot.query, event)),
+            ignoreElements()
+          );
+
+          return merge(
+            this.feedCache.state$(snapshot.query),
+            stateUpdates$
+          );
+        })
+      )
+    ),
     shareReplay({ bufferSize: 1, refCount: true })
   );
 

--- a/src/app/community/preview/community-preview-leave-confirmation.spec.ts
+++ b/src/app/community/preview/community-preview-leave-confirmation.spec.ts
@@ -13,6 +13,7 @@ import { CommunityFeedRepository } from '../data-access/community-feed.repositor
 import { CommunityMembershipRepository } from '../data-access/community-membership.repository';
 import { CommunityPreviewCard } from '../data-access/community-preview.model';
 import { CommunityPreviewRepository } from '../data-access/community-preview.repository';
+import { provideCommunityFeedCacheTestDouble } from '../feed/community-feed-cache.testing';
 import { CommunityPreviewPageComponent } from './community-preview-page.component';
 
 describe('CommunityPreviewPageComponent / confirmação de saída', () => {
@@ -87,6 +88,7 @@ describe('CommunityPreviewPageComponent / confirmação de saída', () => {
       imports: [CommunityPreviewPageComponent],
       providers: [
         provideRouter([]),
+        provideCommunityFeedCacheTestDouble(),
         {
           provide: ActivatedRoute,
           useValue: {

--- a/src/app/community/preview/community-preview-membership-visibility.spec.ts
+++ b/src/app/community/preview/community-preview-membership-visibility.spec.ts
@@ -15,6 +15,7 @@ import type {
   CommunityPreviewResponse,
 } from '../data-access/community-preview.model';
 import { CommunityPreviewRepository } from '../data-access/community-preview.repository';
+import { provideCommunityFeedCacheTestDouble } from '../feed/community-feed-cache.testing';
 import { CommunityPreviewPageComponent } from './community-preview-page.component';
 
 type JoinPolicy = 'open' | 'approval' | 'invite_only';
@@ -87,6 +88,7 @@ describe('CommunityPreviewPageComponent / comunicação de adesão', () => {
       imports: [CommunityPreviewPageComponent],
       providers: [
         provideRouter([]),
+        provideCommunityFeedCacheTestDouble(),
         {
           provide: ActivatedRoute,
           useValue: {

--- a/src/app/community/preview/community-preview-page.component.spec.ts
+++ b/src/app/community/preview/community-preview-page.component.spec.ts
@@ -11,6 +11,7 @@ import { CommunityFeedRepository } from '../data-access/community-feed.repositor
 import { CommunityMembershipRepository } from '../data-access/community-membership.repository';
 import { CommunityPreviewResponse } from '../data-access/community-preview.model';
 import { CommunityPreviewRepository } from '../data-access/community-preview.repository';
+import { provideCommunityFeedCacheTestDouble } from '../feed/community-feed-cache.testing';
 import { CommunityPreviewPageComponent } from './community-preview-page.component';
 
 function preview(
@@ -113,6 +114,7 @@ describe('CommunityPreviewPageComponent / Local', () => {
       imports: [CommunityPreviewPageComponent],
       providers: [
         provideRouter([]),
+        provideCommunityFeedCacheTestDouble(),
         {
           provide: ActivatedRoute,
           useValue: {

--- a/src/app/community/preview/community-preview-topics.spec.ts
+++ b/src/app/community/preview/community-preview-topics.spec.ts
@@ -10,6 +10,7 @@ import { CommunityFeedRepository } from '../data-access/community-feed.repositor
 import { CommunityMembershipRepository } from '../data-access/community-membership.repository';
 import { CommunityPreviewRepository } from '../data-access/community-preview.repository';
 import { CommunityTopicRepository } from '../data-access/community-topic.repository';
+import { provideCommunityFeedCacheTestDouble } from '../feed/community-feed-cache.testing';
 import { CommunityPreviewPageComponent } from './community-preview-page.component';
 
 const now = Date.now();
@@ -92,6 +93,7 @@ describe('CommunityPreviewPageComponent / Tópicos', () => {
       imports: [CommunityPreviewPageComponent],
       providers: [
         provideRouter([]),
+        provideCommunityFeedCacheTestDouble(),
         {
           provide: ActivatedRoute,
           useValue: {

--- a/src/app/store/actions/actions.community/community-feed-cache.actions.ts
+++ b/src/app/store/actions/actions.community/community-feed-cache.actions.ts
@@ -1,0 +1,32 @@
+// src/app/store/actions/actions.community/community-feed-cache.actions.ts
+
+import { createAction, props } from '@ngrx/store';
+
+import type { CommunityFeedCacheQuery } from 'src/app/community/feed/community-feed-cache.model';
+import type { CommunityFeedLoadEvent } from 'src/app/community/feed/community-feed-state.model';
+
+export const activateCommunityFeedViewer = createAction(
+  '[Community Feed Cache] Activate Viewer',
+  props<{ viewerUid: string | null }>()
+);
+
+export const touchCommunityFeedScope = createAction(
+  '[Community Feed Cache] Touch Scope',
+  props<{
+    query: CommunityFeedCacheQuery;
+    accessedAt: number;
+  }>()
+);
+
+export const applyCommunityFeedEvent = createAction(
+  '[Community Feed Cache] Apply Event',
+  props<{
+    query: CommunityFeedCacheQuery;
+    event: CommunityFeedLoadEvent;
+    occurredAt: number;
+  }>()
+);
+
+export const clearCommunityFeedCache = createAction(
+  '[Community Feed Cache] Clear'
+);

--- a/src/app/store/reducers/feature-keys.ts
+++ b/src/app/store/reducers/feature-keys.ts
@@ -21,6 +21,9 @@ export const STORE_FEATURE = {
   discoveryFeeds: 'discoveryFeeds',
   communityDiscoveryCache: 'communityDiscoveryCache',
 
+  // COMMUNITY DOMAIN
+  communityFeedCache: 'communityFeedCache',
+
   // INTERACTIONS DOMAIN
   friendsPages: 'friendsPages',
   interactionsFriends: 'interactions_friends',

--- a/src/app/store/reducers/index.ts
+++ b/src/app/store/reducers/index.ts
@@ -14,6 +14,7 @@ import { locationReducers } from './reducers.location';
 import { interactionsReducers } from './reducers.interactions';
 import { discoveryFeedReducer } from './reducers.discovery/discovery-feed.reducer';
 import { communityDiscoveryCacheReducer } from './reducers.discovery/community-discovery-cache.reducer';
+import { communityFeedCacheReducer } from './reducers.community/community-feed-cache.reducer';
 
 export const reducers: ActionReducerMap<AppState> = {
   // USER DOMAIN
@@ -33,6 +34,9 @@ export const reducers: ActionReducerMap<AppState> = {
   // DISCOVERY DOMAIN
   [STORE_FEATURE.discoveryFeeds]: discoveryFeedReducer,
   [STORE_FEATURE.communityDiscoveryCache]: communityDiscoveryCacheReducer,
+
+  // COMMUNITY DOMAIN
+  [STORE_FEATURE.communityFeedCache]: communityFeedCacheReducer,
 
   // INTERACTIONS DOMAIN
   [STORE_FEATURE.friendsPages]: interactionsReducers.friendsPages,

--- a/src/app/store/reducers/reducers.community/community-feed-cache.reducer.spec.ts
+++ b/src/app/store/reducers/reducers.community/community-feed-cache.reducer.spec.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest';
+
+import type { CommunityFeedItem } from 'src/app/community/data-access/community-feed.model';
+import {
+  COMMUNITY_FEED_CACHE_HARD_TTL_MS,
+  COMMUNITY_FEED_CACHE_MAX_SCOPES,
+  buildCommunityFeedCacheKey,
+  buildCommunityFeedCacheQuery,
+} from 'src/app/community/feed/community-feed-cache.model';
+
+import * as CommunityFeedCacheActions from '../../actions/actions.community/community-feed-cache.actions';
+import { initialCommunityFeedCacheState } from '../../states/states.community/community-feed-cache.state';
+import { communityFeedCacheReducer } from './community-feed-cache.reducer';
+
+const NOW = 1_800_000_000_000;
+
+function item(postId: string): CommunityFeedItem {
+  return {
+    postId,
+    kind: 'text',
+    author: { label: 'Participante', avatarUrl: null },
+    text: `Mensagem ${postId}`,
+    image: null,
+    replyTo: null,
+    metrics: { commentCount: 0, reactionCount: 0 },
+    capabilities: {
+      canDeleteOwn: false,
+      canModerate: false,
+      canReport: true,
+      canReact: true,
+      viewerReacted: false,
+      canViewComments: true,
+      canComment: true,
+    },
+    publishedAt: NOW,
+  };
+}
+
+function query(viewerUid: string, communityId: string) {
+  return buildCommunityFeedCacheQuery(viewerUid, communityId, 'feed')!;
+}
+
+function storeFirstPage(
+  state = initialCommunityFeedCacheState,
+  viewerUid = 'user-1',
+  communityId = 'community-1',
+  occurredAt = NOW
+) {
+  const scope = query(viewerUid, communityId);
+  return communityFeedCacheReducer(state, CommunityFeedCacheActions.applyCommunityFeedEvent({
+    query: scope,
+    event: {
+      type: 'success',
+      request: { cursor: null, append: false, preserve: true },
+      page: {
+        items: [item(`${communityId}-post`)],
+        nextCursor: 'next-page',
+        generatedAt: occurredAt,
+      },
+    },
+    occurredAt,
+  }));
+}
+
+describe('communityFeedCacheReducer', () => {
+  it('limpa snapshots quando o viewer muda', () => {
+    const populated = storeFirstPage();
+    const switched = communityFeedCacheReducer(
+      populated,
+      CommunityFeedCacheActions.activateCommunityFeedViewer({ viewerUid: 'user-2' })
+    );
+
+    expect(switched.activeViewerUid).toBe('user-2');
+    expect(switched.byScope).toEqual({});
+  });
+
+  it('reutiliza o reducer canônico de timeline para realtime', () => {
+    const scope = query('user-1', 'community-1');
+    const populated = storeFirstPage();
+    const realtime = communityFeedCacheReducer(
+      populated,
+      CommunityFeedCacheActions.applyCommunityFeedEvent({
+        query: scope,
+        event: {
+          type: 'realtime',
+          upserts: [item('post-realtime')],
+          metricPatches: [],
+          removedIds: [],
+        },
+        occurredAt: NOW + 1_000,
+      })
+    );
+    const slice = realtime.byScope[buildCommunityFeedCacheKey(scope)];
+
+    expect(slice.state.items.map((entry) => entry.postId)).toContain('post-realtime');
+    expect(slice.lastLoadedAt).toBe(NOW);
+  });
+
+  it('paginação não renova a idade da primeira página', () => {
+    const scope = query('user-1', 'community-1');
+    const populated = storeFirstPage();
+    const paginated = communityFeedCacheReducer(
+      populated,
+      CommunityFeedCacheActions.applyCommunityFeedEvent({
+        query: scope,
+        event: {
+          type: 'success',
+          request: { cursor: 'next-page', append: true },
+          page: {
+            items: [item('older-post')],
+            nextCursor: null,
+            generatedAt: NOW + 60_000,
+          },
+        },
+        occurredAt: NOW + 60_000,
+      })
+    );
+
+    expect(paginated.byScope[buildCommunityFeedCacheKey(scope)].lastLoadedAt).toBe(NOW);
+  });
+
+  it('hard expiry descarta o escopo inteiro antes de reutilizar mídia antiga', () => {
+    const scope = query('user-1', 'community-1');
+    const populated = storeFirstPage();
+    const touched = communityFeedCacheReducer(
+      populated,
+      CommunityFeedCacheActions.touchCommunityFeedScope({
+        query: scope,
+        accessedAt: NOW + COMMUNITY_FEED_CACHE_HARD_TTL_MS,
+      })
+    );
+    const slice = touched.byScope[buildCommunityFeedCacheKey(scope)];
+
+    expect(slice.state.items).toEqual([]);
+    expect(slice.lastLoadedAt).toBe(0);
+  });
+
+  it('limita o cache aos escopos mais recentemente acessados', () => {
+    let state = initialCommunityFeedCacheState;
+
+    for (let index = 0; index < COMMUNITY_FEED_CACHE_MAX_SCOPES + 2; index += 1) {
+      state = storeFirstPage(
+        state,
+        'user-1',
+        `community-${index}`,
+        NOW + index
+      );
+    }
+
+    expect(Object.keys(state.byScope)).toHaveLength(COMMUNITY_FEED_CACHE_MAX_SCOPES);
+    expect(
+      state.byScope[buildCommunityFeedCacheKey(query('user-1', 'community-0'))]
+    ).toBeUndefined();
+    expect(
+      state.byScope[buildCommunityFeedCacheKey(query('user-1', 'community-7'))]
+    ).toBeDefined();
+  });
+});

--- a/src/app/store/reducers/reducers.community/community-feed-cache.reducer.ts
+++ b/src/app/store/reducers/reducers.community/community-feed-cache.reducer.ts
@@ -1,0 +1,139 @@
+// src/app/store/reducers/reducers.community/community-feed-cache.reducer.ts
+
+import { createReducer, on } from '@ngrx/store';
+
+import {
+  COMMUNITY_FEED_CACHE_MAX_SCOPES,
+  buildCommunityFeedCacheKey,
+  isCommunityFeedCacheHardExpired,
+} from 'src/app/community/feed/community-feed-cache.model';
+import {
+  INITIAL_COMMUNITY_FEED_STATE,
+  reduceCommunityFeedState,
+} from 'src/app/community/feed/community-feed-state.model';
+
+import * as CommunityFeedCacheActions from '../../actions/actions.community/community-feed-cache.actions';
+import {
+  CommunityFeedCacheSlice,
+  CommunityFeedCacheState,
+  initialCommunityFeedCacheState,
+} from '../../states/states.community/community-feed-cache.state';
+
+function normalizeTimestamp(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.trunc(value)) : 0;
+}
+
+function initialSlice(accessedAt: number): CommunityFeedCacheSlice {
+  return {
+    state: INITIAL_COMMUNITY_FEED_STATE,
+    lastLoadedAt: 0,
+    lastAccessedAt: normalizeTimestamp(accessedAt),
+  };
+}
+
+function scopeToViewer(
+  state: CommunityFeedCacheState,
+  viewerUid: string | null
+): CommunityFeedCacheState {
+  if (!viewerUid) return initialCommunityFeedCacheState;
+  if (state.activeViewerUid === viewerUid) return state;
+
+  return {
+    activeViewerUid: viewerUid,
+    byScope: {},
+  };
+}
+
+function pruneScopes(
+  byScope: Readonly<Record<string, CommunityFeedCacheSlice>>,
+  now: number
+): Readonly<Record<string, CommunityFeedCacheSlice>> {
+  const activeEntries = Object.entries(byScope)
+    .filter(([, slice]) =>
+      !isCommunityFeedCacheHardExpired(slice.lastLoadedAt, now)
+    )
+    .sort((left, right) =>
+      right[1].lastAccessedAt - left[1].lastAccessedAt
+      || right[1].lastLoadedAt - left[1].lastLoadedAt
+      || left[0].localeCompare(right[0])
+    )
+    .slice(0, COMMUNITY_FEED_CACHE_MAX_SCOPES);
+
+  return Object.fromEntries(activeEntries);
+}
+
+export const communityFeedCacheReducer = createReducer(
+  initialCommunityFeedCacheState,
+
+  on(
+    CommunityFeedCacheActions.activateCommunityFeedViewer,
+    (state, { viewerUid }) => scopeToViewer(state, viewerUid)
+  ),
+
+  on(
+    CommunityFeedCacheActions.touchCommunityFeedScope,
+    (state, { query, accessedAt }) => {
+      const now = normalizeTimestamp(accessedAt);
+      const scoped = scopeToViewer(state, query.viewerUid);
+      const key = buildCommunityFeedCacheKey(query);
+      const current = scoped.byScope[key];
+      const base = current
+        && !isCommunityFeedCacheHardExpired(current.lastLoadedAt, now)
+        ? current
+        : initialSlice(now);
+      const nextSlice: CommunityFeedCacheSlice = {
+        ...base,
+        lastAccessedAt: now,
+      };
+
+      return {
+        ...scoped,
+        byScope: pruneScopes(
+          {
+            ...scoped.byScope,
+            [key]: nextSlice,
+          },
+          now
+        ),
+      };
+    }
+  ),
+
+  on(
+    CommunityFeedCacheActions.applyCommunityFeedEvent,
+    (state, { query, event, occurredAt }) => {
+      const now = normalizeTimestamp(occurredAt);
+      const scoped = scopeToViewer(state, query.viewerUid);
+      const key = buildCommunityFeedCacheKey(query);
+      const current = scoped.byScope[key];
+      const base = current
+        && !isCommunityFeedCacheHardExpired(current.lastLoadedAt, now)
+        ? current
+        : initialSlice(now);
+      const nextState = reduceCommunityFeedState(base.state, event);
+      const refreshesFirstPage =
+        event.type === 'success' && event.request.append !== true;
+      const nextSlice: CommunityFeedCacheSlice = {
+        state: nextState,
+        lastLoadedAt: refreshesFirstPage ? now : base.lastLoadedAt,
+        lastAccessedAt: now,
+      };
+
+      return {
+        ...scoped,
+        byScope: pruneScopes(
+          {
+            ...scoped.byScope,
+            [key]: nextSlice,
+          },
+          now
+        ),
+      };
+    }
+  ),
+
+  on(
+    CommunityFeedCacheActions.clearCommunityFeedCache,
+    () => initialCommunityFeedCacheState
+  )
+);

--- a/src/app/store/selectors/selectors.community/community-feed-cache.selectors.ts
+++ b/src/app/store/selectors/selectors.community/community-feed-cache.selectors.ts
@@ -1,0 +1,41 @@
+// src/app/store/selectors/selectors.community/community-feed-cache.selectors.ts
+
+import { createFeatureSelector, createSelector } from '@ngrx/store';
+
+import type { CommunityFeedCacheQuery } from 'src/app/community/feed/community-feed-cache.model';
+import { buildCommunityFeedCacheKey } from 'src/app/community/feed/community-feed-cache.model';
+import { INITIAL_COMMUNITY_FEED_STATE } from 'src/app/community/feed/community-feed-state.model';
+
+import { STORE_FEATURE } from '../../reducers/feature-keys';
+import type {
+  CommunityFeedCacheSlice,
+  CommunityFeedCacheState,
+} from '../../states/states.community/community-feed-cache.state';
+
+export const selectCommunityFeedCache =
+  createFeatureSelector<CommunityFeedCacheState>(
+    STORE_FEATURE.communityFeedCache
+  );
+
+export function selectCommunityFeedCacheSlice(
+  query: CommunityFeedCacheQuery
+) {
+  const key = buildCommunityFeedCacheKey(query);
+
+  return createSelector(
+    selectCommunityFeedCache,
+    (state): CommunityFeedCacheSlice | null => {
+      if (state.activeViewerUid !== query.viewerUid) return null;
+      return state.byScope[key] ?? null;
+    }
+  );
+}
+
+export function selectCommunityFeedState(
+  query: CommunityFeedCacheQuery
+) {
+  return createSelector(
+    selectCommunityFeedCacheSlice(query),
+    (slice) => slice?.state ?? INITIAL_COMMUNITY_FEED_STATE
+  );
+}

--- a/src/app/store/states/app.state.ts
+++ b/src/app/store/states/app.state.ts
@@ -14,6 +14,7 @@ import { friendsPaginationReducer } from '../reducers/reducers.interactions/frie
 import { friendsReducer } from '../reducers/reducers.interactions/friends.reducer';
 import { discoveryFeedReducer } from '../reducers/reducers.discovery/discovery-feed.reducer';
 import { communityDiscoveryCacheReducer } from '../reducers/reducers.discovery/community-discovery-cache.reducer';
+import { communityFeedCacheReducer } from '../reducers/reducers.community/community-feed-cache.reducer';
 
 export interface AppState {
   // USER DOMAIN
@@ -34,6 +35,9 @@ export interface AppState {
   // DISCOVERY DOMAIN
   discoveryFeeds: ReturnType<typeof discoveryFeedReducer>;
   communityDiscoveryCache: ReturnType<typeof communityDiscoveryCacheReducer>;
+
+  // COMMUNITY DOMAIN
+  communityFeedCache: ReturnType<typeof communityFeedCacheReducer>;
 
   // INTERACTIONS DOMAIN
   interactions_friends: ReturnType<typeof friendsReducer>;

--- a/src/app/store/states/states.community/community-feed-cache.state.ts
+++ b/src/app/store/states/states.community/community-feed-cache.state.ts
@@ -1,0 +1,19 @@
+// src/app/store/states/states.community/community-feed-cache.state.ts
+
+import type { CommunityFeedState } from 'src/app/community/feed/community-feed-state.model';
+
+export interface CommunityFeedCacheSlice {
+  readonly state: CommunityFeedState;
+  readonly lastLoadedAt: number;
+  readonly lastAccessedAt: number;
+}
+
+export interface CommunityFeedCacheState {
+  readonly activeViewerUid: string | null;
+  readonly byScope: Readonly<Record<string, CommunityFeedCacheSlice>>;
+}
+
+export const initialCommunityFeedCacheState: CommunityFeedCacheState = {
+  activeViewerUid: null,
+  byScope: {},
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -43,6 +43,7 @@
   "include": ["src/**/*.ts", "src/**/*.d.ts"],
   "exclude": [
     "src/**/*.spec.ts",
+    "src/**/*.testing.ts",
     "src/test/**/*.ts",
     "jest.config.mjs"
   ]


### PR DESCRIPTION
## Objetivo

Evoluir a reatividade do Mural para uma timeline com continuidade entre navegações, preservando RxJS/Firebase como camada de I/O e usando o NgRx existente como autoridade do estado serializável do feed.

## Arquitetura

- cache por `viewerUid + communityId + view`;
- isolamento obrigatório entre sessões/viewers;
- soft TTL de 30 segundos para continuidade visual;
- hard TTL de 5 minutos para impedir retenção prolongada de URLs temporárias;
- limite LRU de 6 escopos completos;
- stale-while-revalidate: cache aparece imediatamente, mas a callable sempre revalida ao montar a tela;
- paginação/realtime continuam usando `reduceCommunityFeedState` como transição canônica;
- Firebase/callables permanecem no `CommunityFeedRepository` e em Observables;
- NgRx não recebe `File`, DOM, câmera, formulário ou outro estado não serializável.

## Estado local preservado

Continuam no `CommunityFeedComponent`:

- composer/formulário;
- seleção e preview local de anexos;
- câmera;
- scroll/focus/highlight;
- follow inteligente;
- comentários abertos/reply context;
- mutations e overrides otimistas nesta primeira etapa.

## Supressão / ocultação

Foi suprimido do componente apenas o `scan(reduceCommunityFeedState, INITIAL_COMMUNITY_FEED_STATE)` que mantinha uma segunda autoridade local da timeline. A mesma função pura `reduceCommunityFeedState` continua sendo utilizada pelo reducer NgRx.

Nenhum método de UI, câmera, composer, comentários, reactions, acessibilidade ou tratamento centralizado de erros foi removido ou ocultado.

## Segurança do cache

Os itens do Mural carregam `capabilities` e `viewerReacted`; por isso snapshots nunca são compartilhados entre UIDs. A troca de viewer limpa o cache integralmente.

## Ajuste dos testes

O primeiro CI do draft identificou `NG0201: No provider found for Store` em nove TestBeds que renderizam `CommunityFeedComponent` direta ou indiretamente. O runtime estava corretamente configurado; a deficiência era exclusiva da infraestrutura dos testes standalone.

A correção não tornou `Store` opcional nem adicionou fallback ao código de produção. Foi criado um double reativo de `CommunityFeedCacheService` para testes de componente, reutilizando `reduceCommunityFeedState`, enquanto os testes dedicados de reducer/cache continuam cobrindo a integração NgRx. Cada TestBed afetado recebeu apenas o import e o provider desse double.

O helper `*.testing.ts` foi explicitamente excluído da compilação da aplicação via `tsconfig.json` e permanece incluído no `tsconfig.spec.json`.

## Validação final

HEAD validado: `5c564afe815397e47fbc0b0c5ed65082bbb7088a`.

- Angular CI Validation: sucesso;
- Angular tests: sucesso;
- Angular safe build / emulator configuration: sucesso;
- Quality Gate: sucesso;
- canonical Community contracts: sucesso;
- Functions lint/build/tests: sucesso;
- Firestore Rules tests: sucesso;
- Firestore indexes: sucesso;
- Media E2E: sucesso.

Na correção do CI, nenhum código de produção existente foi suprimido ou removido. Nos nove specs existentes foram adicionadas exatamente duas linhas por arquivo (import + provider), sem deleções.