### PR TITLE
fix(community): keep discovery cache coherent after mutations

### DIFF
--- a/src/app/community/data-access/community-create.repository.ts
+++ b/src/app/community/data-access/community-create.repository.ts
@@ -1,7 +1,7 @@
 // src/app/community/data-access/community-create.repository.ts
 import { Injectable, inject } from '@angular/core';
 import { Functions, httpsCallable } from '@angular/fire/functions';
-import { Observable, defer, from, map } from 'rxjs';
+import { Observable, defer, from, map, tap } from 'rxjs';
 
 import {
   CommunityCreateCommand,
@@ -12,10 +12,12 @@ import {
   CommunityCreationCapability,
   normalizeCommunityCreationCapability,
 } from './community-capacity.model';
+import { CommunityDomainEventsService } from './community-domain-events.service';
 
 @Injectable({ providedIn: 'root' })
 export class CommunityCreateRepository {
   private readonly functions = inject(Functions);
+  private readonly domainEvents = inject(CommunityDomainEventsService);
 
   private readonly createCommunityCallable = httpsCallable<
     CommunityCreateCommand,
@@ -53,7 +55,10 @@ export class CommunityCreateRepository {
         }
 
         return normalized;
-      })
+      }),
+      tap((result) =>
+        this.domainEvents.notifyDiscoveryChanged('created', result.communityId)
+      )
     );
   }
 }

--- a/src/app/community/data-access/community-domain-events.service.ts
+++ b/src/app/community/data-access/community-domain-events.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@angular/core';
+import { Subject } from 'rxjs';
+
+export type CommunityDiscoveryChangeReason =
+  | 'created'
+  | 'membership_changed'
+  | 'invite_accepted'
+  | 'settings_changed'
+  | 'ownership_changed'
+  | 'archived'
+  | 'content_changed';
+
+export interface CommunityDiscoveryChangedEvent {
+  readonly reason: CommunityDiscoveryChangeReason;
+  readonly communityId: string | null;
+}
+
+/**
+ * Canal de domínio entre mutations de Community e projeções locais derivadas.
+ * Repositories publicam apenas o fato ocorrido; consumidores como o cache de
+ * descoberta decidem como reagir. NgRx não é conhecido pela camada data-access.
+ */
+@Injectable({ providedIn: 'root' })
+export class CommunityDomainEventsService {
+  private readonly discoveryChangedSubject =
+    new Subject<CommunityDiscoveryChangedEvent>();
+
+  readonly discoveryChanged$ = this.discoveryChangedSubject.asObservable();
+
+  notifyDiscoveryChanged(
+    reason: CommunityDiscoveryChangeReason,
+    communityId: string | null = null
+  ): void {
+    const normalizedCommunityId = String(communityId ?? '').trim() || null;
+    this.discoveryChangedSubject.next({
+      reason,
+      communityId: normalizedCommunityId,
+    });
+  }
+}

--- a/src/app/community/data-access/community-feed.repository.ts
+++ b/src/app/community/data-access/community-feed.repository.ts
@@ -33,8 +33,10 @@ import {
   map,
   of,
   pairwise,
+  tap,
 } from 'rxjs';
 
+import { CommunityDomainEventsService } from './community-domain-events.service';
 import {
   CommunityFeedPage,
   CommunityFeedPageRequest,
@@ -71,6 +73,7 @@ export class CommunityFeedRepository {
   private readonly functions = inject(Functions);
   private readonly firestore = inject(Firestore);
   private readonly environmentInjector = inject(EnvironmentInjector);
+  private readonly domainEvents = inject(CommunityDomainEventsService);
 
   private readonly getCommunityFeedPageCallable = httpsCallable<
     CommunityFeedPageRequest,
@@ -183,7 +186,13 @@ export class CommunityFeedRepository {
     };
 
     return defer(() => from(this.createCommunityFeedPostCallable(payload))).pipe(
-      map((result) => normalizeCommunityFeedPostCreateResponse(result.data))
+      map((result) => normalizeCommunityFeedPostCreateResponse(result.data)),
+      tap(() =>
+        this.domainEvents.notifyDiscoveryChanged(
+          'content_changed',
+          payload.communityId
+        )
+      )
     );
   }
 
@@ -199,7 +208,13 @@ export class CommunityFeedRepository {
     };
 
     return defer(() => from(this.moderateCommunityFeedPostCallable(payload))).pipe(
-      map((result) => normalizeCommunityFeedPostActionResponse(result.data))
+      map((result) => normalizeCommunityFeedPostActionResponse(result.data)),
+      tap(() =>
+        this.domainEvents.notifyDiscoveryChanged(
+          'content_changed',
+          payload.communityId
+        )
+      )
     );
   }
 

--- a/src/app/community/data-access/community-invite.repository.ts
+++ b/src/app/community/data-access/community-invite.repository.ts
@@ -1,8 +1,9 @@
 // src/app/community/data-access/community-invite.repository.ts
 import { Injectable, inject } from '@angular/core';
 import { Functions, httpsCallable } from '@angular/fire/functions';
-import { defer, from, map, Observable } from 'rxjs';
+import { defer, from, map, Observable, tap } from 'rxjs';
 
