### PR TITLE
fix(community): simplify legacy history and dismiss media menu

### DIFF
--- a/src/app/community/feed/community-feed-attachment-source.spec.ts
+++ b/src/app/community/feed/community-feed-attachment-source.spec.ts
@@ -145,8 +145,54 @@ describe('CommunityFeedComponent attachment sources', () => {
     cameraAction?.click();
     fixture.detectChanges();
 
-    expect(menu?.open).toBe(true);
     expect(fixture.nativeElement.querySelector('[role="dialog"]')).not.toBeNull();
+  });
+
+  it('fecha o menu ao clicar fora e ao pressionar Escape', () => {
+    const fixture = createFixture();
+    const menu = fixture.nativeElement.querySelector(
+      '.community-feed__attachment-menu'
+    ) as HTMLDetailsElement;
+    const trigger = menu.querySelector('summary') as HTMLElement;
+
+    trigger.click();
+    fixture.detectChanges();
+    expect(menu.open).toBe(true);
+
+    document.body.dispatchEvent(
+      new PointerEvent('pointerdown', { bubbles: true })
+    );
+    fixture.detectChanges();
+    expect(menu.open).toBe(false);
+
+    trigger.click();
+    fixture.detectChanges();
+    expect(menu.open).toBe(true);
+
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+    );
+    fixture.detectChanges();
+    expect(menu.open).toBe(false);
+  });
+
+  it('não fecha o menu em interação interna antes da ação escolhida', () => {
+    const fixture = createFixture();
+    const menu = fixture.nativeElement.querySelector(
+      '.community-feed__attachment-menu'
+    ) as HTMLDetailsElement;
+    const trigger = menu.querySelector('summary') as HTMLElement;
+    const panel = menu.querySelector(
+      '.community-post__menu-panel'
+    ) as HTMLElement;
+
+    trigger.click();
+    fixture.detectChanges();
+    expect(menu.open).toBe(true);
+
+    panel.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+    fixture.detectChanges();
+    expect(menu.open).toBe(true);
   });
 
   it('fecha o menu para Galeria e envia a foto escolhida ao editor canônico', () => {

--- a/src/app/community/feed/community-feed-attachment-source.spec.ts
+++ b/src/app/community/feed/community-feed-attachment-source.spec.ts
@@ -161,7 +161,7 @@ describe('CommunityFeedComponent attachment sources', () => {
     expect(menu.open).toBe(true);
 
     document.body.dispatchEvent(
-      new PointerEvent('pointerdown', { bubbles: true })
+      new Event('pointerdown', { bubbles: true })
     );
     fixture.detectChanges();
     expect(menu.open).toBe(false);
@@ -191,7 +191,7 @@ describe('CommunityFeedComponent attachment sources', () => {
     fixture.detectChanges();
     expect(menu.open).toBe(true);
 
-    panel.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+    panel.dispatchEvent(new Event('pointerdown', { bubbles: true }));
     fixture.detectChanges();
     expect(menu.open).toBe(true);
   });

--- a/src/app/community/feed/community-feed-attachment-source.spec.ts
+++ b/src/app/community/feed/community-feed-attachment-source.spec.ts
@@ -145,6 +145,7 @@ describe('CommunityFeedComponent attachment sources', () => {
     cameraAction?.click();
     fixture.detectChanges();
 
+    expect(menu?.open).toBe(false);
     expect(fixture.nativeElement.querySelector('[role="dialog"]')).not.toBeNull();
   });
 

--- a/src/app/community/feed/community-feed-legacy-comments-access.spec.ts
+++ b/src/app/community/feed/community-feed-legacy-comments-access.spec.ts
@@ -129,23 +129,18 @@ describe('CommunityFeedComponent legacy comments access', () => {
     expect(reaction.querySelector('.community-post__action-count')?.textContent).toContain('3');
   });
 
-  it('oferece acesso secundário somente quando há mensagens anteriores', () => {
+  it('não reintroduz acesso ao histórico legado mesmo quando há mensagens anteriores', () => {
     const fixture = createFixture(2);
-    const legacyAccess = fixture.nativeElement.querySelector(
-      '.community-post__comments-toggle'
-    ) as HTMLButtonElement;
 
-    expect(legacyAccess).not.toBeNull();
-    expect(legacyAccess.textContent).toContain('Ver');
-    expect(legacyAccess.textContent).toContain('2');
-    expect(legacyAccess.textContent).toContain('mensagens anteriores');
-
-    legacyAccess.click();
-    fixture.detectChanges();
-
-    expect(legacyAccess.getAttribute('aria-expanded')).toBe('true');
+    expect(fixture.nativeElement.textContent).toContain('Responder');
+    expect(fixture.nativeElement.textContent).not.toContain('mensagens anteriores');
+    expect(fixture.nativeElement.textContent).not.toContain('mensagem anterior');
+    expect(
+      fixture.nativeElement.querySelector('.community-post__comments-toggle')
+    ).toBeNull();
     expect(
       fixture.nativeElement.querySelector('app-community-feed-comments')
-    ).not.toBeNull();
+    ).toBeNull();
+    expect(commentRepository.getPage$).not.toHaveBeenCalled();
   });
 });

--- a/src/app/community/feed/community-feed.component.html
+++ b/src/app/community/feed/community-feed.component.html
@@ -419,35 +419,6 @@
                 }
               </footer>
 
-              <!--
-                Histórico legado preservado para compatibilidade/migração, mas não
-                é mais uma superfície navegável do Mural. O atributo hidden remove
-                o controle do layout, do foco e da árvore de acessibilidade.
-              -->
-              @if (item.capabilities.canViewComments && commentCount(item) > 0) {
-                <div
-                  class="community-post__metrics"
-                  aria-label="Histórico anterior da publicação"
-                  hidden
-                >
-                  <button
-                    class="community-post__action community-post__comments-toggle"
-                    type="button"
-                    [attr.aria-expanded]="commentsOpen(item)"
-                    [attr.aria-controls]="'community-feed-comments-' + item.postId"
-                    [attr.aria-label]="(commentsOpen(item) ? 'Ocultar ' : 'Ver ') + commentCount(item) + (commentCount(item) === 1 ? ' mensagem anterior.' : ' mensagens anteriores.')"
-                    (click)="toggleComments(item)"
-                  >
-                    <i class="fas fa-clock-rotate-left" aria-hidden="true"></i>
-                    <span class="community-post__action-label">
-                      {{ commentsOpen(item) ? 'Ocultar' : 'Ver' }}
-                      {{ commentCount(item) }}
-                      {{ commentCount(item) === 1 ? 'mensagem anterior' : 'mensagens anteriores' }}
-                    </span>
-                  </button>
-                </div>
-              }
-
               @if (commentsOpen(item)) {
                 <app-community-feed-comments
                   [communityId]="communityId()"

--- a/src/app/community/feed/community-feed.component.html
+++ b/src/app/community/feed/community-feed.component.html
@@ -114,6 +114,7 @@
                 <app-community-camera-capture
                   #cameraCapture
                   [disabled]="writeState.status === 'loading'"
+                  (opened)="attachmentMenu.open = false"
                   (closed)="attachmentMenu.open = false"
                   (attachmentCaptured)="attachmentMenu.open = false; removeSelectedPhoto(); selectedAttachment.set($event); expandComposer()"
                   (fallbackRequested)="attachmentMenu.open = false; cameraPhotoInput.click()"

--- a/src/app/community/feed/community-feed.component.html
+++ b/src/app/community/feed/community-feed.component.html
@@ -83,11 +83,14 @@
             <details
               #attachmentMenu
               class="community-post__menu community-feed__attachment-menu"
+              (document:pointerdown)="attachmentMenu.open && !attachmentMenu.contains($any($event.target)) ? attachmentMenu.open = false : null"
+              (document:keydown.escape)="attachmentMenu.open = false"
             >
               <summary
                 class="community-feed__composer-tool"
                 aria-label="Adicionar ao Mural"
                 title="Adicionar"
+                [attr.aria-expanded]="attachmentMenu.open"
                 [attr.aria-disabled]="writeState.status === 'loading' ? 'true' : null"
                 (click)="writeState.status === 'loading' ? $event.preventDefault() : null"
               >
@@ -415,8 +418,17 @@
                 }
               </footer>
 
+              <!--
+                Histórico legado preservado para compatibilidade/migração, mas não
+                é mais uma superfície navegável do Mural. O atributo hidden remove
+                o controle do layout, do foco e da árvore de acessibilidade.
+              -->
               @if (item.capabilities.canViewComments && commentCount(item) > 0) {
-                <div class="community-post__metrics" aria-label="Histórico anterior da publicação">
+                <div
+                  class="community-post__metrics"
+                  aria-label="Histórico anterior da publicação"
+                  hidden
+                >
                   <button
                     class="community-post__action community-post__comments-toggle"
                     type="button"

--- a/src/app/community/feed/community-feed.component.spec.ts
+++ b/src/app/community/feed/community-feed.component.spec.ts
@@ -297,41 +297,25 @@ describe('CommunityFeedComponent', () => {
     expect(removed.items).toHaveLength(0);
   });
 
-  it('abre comentários autorizados também no item retornado pelo Mural', () => {
+  it('mantém Responder sem reabrir o histórico legado', () => {
     const interactivePage = page();
     interactivePage.items[0].capabilities.canViewComments = true;
     interactivePage.items[0].capabilities.canComment = true;
     repositoryMock.getPage$.mockReturnValue(of(interactivePage));
-    commentRepositoryMock.getPage$.mockReturnValue(of({
-      items: [],
-      nextCursor: null,
-      generatedAt: Date.now(),
-    }));
     const fixture = create('feed', 'community', true, 'member');
-    const toggle = fixture.nativeElement.querySelector(
-      '.community-post__comments-toggle'
+    const reply = fixture.nativeElement.querySelector(
+      '.community-post__reply'
     ) as HTMLButtonElement;
 
-    expect(toggle).not.toBeNull();
-    expect(toggle.getAttribute('aria-expanded')).toBe('false');
-    toggle.click();
-    fixture.detectChanges();
-
-    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    expect(reply).not.toBeNull();
+    expect(reply.textContent).toContain('Responder');
+    expect(
+      fixture.nativeElement.querySelector('.community-post__comments-toggle')
+    ).toBeNull();
     expect(
       fixture.nativeElement.querySelector('app-community-feed-comments')
-    ).not.toBeNull();
-    expect(fixture.nativeElement.querySelector(
-      'app-community-feed-comments textarea'
-    )).not.toBeNull();
-    expect(commentRepositoryMock.getPage$).toHaveBeenCalledWith(expect.objectContaining({
-      communityId: 'community-1',
-      postId: 'post-1',
-    }));
-
-    fixture.componentInstance.updateCommentCount(interactivePage.items[0], 4);
-    fixture.detectChanges();
-    expect(toggle.textContent).toContain('4');
+    ).toBeNull();
+    expect(commentRepositoryMock.getPage$).not.toHaveBeenCalled();
   });
 
   it('mostra estados vazios coerentes por contexto', () => {


### PR DESCRIPTION
## Objetivo

Corrigir dois problemas observados na inspeção visual do Mural:

1. remover da interface o controle `Ver/Ocultar mensagem anterior`, que criava uma segunda navegação paralela sem sentido na timeline;
2. fazer o seletor `Galeria / Câmera` fechar ao clicar/tocar fora, ao pressionar `Escape` e assim que a câmera é aberta.

## Histórico legado

O bloco visual `community-post__comments-toggle` foi **removido do template**, não apenas escondido. Mesmo quando documentos antigos ainda trazem `commentCount > 0`, o Mural não oferece mais `Ver/Ocultar mensagem anterior` nem abre esse histórico por uma ação secundária.

Os dados legados de `CommunityFeedComment` **não foram apagados** nesta correção. Eles permanecem preservados para compatibilidade/migração e para evitar mistura entre uma decisão de UX e uma eventual limpeza física de dados.

O fluxo `Responder` permanece intacto: ele reutiliza o compositor necessário e continua criando uma nova publicação canônica do Mural via `replyToPostId`.

## Menu Galeria / Câmera

O `<details>` existente agora:

- observa `document:pointerdown` e fecha somente quando a interação acontece fora dele;
- fecha com `Escape`;
- fecha antes de abrir a Galeria;
- fecha imediatamente no evento `opened` da câmera;
- continua fechando em `closed`, captura e fallback.

`pointerdown` cobre mouse, toque e caneta no navegador. O teste dispara um `Event('pointerdown')` porque o ambiente headless não expõe o construtor global `PointerEvent`; isso não altera o evento ouvido no runtime.

## Testes

`community-feed-attachment-source.spec.ts` cobre:

- clicar/tocar fora fecha;
- `Escape` fecha;
- interação interna não fecha prematuramente;
- Galeria fecha antes de abrir o seletor/editor canônico;
- Câmera fecha o menu assim que abre.

`community-feed-legacy-comments-access.spec.ts` e `community-feed.component.spec.ts` garantem que `commentCount` legado não reintroduz a ação visual nem carrega a conversa paralela, preservando o botão `Responder`.

## Supressão / remoção explícita

Foi **removido** do template o bloco `community-post__comments-toggle` (`Ver/Ocultar mensagem anterior`), totalizando 20 linhas de markup legado. Motivo: essa superfície duplicava a navegação de conversa e não corresponde ao modelo atual, em que respostas relevantes pertencem à própria timeline.

Não foram removidos dados de comentários legados, nem métodos de Galeria, câmera, editor de foto, publicação, resposta, reação, moderação ou tratamento centralizado de erros.

## Validação final

HEAD validado: `4f683adc844648c5c989f0b3afd85691dff589e1`.

- Quality Gate: sucesso;
- Angular tests: sucesso;
- Angular safe build: sucesso;
- Angular CI Validation: sucesso;
- build de emulador: sucesso;
- Functions lint/build/tests: sucesso;
- Firestore Rules tests: sucesso;
- Firestore indexes: sucesso;
- contratos canônicos de Community: sucesso.

O workflow Media E2E não foi disparado para este HEAD porque o PR altera apenas template/specs do Mural e não corresponde ao filtro de caminhos desse workflow.