### PR TITLE
refactor(community): canonicalize feed attachment transport

### DIFF
--- a/functions/src/community/community-feed-write.handler.ts
+++ b/functions/src/community/community-feed-write.handler.ts
@@ -162,6 +162,13 @@ export const createCommunityFeedPost = onCall<CommunityFeedPostCreateRequest>(
     const command = normalizeCommunityFeedPostCreateRequest(request.data);
     const rawReplyToPostId = String(request.data?.replyToPostId ?? '').trim();
 
+    if (!command.attachmentValid) {
+      throw new HttpsError(
+        'invalid-argument',
+        'O anexo enviado para o Mural não é válido.'
+      );
+    }
+
     if (
       !command.requestId
       || !command.communityId
@@ -171,7 +178,7 @@ export const createCommunityFeedPost = onCall<CommunityFeedPostCreateRequest>(
       throw new HttpsError('invalid-argument', 'Mensagem inválida para o Mural.');
     }
 
-    if (!command.text && !command.imageUploadPath) {
+    if (!command.text && !command.attachment) {
       throw new HttpsError(
         'invalid-argument',
         'Escreva uma mensagem ou adicione uma foto.'
@@ -181,11 +188,11 @@ export const createCommunityFeedPost = onCall<CommunityFeedPostCreateRequest>(
     const communityId = command.communityId;
     const postId = command.requestId;
     const requestRef = db.collection('community_feed_requests').doc(postId);
-    const privateImagePath = command.imageUploadPath
-      ? extractOwnedPrivatePhotoPath(actorUid, command.imageUploadPath)
+    const privateImagePath = command.attachment
+      ? extractOwnedPrivatePhotoPath(actorUid, command.attachment.uploadPath)
       : null;
 
-    if (command.imageUploadPath && !privateImagePath) {
+    if (command.attachment && !privateImagePath) {
       throw new HttpsError(
         'invalid-argument',
         'A foto deve pertencer ao usuário autenticado.'

--- a/functions/src/community/community-feed.model.test.ts
+++ b/functions/src/community/community-feed.model.test.ts
@@ -75,7 +75,8 @@ test('normaliza mensagem textual com audiência privada por padrão', () => {
       communityId: 'community-1',
       text: 'Uma nova conversa no mural.',
       audience: 'members_only',
-      imageUploadPath: null,
+      attachment: null,
+      attachmentValid: true,
       replyToPostId: null,
     }
   );
@@ -111,19 +112,68 @@ test('normaliza resposta como nova mensagem do Mural ligada à origem', () => {
   );
 });
 
-test('normaliza mensagem com foto privada para promoção backend', () => {
+test('normaliza attachment canônico de foto privada', () => {
   const result = normalizeCommunityFeedPostCreateRequest({
-    requestId: 'post-photo-1',
+    requestId: 'post-photo-canonical-1',
+    communityId: 'community-1',
+    text: 'Como está o local agora.',
+    attachment: {
+      type: 'photo',
+      uploadPath: 'users/u1/uploads/images/photo.webp',
+    },
+  });
+
+  assert.equal(result.attachmentValid, true);
+  assert.deepEqual(result.attachment, {
+    type: 'photo',
+    uploadPath: 'users/u1/uploads/images/photo.webp',
+  });
+});
+
+test('converte imageUploadPath legado para o attachment canônico', () => {
+  const result = normalizeCommunityFeedPostCreateRequest({
+    requestId: 'post-photo-legacy-1',
     communityId: 'community-1',
     text: 'Como está o local agora.',
     imageUploadPath: 'users/u1/uploads/images/photo.webp',
   });
 
-  assert.equal(result.text, 'Como está o local agora.');
-  assert.equal(
-    result.imageUploadPath,
-    'users/u1/uploads/images/photo.webp'
-  );
+  assert.equal(result.attachmentValid, true);
+  assert.deepEqual(result.attachment, {
+    type: 'photo',
+    uploadPath: 'users/u1/uploads/images/photo.webp',
+  });
+});
+
+test('rejeita duas autoridades de transporte de anexo no mesmo request', () => {
+  const result = normalizeCommunityFeedPostCreateRequest({
+    requestId: 'post-photo-conflict-1',
+    communityId: 'community-1',
+    text: 'Não pode publicar parcialmente.',
+    attachment: {
+      type: 'photo',
+      uploadPath: 'users/u1/uploads/images/photo-new.webp',
+    },
+    imageUploadPath: 'users/u1/uploads/images/photo-legacy.webp',
+  });
+
+  assert.equal(result.attachmentValid, false);
+  assert.equal(result.attachment, null);
+});
+
+test('rejeita tipo de attachment ainda não habilitado', () => {
+  const result = normalizeCommunityFeedPostCreateRequest({
+    requestId: 'post-video-premature-1',
+    communityId: 'community-1',
+    text: 'Vídeo ainda não está habilitado.',
+    attachment: {
+      type: 'video',
+      uploadPath: 'users/u1/uploads/videos/video.mp4',
+    },
+  });
+
+  assert.equal(result.attachmentValid, false);
+  assert.equal(result.attachment, null);
 });
 
 test('sanitiza publicação pública com foto legada HTTPS', () => {

--- a/functions/src/community/community-feed.model.ts
+++ b/functions/src/community/community-feed.model.ts
@@ -29,16 +29,27 @@ export interface CommunityFeedPostCreateRequest {
   communityId?: unknown;
   text?: unknown;
   audience?: unknown;
+  attachment?: unknown;
+  /** Compatibilidade temporária com clientes anteriores ao contrato de anexo. */
   imageUploadPath?: unknown;
   replyToPostId?: unknown;
 }
+
+export interface NormalizedCommunityFeedPhotoAttachment {
+  readonly type: 'photo';
+  readonly uploadPath: string;
+}
+
+export type NormalizedCommunityFeedPostAttachment =
+  NormalizedCommunityFeedPhotoAttachment;
 
 export interface NormalizedCommunityFeedPostCreateRequest {
   requestId: string | null;
   communityId: string | null;
   text: string;
   audience: CommunityFeedAudience;
-  imageUploadPath: string | null;
+  attachment: NormalizedCommunityFeedPostAttachment | null;
+  attachmentValid: boolean;
   replyToPostId: string | null;
 }
 
@@ -200,6 +211,60 @@ interface ProjectionPhotoSource {
   valid: boolean;
 }
 
+interface NormalizedPostAttachmentResult {
+  attachment: NormalizedCommunityFeedPostAttachment | null;
+  valid: boolean;
+}
+
+function invalidPostAttachment(): NormalizedPostAttachmentResult {
+  return { attachment: null, valid: false };
+}
+
+function normalizePostAttachment(
+  raw: CommunityFeedPostCreateRequest | null | undefined
+): NormalizedPostAttachmentResult {
+  const source = (raw ?? {}) as CommunityFeedPostCreateRequest;
+  const hasCanonicalAttachment = Object.prototype.hasOwnProperty.call(
+    source,
+    'attachment'
+  );
+  const legacyUploadPath = normalizeText(source.imageUploadPath, 2_000) || null;
+
+  if (!hasCanonicalAttachment) {
+    return {
+      attachment: legacyUploadPath
+        ? { type: 'photo', uploadPath: legacyUploadPath }
+        : null,
+      valid: true,
+    };
+  }
+
+  // Um cliente não pode enviar duas autoridades de transporte ao mesmo tempo.
+  if (legacyUploadPath) return invalidPostAttachment();
+
+  if (source.attachment == null) {
+    return { attachment: null, valid: true };
+  }
+
+  if (
+    typeof source.attachment !== 'object'
+    || Array.isArray(source.attachment)
+  ) {
+    return invalidPostAttachment();
+  }
+
+  const attachment = source.attachment as Record<string, unknown>;
+  const type = normalizeText(attachment['type'], 32);
+  const uploadPath = normalizeText(attachment['uploadPath'], 2_000);
+
+  if (type !== 'photo' || !uploadPath) return invalidPostAttachment();
+
+  return {
+    attachment: { type: 'photo', uploadPath },
+    valid: true,
+  };
+}
+
 function invalidProjectionPhotoSource(): ProjectionPhotoSource {
   return {
     url: null,
@@ -266,7 +331,7 @@ export function normalizeCommunityFeedPageRequest(
 export function normalizeCommunityFeedPostCreateRequest(
   raw: CommunityFeedPostCreateRequest | null | undefined
 ): NormalizedCommunityFeedPostCreateRequest {
-  const imageUploadPath = normalizeText(raw?.imageUploadPath, 2_000);
+  const attachmentResult = normalizePostAttachment(raw);
 
   return {
     requestId: normalizeSafeId(raw?.requestId),
@@ -275,7 +340,8 @@ export function normalizeCommunityFeedPostCreateRequest(
     audience: raw?.audience === 'public_preview'
       ? 'public_preview'
       : 'members_only',
-    imageUploadPath: imageUploadPath || null,
+    attachment: attachmentResult.attachment,
+    attachmentValid: attachmentResult.valid,
     replyToPostId: normalizeSafeId(raw?.replyToPostId),
   };
 }

--- a/src/app/community/data-access/community-feed-write-contract.model.spec.ts
+++ b/src/app/community/data-access/community-feed-write-contract.model.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildCommunityFeedPostCreateWireRequest,
+} from './community-feed-write-contract.model';
+
+describe('buildCommunityFeedPostCreateWireRequest', () => {
+  it('envia foto pelo contrato discriminado de attachment', () => {
+    const payload = buildCommunityFeedPostCreateWireRequest({
+      requestId: ' request-1 ',
+      communityId: ' community-1 ',
+      text: ' Olá Comunidade ',
+      audience: 'members_only',
+      imageUploadPath: ' users/u1/uploads/images/photo.webp ',
+      replyToPostId: ' post-original ',
+    });
+
+    expect(payload).toEqual({
+      requestId: 'request-1',
+      communityId: 'community-1',
+      text: 'Olá Comunidade',
+      audience: 'members_only',
+      attachment: {
+        type: 'photo',
+        uploadPath: 'users/u1/uploads/images/photo.webp',
+      },
+      replyToPostId: 'post-original',
+    });
+    expect('imageUploadPath' in payload).toBe(false);
+  });
+
+  it('envia attachment nulo quando a publicação não possui foto', () => {
+    expect(buildCommunityFeedPostCreateWireRequest({
+      requestId: 'request-2',
+      communityId: 'community-1',
+      text: 'Mensagem textual',
+      audience: 'members_only',
+      imageUploadPath: null,
+    }).attachment).toBeNull();
+  });
+});

--- a/src/app/community/data-access/community-feed-write-contract.model.ts
+++ b/src/app/community/data-access/community-feed-write-contract.model.ts
@@ -1,0 +1,50 @@
+// src/app/community/data-access/community-feed-write-contract.model.ts
+// -----------------------------------------------------------------------------
+// COMMUNITY FEED WRITE WIRE CONTRACT
+// -----------------------------------------------------------------------------
+// O compositor pode evoluir para múltiplos tipos de anexo sem acoplar o payload
+// da callable a um campo específico de foto. Nesta etapa somente `photo` é
+// habilitado; vídeo e localização entrarão como variantes explícitas depois.
+// -----------------------------------------------------------------------------
+
+import type {
+  CommunityFeedAudience,
+  CommunityFeedPostCreateRequest,
+} from './community-feed.model';
+
+export interface CommunityFeedPhotoAttachmentPayload {
+  readonly type: 'photo';
+  readonly uploadPath: string;
+}
+
+export type CommunityFeedPostAttachmentPayload =
+  CommunityFeedPhotoAttachmentPayload;
+
+export interface CommunityFeedPostCreateWireRequest {
+  readonly requestId: string;
+  readonly communityId: string;
+  readonly text: string;
+  readonly audience: CommunityFeedAudience;
+  readonly attachment: CommunityFeedPostAttachmentPayload | null;
+  readonly replyToPostId: string | null;
+}
+
+export function buildCommunityFeedPostCreateWireRequest(
+  request: CommunityFeedPostCreateRequest
+): CommunityFeedPostCreateWireRequest {
+  const imageUploadPath = request.imageUploadPath?.trim() || null;
+
+  return {
+    requestId: request.requestId.trim(),
+    communityId: request.communityId.trim(),
+    text: request.text.trim(),
+    audience: request.audience,
+    attachment: imageUploadPath
+      ? {
+          type: 'photo',
+          uploadPath: imageUploadPath,
+        }
+      : null,
+    replyToPostId: request.replyToPostId?.trim() || null,
+  };
+}

--- a/src/app/community/data-access/community-feed.repository.ts
+++ b/src/app/community/data-access/community-feed.repository.ts
@@ -53,6 +53,10 @@ import {
   normalizeCommunityFeedPageResponse,
 } from './community-feed.model';
 import {
+  CommunityFeedPostCreateWireRequest,
+  buildCommunityFeedPostCreateWireRequest,
+} from './community-feed-write-contract.model';
+import {
   CommunityFeedRealtimeChange,
   CommunityFeedRealtimeProjection,
   diffCommunityFeedRealtimeProjections,
@@ -86,7 +90,7 @@ export class CommunityFeedRepository {
   >(this.functions, 'getCommunityFeedItems');
 
   private readonly createCommunityFeedPostCallable = httpsCallable<
-    CommunityFeedPostCreateRequest,
+    CommunityFeedPostCreateWireRequest,
     unknown
   >(this.functions, 'createCommunityFeedPost');
 
@@ -176,14 +180,7 @@ export class CommunityFeedRepository {
   createPost$(
     request: CommunityFeedPostCreateRequest
   ): Observable<CommunityFeedPostCreateResponse> {
-    const payload: CommunityFeedPostCreateRequest = {
-      requestId: request.requestId.trim(),
-      communityId: request.communityId.trim(),
-      text: request.text.trim(),
-      audience: request.audience,
-      imageUploadPath: request.imageUploadPath?.trim() || null,
-      replyToPostId: request.replyToPostId?.trim() || null,
-    };
+    const payload = buildCommunityFeedPostCreateWireRequest(request);
 
     return defer(() => from(this.createCommunityFeedPostCallable(payload))).pipe(
       map((result) => normalizeCommunityFeedPostCreateResponse(result.data)),


### PR DESCRIPTION
## Objetivo
Preparar o compositor do Mural para múltiplos tipos de anexo sem manter o contrato de rede acoplado a `imageUploadPath`.

## Alterações
- adiciona contrato Angular discriminado `attachment` para publicação no Mural;
- `CommunityFeedRepository` deixa de enviar `imageUploadPath` pela callable e passa a enviar `attachment: { type: 'photo', uploadPath } | null`;
- Functions aceita o novo contrato e converte `imageUploadPath` apenas como entrada legada de clientes antigos;
- o backend rejeita requests que misturem as duas autoridades de transporte;
- tipos de attachment ainda não habilitados, como `video`, falham fechado;
- `community-feed-write.handler.ts` passa a consumir somente `command.attachment` após a normalização;
- mantém o pipeline físico canônico existente de foto (`copyPrivatePhotoToPublishedAsset` / published media reference).

## Compatibilidade
`imageUploadPath` permanece somente no contrato bruto backend para compatibilidade temporária com clientes anteriores. Depois da normalização, o backend trabalha exclusivamente com `attachment`.

O request interno do componente Angular ainda mantém `imageUploadPath` nesta etapa. Isso é intencional: a retirada desse campo do estado do compositor ficará para a próxima etapa estrutural, antes de adicionar localização/vídeo.

## Não habilita ainda
- vídeo em Comunidades;
- compartilhamento de localização (issue #95);
- mudança visual em Galeria/Câmera;
- mudança de Storage/política de publicação.

## Supressões/remoções
Nenhuma funcionalidade, UI, método público ou fluxo existente foi suprimido/removido. Apenas `imageUploadPath` deixou de ser enviado pelo novo cliente Angular na fronteira de rede; o backend mantém leitura legada para clientes antigos.

## Testes
- novo teste Angular do wire contract;
- suíte backend cobre attachment canônico, conversão do legado, conflito entre formatos e rejeição de tipo ainda não habilitado.