+import { CommunityDomainEventsService } from './community-domain-events.service';
 import {
   CommunityInviteInbox,
   CommunityInviteCandidateResponse,
@@ -17,6 +18,7 @@ import {
 @Injectable({ providedIn: 'root' })
 export class CommunityInviteRepository {
   private readonly functions = inject(Functions);
+  private readonly domainEvents = inject(CommunityDomainEventsService);
 
   private readonly getInvitesCallable = httpsCallable<void, unknown>(
     this.functions,
@@ -68,7 +70,9 @@ export class CommunityInviteRepository {
   }
 
   acceptInvite$(inviteId: string): Observable<CommunityInviteResult> {
-    return this.respond$(this.acceptInviteCallable, inviteId, 'accepted');
+    return this.respond$(this.acceptInviteCallable, inviteId, 'accepted').pipe(
+      tap(() => this.domainEvents.notifyDiscoveryChanged('invite_accepted'))
+    );
   }
 
   declineInvite$(inviteId: string): Observable<CommunityInviteResult> {

--- a/src/app/community/data-access/community-member-management.repository.ts
+++ b/src/app/community/data-access/community-member-management.repository.ts
@@ -1,8 +1,9 @@
 // src/app/community/data-access/community-member-management.repository.ts
 import { Injectable, inject } from '@angular/core';
 import { Functions, httpsCallable } from '@angular/fire/functions';
-import { defer, from, map, Observable } from 'rxjs';
+import { defer, from, map, Observable, tap } from 'rxjs';
 
+import { CommunityDomainEventsService } from './community-domain-events.service';
 import {
   CommunityAssignableMemberRole,
   CommunityManagedMembersPage,
@@ -16,6 +17,7 @@ import {
 @Injectable({ providedIn: 'root' })
 export class CommunityMemberManagementRepository {
   private readonly functions = inject(Functions);
+  private readonly domainEvents = inject(CommunityDomainEventsService);
 
   private readonly getMembersPageCallable = httpsCallable<
     {
@@ -66,10 +68,11 @@ export class CommunityMemberManagementRepository {
     action: CommunityMemberManagementAction,
     nextRole: CommunityAssignableMemberRole | null = null
   ): Observable<CommunityManageMemberResponse> {
+    const normalizedCommunityId = communityId.trim();
     return defer(() =>
       from(
         this.manageMemberCallable({
-          communityId: communityId.trim(),
+          communityId: normalizedCommunityId,
           memberId: memberId.trim(),
           action,
           nextRole,
@@ -82,7 +85,13 @@ export class CommunityMemberManagementRepository {
           throw new Error('Resposta de gestão de participante inválida.');
         }
         return normalized;
-      })
+      }),
+      tap(() =>
+        this.domainEvents.notifyDiscoveryChanged(
+          'membership_changed',
+          normalizedCommunityId
+        )
+      )
     );
   }
 }

--- a/src/app/community/data-access/community-membership.repository.ts
+++ b/src/app/community/data-access/community-membership.repository.ts
@@ -8,8 +8,9 @@
 
 import { Injectable, inject } from '@angular/core';
 import { Functions, httpsCallable } from '@angular/fire/functions';
-import { defer, from, map, Observable } from 'rxjs';
+import { defer, from, map, Observable, tap } from 'rxjs';
 
+import { CommunityDomainEventsService } from './community-domain-events.service';
 import {
   CommunityMembershipRequestResponse,
   CommunityMembershipRequestsResponse,
@@ -23,6 +24,7 @@ import {
 @Injectable({ providedIn: 'root' })
 export class CommunityMembershipRepository {
   private readonly functions = inject(Functions);
+  private readonly domainEvents = inject(CommunityDomainEventsService);
 
   private readonly requestMembershipCallable = httpsCallable<
     { communityId: string },
@@ -51,8 +53,9 @@ export class CommunityMembershipRepository {
   requestMembership$(
     communityId: string
   ): Observable<CommunityMembershipRequestResponse> {
+    const normalizedCommunityId = communityId.trim();
     return defer(() =>
-      from(this.requestMembershipCallable({ communityId: communityId.trim() }))
+      from(this.requestMembershipCallable({ communityId: normalizedCommunityId }))
     ).pipe(
       map((result) => {
         const normalized = normalizeCommunityMembershipResponse(result.data);
@@ -62,15 +65,22 @@ export class CommunityMembershipRepository {
         }
 
         return normalized;
-      })
+      }),
+      tap(() =>
+        this.domainEvents.notifyDiscoveryChanged(
+          'membership_changed',
+          normalizedCommunityId
+        )
+      )
     );
   }
 
   leaveMembership$(
     communityId: string
   ): Observable<CommunityMembershipRequestResponse> {
+    const normalizedCommunityId = communityId.trim();
     return defer(() =>
-      from(this.leaveMembershipCallable({ communityId: communityId.trim() }))
+      from(this.leaveMembershipCallable({ communityId: normalizedCommunityId }))
     ).pipe(
       map((result) => {
         const normalized = normalizeCommunityMembershipResponse(result.data);
@@ -80,7 +90,13 @@ export class CommunityMembershipRepository {
         }
 
         return normalized;
-      })
+      }),
+      tap(() =>
+        this.domainEvents.notifyDiscoveryChanged(
+          'membership_changed',
+          normalizedCommunityId
+        )
+      )
     );
   }
 
@@ -111,10 +127,11 @@ export class CommunityMembershipRepository {
     memberId: string,
     action: CommunityMembershipReviewAction
   ): Observable<CommunityMembershipReviewResponse> {
+    const normalizedCommunityId = communityId.trim();
     return defer(() =>
       from(
         this.reviewMembershipCallable({
-          communityId: communityId.trim(),
+          communityId: normalizedCommunityId,
           memberId: memberId.trim(),
           action,
         })
@@ -130,7 +147,13 @@ export class CommunityMembershipRepository {
         }
 
         return normalized;
-      })
+      }),
+      tap(() =>
+        this.domainEvents.notifyDiscoveryChanged(
+          'membership_changed',
+          normalizedCommunityId
+        )
+      )
     );
   }
 }

--- a/src/app/community/data-access/community-ownership.repository.ts
+++ b/src/app/community/data-access/community-ownership.repository.ts
@@ -8,8 +8,9 @@
 
 import { Injectable, inject } from '@angular/core';
 import { Functions, httpsCallable } from '@angular/fire/functions';
-import { defer, from, map, Observable } from 'rxjs';
+import { defer, from, map, Observable, tap } from 'rxjs';
 
+import { CommunityDomainEventsService } from './community-domain-events.service';
 import {
   CommunityArchiveResponse,
   CommunityOwnershipCandidatesResponse,
@@ -22,6 +23,7 @@ import {
 @Injectable({ providedIn: 'root' })
 export class CommunityOwnershipRepository {
   private readonly functions = inject(Functions);
+  private readonly domainEvents = inject(CommunityDomainEventsService);
 
   private readonly getCandidatesCallable = httpsCallable<
     { communityId: string },
@@ -63,11 +65,12 @@ export class CommunityOwnershipRepository {
     targetUid: string
   ): Observable<CommunityOwnershipTransferResponse> {
     const requestId = this.createRequestId('transfer');
+    const normalizedCommunityId = communityId.trim();
 
     return defer(() =>
       from(
         this.transferOwnershipCallable({
-          communityId: communityId.trim(),
+          communityId: normalizedCommunityId,
           targetUid: targetUid.trim(),
           requestId,
         })
@@ -83,7 +86,13 @@ export class CommunityOwnershipRepository {
         }
 
         return normalized;
-      })
+      }),
+      tap(() =>
+        this.domainEvents.notifyDiscoveryChanged(
+          'ownership_changed',
+          normalizedCommunityId
+        )
+      )
     );
   }
 
@@ -93,11 +102,12 @@ export class CommunityOwnershipRepository {
   ): Observable<CommunityArchiveResponse> {
     const requestId = this.createRequestId('archive');
     const safeReason = this.normalizeOptionalReason(reason);
+    const normalizedCommunityId = communityId.trim();
 
     return defer(() =>
       from(
         this.archiveCommunityCallable({
-          communityId: communityId.trim(),
+          communityId: normalizedCommunityId,
           requestId,
           reason: safeReason,
         })
@@ -111,7 +121,13 @@ export class CommunityOwnershipRepository {
         }
 
         return normalized;
-      })
+      }),
+      tap(() =>
+        this.domainEvents.notifyDiscoveryChanged(
+          'archived',
+          normalizedCommunityId
+        )
+      )
     );
   }
 

--- a/src/app/community/data-access/community-settings.repository.ts
+++ b/src/app/community/data-access/community-settings.repository.ts
@@ -1,7 +1,8 @@
 import { Injectable, inject } from '@angular/core';
 import { Functions, httpsCallable } from '@angular/fire/functions';
-import { Observable, defer, from, map } from 'rxjs';
+import { Observable, defer, from, map, tap } from 'rxjs';
 
+import { CommunityDomainEventsService } from './community-domain-events.service';
 import {
   CommunitySettingsUpdateCommand,
   CommunitySettingsUpdateResult,
@@ -11,6 +12,7 @@ import {
 @Injectable({ providedIn: 'root' })
 export class CommunitySettingsRepository {
   private readonly functions = inject(Functions);
+  private readonly domainEvents = inject(CommunityDomainEventsService);
 
   private readonly updateCommunitySettingsCallable = httpsCallable<
     CommunitySettingsUpdateCommand,
@@ -20,6 +22,7 @@ export class CommunitySettingsRepository {
   updateSettings$(
     command: CommunitySettingsUpdateCommand
   ): Observable<CommunitySettingsUpdateResult> {
+    const communityId = command.communityId.trim();
     return defer(() => from(this.updateCommunitySettingsCallable(command))).pipe(
       map((result) => {
         const normalized = normalizeCommunitySettingsUpdateResult(result.data);
@@ -29,7 +32,10 @@ export class CommunitySettingsRepository {
         }
 
         return normalized;
-      })
+      }),
+      tap(() =>
+        this.domainEvents.notifyDiscoveryChanged('settings_changed', communityId)
+      )
     );
   }
 }

--- a/src/app/community/discovery/community-discovery-cache.model.ts
+++ b/src/app/community/discovery/community-discovery-cache.model.ts
@@ -24,7 +24,16 @@ export interface CommunityDiscoveryCacheQuery
 }
 
 export const DEFAULT_COMMUNITY_DISCOVERY_PAGE_SIZE = 12;
-export const COMMUNITY_DISCOVERY_CACHE_TTL_MS = 30_000;
+export const COMMUNITY_DISCOVERY_CACHE_SOFT_TTL_MS = 30_000;
+export const COMMUNITY_DISCOVERY_CACHE_HARD_TTL_MS = 5 * 60_000;
+export const COMMUNITY_DISCOVERY_CACHE_MAX_QUERIES = 10;
+
+/**
+ * Alias preservado para consumidores existentes. Novos usos devem distinguir
+ * explicitamente soft TTL de hard TTL.
+ */
+export const COMMUNITY_DISCOVERY_CACHE_TTL_MS =
+  COMMUNITY_DISCOVERY_CACHE_SOFT_TTL_MS;
 
 const SAFE_UID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
 const COMMUNITY_DISCOVERY_CACHE_PREFIX = 'community:discovery:v1';
@@ -94,4 +103,35 @@ export function buildCommunityDiscoveryCacheKey(
     `tag=${normalized.tagId ?? 'all'}`,
     `size=${normalized.pageSize}`,
   ].join('|');
+}
+
+export function communityDiscoveryCacheAgeMs(
+  lastLoadedAt: number,
+  now = Date.now()
+): number | null {
+  if (
+    !Number.isFinite(lastLoadedAt)
+    || lastLoadedAt <= 0
+    || !Number.isFinite(now)
+  ) {
+    return null;
+  }
+
+  return Math.max(0, Math.trunc(now) - Math.trunc(lastLoadedAt));
+}
+
+export function isCommunityDiscoveryCacheSoftFresh(
+  lastLoadedAt: number,
+  now = Date.now()
+): boolean {
+  const age = communityDiscoveryCacheAgeMs(lastLoadedAt, now);
+  return age !== null && age < COMMUNITY_DISCOVERY_CACHE_SOFT_TTL_MS;
+}
+
+export function isCommunityDiscoveryCacheHardExpired(
+  lastLoadedAt: number,
+  now = Date.now()
+): boolean {
+  const age = communityDiscoveryCacheAgeMs(lastLoadedAt, now);
+  return age !== null && age >= COMMUNITY_DISCOVERY_CACHE_HARD_TTL_MS;
 }

--- a/src/app/community/discovery/community-discovery-cache.service.spec.ts
+++ b/src/app/community/discovery/community-discovery-cache.service.spec.ts
@@ -1,0 +1,56 @@
+import { TestBed } from '@angular/core/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
+import { of } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AuthSessionService } from 'src/app/core/services/autentication/auth/auth-session.service';
+import * as CommunityDiscoveryCacheActions from 'src/app/store/actions/actions.discovery/community-discovery-cache.actions';
+import { CommunityDomainEventsService } from '../data-access/community-domain-events.service';
+import { CommunityDiscoveryCacheService } from './community-discovery-cache.service';
+
+describe('CommunityDiscoveryCacheService', () => {
+  let store: MockStore;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        CommunityDiscoveryCacheService,
+        CommunityDomainEventsService,
+        provideMockStore({
+          initialState: {
+            communityDiscoveryCache: {
+              activeViewerUid: 'viewer-1',
+              byQuery: {},
+            },
+          },
+        }),
+        {
+          provide: AuthSessionService,
+          useValue: {
+            uid$: of('viewer-1'),
+            currentAuthUser: { uid: 'viewer-1' },
+          },
+        },
+      ],
+    });
+
+    store = TestBed.inject(MockStore);
+    vi.spyOn(store, 'dispatch');
+  });
+
+  it('invalida o viewer atual quando uma mutation de dominio altera a descoberta', () => {
+    TestBed.inject(CommunityDiscoveryCacheService);
+    vi.mocked(store.dispatch).mockClear();
+
+    TestBed.inject(CommunityDomainEventsService).notifyDiscoveryChanged(
+      'membership_changed',
+      'community-1'
+    );
+
+    expect(store.dispatch).toHaveBeenCalledWith(
+      CommunityDiscoveryCacheActions.invalidateCommunityDiscoveryViewer({
+        viewerUid: 'viewer-1',
+      })
+    );
+  });
+});

--- a/src/app/community/discovery/community-discovery-cache.service.ts
+++ b/src/app/community/discovery/community-discovery-cache.service.ts
@@ -78,10 +78,12 @@ export class CommunityDiscoveryCacheService {
                 nextCursor: slice.nextCursor,
                 generatedAt: slice.lastLoadedAt,
               },
-              fresh: isCommunityDiscoveryCacheSoftFresh(
-                slice.lastLoadedAt,
-                accessedAt
-              ),
+              fresh:
+                !slice.invalidated
+                && isCommunityDiscoveryCacheSoftFresh(
+                  slice.lastLoadedAt,
+                  accessedAt
+                ),
             };
           })
         );

--- a/src/app/community/discovery/community-discovery-cache.service.ts
+++ b/src/app/community/discovery/community-discovery-cache.service.ts
@@ -8,6 +8,7 @@ import { AuthSessionService } from 'src/app/core/services/autentication/auth/aut
 import * as CommunityDiscoveryCacheActions from 'src/app/store/actions/actions.discovery/community-discovery-cache.actions';
 import { selectCommunityDiscoveryCacheSlice } from 'src/app/store/selectors/selectors.discovery/community-discovery-cache.selectors';
 import type { AppState } from 'src/app/store/states/app.state';
+import { CommunityDomainEventsService } from '../data-access/community-domain-events.service';
 import type { CommunityDiscoveryPage } from '../data-access/community-preview.model';
 import {
   CommunityDiscoveryCacheContext,
@@ -26,6 +27,7 @@ export interface CommunityDiscoveryCacheSnapshot {
 export class CommunityDiscoveryCacheService {
   private readonly store = inject(Store<AppState>);
   private readonly session = inject(AuthSessionService);
+  private readonly domainEvents = inject(CommunityDomainEventsService);
   private readonly destroyRef = inject(DestroyRef);
   private activeViewerUid: string | null = null;
 
@@ -41,6 +43,10 @@ export class CommunityDiscoveryCacheService {
           })
         );
       });
+
+    this.domainEvents.discoveryChanged$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => this.invalidateCurrentViewer());
   }
 
   readSnapshot$(
@@ -108,7 +114,12 @@ export class CommunityDiscoveryCacheService {
   }
 
   invalidateCurrentViewer(): void {
-    const viewerUid = this.activeViewerUid;
+    const viewerUid =
+      this.activeViewerUid
+      || normalizeCommunityDiscoveryViewerUid(
+        this.session.currentAuthUser?.uid
+      )
+      || null;
     if (!viewerUid) return;
 
     this.store.dispatch(

--- a/src/app/community/discovery/community-discovery-cache.service.ts
+++ b/src/app/community/discovery/community-discovery-cache.service.ts
@@ -10,10 +10,10 @@ import { selectCommunityDiscoveryCacheSlice } from 'src/app/store/selectors/sele
 import type { AppState } from 'src/app/store/states/app.state';
 import type { CommunityDiscoveryPage } from '../data-access/community-preview.model';
 import {
-  COMMUNITY_DISCOVERY_CACHE_TTL_MS,
   CommunityDiscoveryCacheContext,
   buildCommunityDiscoveryCacheKey,
   buildCommunityDiscoveryCacheQuery,
+  isCommunityDiscoveryCacheSoftFresh,
   normalizeCommunityDiscoveryViewerUid,
 } from './community-discovery-cache.model';
 
@@ -52,23 +52,30 @@ export class CommunityDiscoveryCacheService {
         const query = buildCommunityDiscoveryCacheQuery(uid, context);
         if (!query) return of(null);
 
+        const accessedAt = Date.now();
+        this.store.dispatch(
+          CommunityDiscoveryCacheActions.touchCommunityDiscoveryQuery({
+            query,
+            accessedAt,
+          })
+        );
+
         const queryKey = buildCommunityDiscoveryCacheKey(query);
         return this.store.select(selectCommunityDiscoveryCacheSlice(queryKey)).pipe(
           take(1),
           map((slice): CommunityDiscoveryCacheSnapshot | null => {
             if (!slice) return null;
 
-            const age = Date.now() - slice.lastLoadedAt;
             return {
               page: {
                 items: slice.items,
                 nextCursor: slice.nextCursor,
                 generatedAt: slice.lastLoadedAt,
               },
-              fresh:
-                slice.lastLoadedAt > 0
-                && age >= 0
-                && age <= COMMUNITY_DISCOVERY_CACHE_TTL_MS,
+              fresh: isCommunityDiscoveryCacheSoftFresh(
+                slice.lastLoadedAt,
+                accessedAt
+              ),
             };
           })
         );

--- a/src/app/store/actions/actions.discovery/community-discovery-cache.actions.ts
+++ b/src/app/store/actions/actions.discovery/community-discovery-cache.actions.ts
@@ -10,6 +10,14 @@ export const activateCommunityDiscoveryViewer = createAction(
   props<{ viewerUid: string | null }>()
 );
 
+export const touchCommunityDiscoveryQuery = createAction(
+  '[Community Discovery Cache] Touch Query',
+  props<{
+    query: CommunityDiscoveryCacheQuery;
+    accessedAt: number;
+  }>()
+);
+
 export const storeCommunityDiscoveryPage = createAction(
   '[Community Discovery Cache] Store Page',
   props<{

--- a/src/app/store/reducers/reducers.discovery/community-discovery-cache.reducer.spec.ts
+++ b/src/app/store/reducers/reducers.discovery/community-discovery-cache.reducer.spec.ts
@@ -49,6 +49,7 @@ describe('communityDiscoveryCacheReducer', () => {
     expect(slice.items.map((item) => item.communityId)).toEqual(['a', 'b', 'c']);
     expect(slice.lastLoadedAt).toBe(100);
     expect(slice.lastAccessedAt).toBe(200);
+    expect(slice.invalidated).toBe(false);
   });
 
   it('limpa snapshots quando o viewer muda', () => {
@@ -65,7 +66,7 @@ describe('communityDiscoveryCacheReducer', () => {
     expect(switched.byQuery).toEqual({});
   });
 
-  it('invalida sem destruir a lista para stale-while-revalidate', () => {
+  it('invalida sem destruir a lista nem perder a idade real', () => {
     const populated = communityDiscoveryCacheReducer(initialCommunityDiscoveryCacheState,
       Actions.storeCommunityDiscoveryPage({
         query,
@@ -77,11 +78,12 @@ describe('communityDiscoveryCacheReducer', () => {
       Actions.invalidateCommunityDiscoveryViewer({ viewerUid: 'viewer-1' }));
     const slice = Object.values(invalidated.byQuery)[0]!;
     expect(slice.items).toHaveLength(1);
-    expect(slice.lastLoadedAt).toBe(0);
+    expect(slice.lastLoadedAt).toBe(100);
     expect(slice.lastAccessedAt).toBe(100);
+    expect(slice.invalidated).toBe(true);
   });
 
-  it('descarta um snapshot no hard ttl quando a consulta volta a ser acessada', () => {
+  it('descarta um snapshot no hard ttl mesmo depois de invalidado', () => {
     const populated = communityDiscoveryCacheReducer(initialCommunityDiscoveryCacheState,
       Actions.storeCommunityDiscoveryPage({
         query,
@@ -89,7 +91,9 @@ describe('communityDiscoveryCacheReducer', () => {
         append: false,
         storedAt: 100,
       }));
-    const expired = communityDiscoveryCacheReducer(populated,
+    const invalidated = communityDiscoveryCacheReducer(populated,
+      Actions.invalidateCommunityDiscoveryViewer({ viewerUid: 'viewer-1' }));
+    const expired = communityDiscoveryCacheReducer(invalidated,
       Actions.touchCommunityDiscoveryQuery({
         query,
         accessedAt: 100 + COMMUNITY_DISCOVERY_CACHE_HARD_TTL_MS,

--- a/src/app/store/reducers/reducers.discovery/community-discovery-cache.reducer.spec.ts
+++ b/src/app/store/reducers/reducers.discovery/community-discovery-cache.reducer.spec.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import type { CommunityPreviewCard } from 'src/app/community/data-access/community-preview.model';
-import { buildCommunityDiscoveryCacheQuery } from 'src/app/community/discovery/community-discovery-cache.model';
+import {
+  COMMUNITY_DISCOVERY_CACHE_HARD_TTL_MS,
+  COMMUNITY_DISCOVERY_CACHE_MAX_QUERIES,
+  buildCommunityDiscoveryCacheKey,
+  buildCommunityDiscoveryCacheQuery,
+} from 'src/app/community/discovery/community-discovery-cache.model';
 import * as Actions from '../../actions/actions.discovery/community-discovery-cache.actions';
 import { initialCommunityDiscoveryCacheState } from '../../states/states.discovery/community-discovery-cache.state';
 import { communityDiscoveryCacheReducer } from './community-discovery-cache.reducer';
@@ -25,7 +30,7 @@ describe('communityDiscoveryCacheReducer', () => {
     sourceType: 'community', discoveryMode: 'explore', tagId: null, pageSize: 12,
   })!;
 
-  it('acumula paginas sem duplicar communityId', () => {
+  it('acumula paginas sem duplicar communityId nem renovar a idade da primeira pagina', () => {
     const first = communityDiscoveryCacheReducer(initialCommunityDiscoveryCacheState,
       Actions.storeCommunityDiscoveryPage({
         query,
@@ -42,7 +47,8 @@ describe('communityDiscoveryCacheReducer', () => {
       }));
     const slice = Object.values(appended.byQuery)[0]!;
     expect(slice.items.map((item) => item.communityId)).toEqual(['a', 'b', 'c']);
-    expect(slice.lastLoadedAt).toBe(200);
+    expect(slice.lastLoadedAt).toBe(100);
+    expect(slice.lastAccessedAt).toBe(200);
   });
 
   it('limpa snapshots quando o viewer muda', () => {
@@ -59,7 +65,7 @@ describe('communityDiscoveryCacheReducer', () => {
     expect(switched.byQuery).toEqual({});
   });
 
-  it('invalida sem destruir a lista', () => {
+  it('invalida sem destruir a lista para stale-while-revalidate', () => {
     const populated = communityDiscoveryCacheReducer(initialCommunityDiscoveryCacheState,
       Actions.storeCommunityDiscoveryPage({
         query,
@@ -72,5 +78,74 @@ describe('communityDiscoveryCacheReducer', () => {
     const slice = Object.values(invalidated.byQuery)[0]!;
     expect(slice.items).toHaveLength(1);
     expect(slice.lastLoadedAt).toBe(0);
+    expect(slice.lastAccessedAt).toBe(100);
+  });
+
+  it('descarta um snapshot no hard ttl quando a consulta volta a ser acessada', () => {
+    const populated = communityDiscoveryCacheReducer(initialCommunityDiscoveryCacheState,
+      Actions.storeCommunityDiscoveryPage({
+        query,
+        page: { items: [card('a')], nextCursor: null, generatedAt: 10 },
+        append: false,
+        storedAt: 100,
+      }));
+    const expired = communityDiscoveryCacheReducer(populated,
+      Actions.touchCommunityDiscoveryQuery({
+        query,
+        accessedAt: 100 + COMMUNITY_DISCOVERY_CACHE_HARD_TTL_MS,
+      }));
+
+    expect(expired.byQuery[buildCommunityDiscoveryCacheKey(query)]).toBeUndefined();
+  });
+
+  it('limita consultas pelo acesso mais recente usando lru', () => {
+    let state = initialCommunityDiscoveryCacheState;
+    const queries = Array.from(
+      { length: COMMUNITY_DISCOVERY_CACHE_MAX_QUERIES + 1 },
+      (_, index) => buildCommunityDiscoveryCacheQuery('viewer-1', {
+        sourceType: 'community',
+        discoveryMode: 'explore',
+        tagId: null,
+        pageSize: 6 + index,
+      })!
+    );
+
+    queries.forEach((currentQuery, index) => {
+      state = communityDiscoveryCacheReducer(state,
+        Actions.storeCommunityDiscoveryPage({
+          query: currentQuery,
+          page: {
+            items: [card(`community-${index}`)],
+            nextCursor: null,
+            generatedAt: index + 1,
+          },
+          append: false,
+          storedAt: 1_000 + index,
+        }));
+    });
+
+    expect(Object.keys(state.byQuery)).toHaveLength(
+      COMMUNITY_DISCOVERY_CACHE_MAX_QUERIES
+    );
+    expect(
+      state.byQuery[buildCommunityDiscoveryCacheKey(queries[0])]
+    ).toBeUndefined();
+    expect(
+      state.byQuery[buildCommunityDiscoveryCacheKey(queries.at(-1)!)]
+    ).toBeDefined();
+  });
+
+  it('nao cria snapshot truncado ao receber append sem primeira pagina valida', () => {
+    const appendedOnly = communityDiscoveryCacheReducer(
+      initialCommunityDiscoveryCacheState,
+      Actions.storeCommunityDiscoveryPage({
+        query,
+        page: { items: [card('page-2')], nextCursor: null, generatedAt: 20 },
+        append: true,
+        storedAt: 200,
+      })
+    );
+
+    expect(appendedOnly.byQuery).toEqual({});
   });
 });

--- a/src/app/store/reducers/reducers.discovery/community-discovery-cache.reducer.ts
+++ b/src/app/store/reducers/reducers.discovery/community-discovery-cache.reducer.ts
@@ -2,14 +2,23 @@
 
 import { createReducer, on } from '@ngrx/store';
 
-import { buildCommunityDiscoveryCacheKey } from 'src/app/community/discovery/community-discovery-cache.model';
+import {
+  COMMUNITY_DISCOVERY_CACHE_MAX_QUERIES,
+  buildCommunityDiscoveryCacheKey,
+  isCommunityDiscoveryCacheHardExpired,
+} from 'src/app/community/discovery/community-discovery-cache.model';
 import type { CommunityPreviewCard } from 'src/app/community/data-access/community-preview.model';
 
 import * as CommunityDiscoveryCacheActions from '../../actions/actions.discovery/community-discovery-cache.actions';
 import {
+  CommunityDiscoveryCacheSlice,
   CommunityDiscoveryCacheState,
   initialCommunityDiscoveryCacheState,
 } from '../../states/states.discovery/community-discovery-cache.state';
+
+function normalizeTimestamp(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.trunc(value)) : 0;
+}
 
 function mergeCards(
   current: readonly CommunityPreviewCard[],
@@ -36,6 +45,24 @@ function scopeToViewer(
   };
 }
 
+function pruneQueries(
+  byQuery: Readonly<Record<string, CommunityDiscoveryCacheSlice>>,
+  now: number
+): Readonly<Record<string, CommunityDiscoveryCacheSlice>> {
+  const activeEntries = Object.entries(byQuery)
+    .filter(([, slice]) =>
+      !isCommunityDiscoveryCacheHardExpired(slice.lastLoadedAt, now)
+    )
+    .sort((left, right) =>
+      right[1].lastAccessedAt - left[1].lastAccessedAt
+      || right[1].lastLoadedAt - left[1].lastLoadedAt
+      || left[0].localeCompare(right[0])
+    )
+    .slice(0, COMMUNITY_DISCOVERY_CACHE_MAX_QUERIES);
+
+  return Object.fromEntries(activeEntries);
+}
+
 export const communityDiscoveryCacheReducer = createReducer(
   initialCommunityDiscoveryCacheState,
 
@@ -45,25 +72,80 @@ export const communityDiscoveryCacheReducer = createReducer(
   ),
 
   on(
-    CommunityDiscoveryCacheActions.storeCommunityDiscoveryPage,
-    (state, { query, page, append, storedAt }) => {
+    CommunityDiscoveryCacheActions.touchCommunityDiscoveryQuery,
+    (state, { query, accessedAt }) => {
+      const now = normalizeTimestamp(accessedAt);
       const scoped = scopeToViewer(state, query.viewerUid);
       const key = buildCommunityDiscoveryCacheKey(query);
       const current = scoped.byQuery[key];
-      const items = append && current
-        ? mergeCards(current.items, page.items)
-        : [...page.items];
+      const pruned = pruneQueries(scoped.byQuery, now);
+
+      if (
+        !current
+        || isCommunityDiscoveryCacheHardExpired(current.lastLoadedAt, now)
+      ) {
+        return { ...scoped, byQuery: pruned };
+      }
 
       return {
         ...scoped,
-        byQuery: {
-          ...scoped.byQuery,
-          [key]: {
-            items,
-            nextCursor: page.nextCursor,
-            lastLoadedAt: Math.max(0, Math.trunc(storedAt)),
+        byQuery: pruneQueries(
+          {
+            ...pruned,
+            [key]: {
+              ...current,
+              lastAccessedAt: now,
+            },
           },
-        },
+          now
+        ),
+      };
+    }
+  ),
+
+  on(
+    CommunityDiscoveryCacheActions.storeCommunityDiscoveryPage,
+    (state, { query, page, append, storedAt }) => {
+      const now = normalizeTimestamp(storedAt);
+      const scoped = scopeToViewer(state, query.viewerUid);
+      const key = buildCommunityDiscoveryCacheKey(query);
+      const current = scoped.byQuery[key];
+      const currentHardExpired = current
+        ? isCommunityDiscoveryCacheHardExpired(current.lastLoadedAt, now)
+        : false;
+
+      /**
+       * Uma página adicional sem a primeira página válida não forma um snapshot
+       * navegável. Descartamos esse append e forçamos revalidação na próxima leitura.
+       */
+      if (append && (!current || currentHardExpired)) {
+        return {
+          ...scoped,
+          byQuery: pruneQueries(scoped.byQuery, now),
+        };
+      }
+
+      const items = append && current
+        ? mergeCards(current.items, page.items)
+        : [...page.items];
+      const lastLoadedAt = append && current
+        ? current.lastLoadedAt
+        : now;
+
+      return {
+        ...scoped,
+        byQuery: pruneQueries(
+          {
+            ...scoped.byQuery,
+            [key]: {
+              items,
+              nextCursor: page.nextCursor,
+              lastLoadedAt,
+              lastAccessedAt: now,
+            },
+          },
+          now
+        ),
       };
     }
   ),

--- a/src/app/store/reducers/reducers.discovery/community-discovery-cache.reducer.ts
+++ b/src/app/store/reducers/reducers.discovery/community-discovery-cache.reducer.ts
@@ -131,6 +131,9 @@ export const communityDiscoveryCacheReducer = createReducer(
       const lastLoadedAt = append && current
         ? current.lastLoadedAt
         : now;
+      const invalidated = append && current
+        ? current.invalidated
+        : false;
 
       return {
         ...scoped,
@@ -142,6 +145,7 @@ export const communityDiscoveryCacheReducer = createReducer(
               nextCursor: page.nextCursor,
               lastLoadedAt,
               lastAccessedAt: now,
+              invalidated,
             },
           },
           now
@@ -158,7 +162,7 @@ export const communityDiscoveryCacheReducer = createReducer(
       const byQuery = Object.fromEntries(
         Object.entries(state.byQuery).map(([key, slice]) => [
           key,
-          { ...slice, lastLoadedAt: 0 },
+          { ...slice, invalidated: true },
         ])
       );
 

--- a/src/app/store/states/states.discovery/community-discovery-cache.state.ts
+++ b/src/app/store/states/states.discovery/community-discovery-cache.state.ts
@@ -9,6 +9,8 @@ export interface CommunityDiscoveryCacheSlice {
   readonly lastLoadedAt: number;
   /** Último acesso ao escopo, usado exclusivamente para retenção LRU. */
   readonly lastAccessedAt: number;
+  /** Força revalidação sem perder a idade real usada pelo hard TTL. */
+  readonly invalidated: boolean;
 }
 
 export interface CommunityDiscoveryCacheState {

--- a/src/app/store/states/states.discovery/community-discovery-cache.state.ts
+++ b/src/app/store/states/states.discovery/community-discovery-cache.state.ts
@@ -5,7 +5,10 @@ import type { CommunityPreviewCard } from 'src/app/community/data-access/communi
 export interface CommunityDiscoveryCacheSlice {
   readonly items: readonly CommunityPreviewCard[];
   readonly nextCursor: string | null;
+  /** Última revalidação bem-sucedida da primeira página da consulta. */
   readonly lastLoadedAt: number;
+  /** Último acesso ao escopo, usado exclusivamente para retenção LRU. */
+  readonly lastAccessedAt: number;
 }
 
 export interface CommunityDiscoveryCacheState {


### PR DESCRIPTION
## Objetivo

Corrigir a incoerência entre mutations de Community e os snapshots da descoberta (`Explorar` / `Minhas`), preservando stale-while-revalidate e sem mover ainda a máquina de estado inteira do componente para NgRx.

## Coerência após mutations

Foi adicionado `CommunityDomainEventsService` como canal de domínio desacoplado de NgRx. Repositories publicam somente o fato de que uma mutation alterou dados projetados na descoberta; `CommunityDiscoveryCacheService` é o único responsável por traduzir isso em invalidação do viewer atual.

Eventos publicados após sucesso em:

- criação de Comunidade;
- solicitar/cancelar/alterar membership;
- aprovação/recusa de solicitação;
- aceitar convite;
- alterar configurações;
- gestão de membros;
- transferência de ownership;
- arquivamento;
- criar/moderar publicação do Mural, pois altera `postCount/mediaCount` dos cards.

Reações não invalidam a descoberta porque não alteram métricas exibidas nos cards. Discussões não entram neste PR porque o backend atualiza `metrics.topicCount`, campo que não é exibido atualmente na descoberta.

## Retenção do cache

A política passa a distinguir:

- soft TTL: 30 segundos;
- hard TTL: 5 minutos;
- LRU: máximo de 10 consultas por viewer.

`lastLoadedAt` representa apenas a última revalidação bem-sucedida da primeira página. `Ver mais` atualiza `lastAccessedAt`, mas não renova a idade da primeira página.

Uma mutation marca o slice como `invalidated: true` sem apagar itens nem zerar `lastLoadedAt`. Assim a navegação mantém continuidade visual, força revalidação e ainda permite que o hard TTL descarte snapshots realmente antigos.

Append sem primeira página válida/retida é descartado do cache para não criar snapshot truncado.

## Arquitetura

- Firebase/callables continuam em repositories Observable-first;
- repositories não conhecem NgRx;
- o evento de domínio não carrega dados sensíveis nem estado de UI;
- `CommunityDiscoveryCacheService` continua isolando snapshots por viewer;
- nenhuma regra de produto, membership, plano, KYC/AML ou autorização foi alterada.

## Testes adicionados/atualizados

- paginação não renova `lastLoadedAt`;
- invalidação preserva lista e idade real;
- snapshot invalidado ainda expira pelo hard TTL;
- LRU limita queries;
- append sem primeira página válida não cria cache parcial;
- mutation de domínio dispara invalidação do viewer atual.

## Supressão / remoção explícita

Nenhum método, template, fluxo de UI ou dado existente foi removido ou ocultado. Este PR adiciona invalidação/retention e eventos de domínio; a migração da máquina local `Subject + scan + shareReplay` da descoberta para uma única autoridade NgRx fica deliberadamente para um PR posterior.

## Validação final

HEAD validado: `6167efb5ff6b8f888382b21215ac5f8663b4096f`.

- Quality Gate: sucesso;
- Angular tests: sucesso;
- Angular safe build: sucesso;
- Angular CI Validation: sucesso;
- build da configuração de emulador: sucesso;
- Functions lint/build/tests: sucesso;
- Firestore Rules tests: sucesso;
- Firestore indexes: sucesso;
- contratos canônicos de Community: sucesso;
- Photo publication/moderation E2E: sucesso;
- Video publication/moderation E2E: sucesso.